### PR TITLE
Renamed csdl-compiler to nv-redfish-csdl-compiler

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         sed -i "s/^version = .*/version = \"$VERSION\"/" Cargo.toml
         
         echo "Publishing csdl-compiler..."
-        cargo publish -p csdl-compiler --allow-dirty
+        cargo publish -p nv-redfish-csdl-compiler --allow-dirty
         
         echo "Publishing nv-redfish-core..."
         cargo publish -p nv-redfish-core --allow-dirty

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ nv-redfish-core = { version = "0.1", path = "./core" }
 nv-redfish-bmc-http = { version = "0.1", path = "./bmc-http" }
 nv-redfish-bmc-mock = { version = "0.1", path = "./bmc-mock" }
 nv-redfish = { version = "0.1", path = "./redfish" }
-csdl-compiler = { version = "0.1", path = "./csdl-compiler" }
+nv-redfish-csdl-compiler = { version = "0.1", path = "./csdl-compiler" }
 toml = { version = "0.9", default-features = false }
 
 # Dev

--- a/csdl-compiler/Cargo.toml
+++ b/csdl-compiler/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "csdl-compiler"
+name = "nv-redfish-csdl-compiler"
 version.workspace = true
 license-file.workspace = true
 repository.workspace = true

--- a/csdl-compiler/examples/csdl-parser.rs
+++ b/csdl-compiler/examples/csdl-parser.rs
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use csdl_compiler::edmx::Edmx;
-use csdl_compiler::edmx::ValidateError;
+use nv_redfish_csdl_compiler::edmx::Edmx;
+use nv_redfish_csdl_compiler::edmx::ValidateError;
 use std::io::Error as IoError;
 use std::io::Read;
 

--- a/csdl-compiler/examples/schema-compilation.rs
+++ b/csdl-compiler/examples/schema-compilation.rs
@@ -13,18 +13,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use csdl_compiler::compiler::Config;
-use csdl_compiler::compiler::NavProperty;
-use csdl_compiler::compiler::NavPropertyExpandable;
-use csdl_compiler::compiler::NavPropertyType;
-use csdl_compiler::compiler::PropertyType;
-use csdl_compiler::compiler::SchemaBundle;
-use csdl_compiler::edmx::attribute_values::Error as AttributeValuesError;
-use csdl_compiler::edmx::Edmx;
-use csdl_compiler::edmx::ValidateError;
-use csdl_compiler::optimizer::optimize;
-use csdl_compiler::optimizer::Config as OptimizerConfig;
-use csdl_compiler::OneOrCollection;
+use nv_redfish_csdl_compiler::compiler::Config;
+use nv_redfish_csdl_compiler::compiler::NavProperty;
+use nv_redfish_csdl_compiler::compiler::NavPropertyExpandable;
+use nv_redfish_csdl_compiler::compiler::NavPropertyType;
+use nv_redfish_csdl_compiler::compiler::PropertyType;
+use nv_redfish_csdl_compiler::compiler::SchemaBundle;
+use nv_redfish_csdl_compiler::edmx::attribute_values::Error as AttributeValuesError;
+use nv_redfish_csdl_compiler::edmx::Edmx;
+use nv_redfish_csdl_compiler::edmx::ValidateError;
+use nv_redfish_csdl_compiler::optimizer::optimize;
+use nv_redfish_csdl_compiler::optimizer::Config as OptimizerConfig;
+use nv_redfish_csdl_compiler::OneOrCollection;
 use std::io::Error as IoError;
 use std::io::Read;
 

--- a/csdl-compiler/examples/schema-rust-gen.rs
+++ b/csdl-compiler/examples/schema-rust-gen.rs
@@ -13,15 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use csdl_compiler::compiler::Config as CompilerConfig;
-use csdl_compiler::compiler::SchemaBundle;
-use csdl_compiler::edmx::attribute_values::Error as AttributeValuesError;
-use csdl_compiler::edmx::Edmx;
-use csdl_compiler::edmx::ValidateError;
-use csdl_compiler::generator::rust::Config as GeneratorConfig;
-use csdl_compiler::generator::rust::RustGenerator;
-use csdl_compiler::optimizer::optimize;
-use csdl_compiler::optimizer::Config as OptimizerConfig;
+use nv_redfish_csdl_compiler::compiler::Config as CompilerConfig;
+use nv_redfish_csdl_compiler::compiler::SchemaBundle;
+use nv_redfish_csdl_compiler::edmx::attribute_values::Error as AttributeValuesError;
+use nv_redfish_csdl_compiler::edmx::Edmx;
+use nv_redfish_csdl_compiler::edmx::ValidateError;
+use nv_redfish_csdl_compiler::generator::rust::Config as GeneratorConfig;
+use nv_redfish_csdl_compiler::generator::rust::RustGenerator;
+use nv_redfish_csdl_compiler::optimizer::optimize;
+use nv_redfish_csdl_compiler::optimizer::Config as OptimizerConfig;
 use std::io::Error as IoError;
 use std::io::Read;
 

--- a/csdl-compiler/src/main.rs
+++ b/csdl-compiler/src/main.rs
@@ -14,9 +14,9 @@
 // limitations under the License.
 
 use clap::Parser;
-use csdl_compiler::commands::process_command;
-use csdl_compiler::commands::Commands;
-use csdl_compiler::Error;
+use nv_redfish_csdl_compiler::commands::process_command;
+use nv_redfish_csdl_compiler::commands::Commands;
+use nv_redfish_csdl_compiler::Error;
 
 /// Compiler CLI.
 #[derive(Parser, Debug)]

--- a/examples/redfish-oem-contoso/Cargo.toml
+++ b/examples/redfish-oem-contoso/Cargo.toml
@@ -15,4 +15,4 @@ nv-redfish-core = { workspace = true }
 
 [build-dependencies]
 glob = { workspace = true }
-csdl-compiler = { workspace = true }
+nv-redfish-csdl-compiler = { workspace = true }

--- a/examples/redfish-oem-contoso/build.rs
+++ b/examples/redfish-oem-contoso/build.rs
@@ -13,9 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use csdl_compiler::commands::process_command;
-use csdl_compiler::commands::Commands;
-use csdl_compiler::Error;
+use nv_redfish_csdl_compiler::commands::process_command;
+use nv_redfish_csdl_compiler::commands::Commands;
+use nv_redfish_csdl_compiler::Error;
 use glob::glob;
 use std::env::var;
 use std::path::PathBuf;

--- a/examples/redfish-std/Cargo.toml
+++ b/examples/redfish-std/Cargo.toml
@@ -15,4 +15,4 @@ nv-redfish-core = { workspace = true }
 
 [build-dependencies]
 glob = { workspace = true }
-csdl-compiler = { workspace = true }
+nv-redfish-csdl-compiler = { workspace = true }

--- a/examples/redfish-std/build.rs
+++ b/examples/redfish-std/build.rs
@@ -16,8 +16,8 @@
 use std::env::var;
 use std::path::PathBuf;
 
-use csdl_compiler::commands::{process_command, Commands, DEFAULT_ROOT};
-use csdl_compiler::Error;
+use nv_redfish_csdl_compiler::commands::{process_command, Commands, DEFAULT_ROOT};
+use nv_redfish_csdl_compiler::Error;
 use glob::glob;
 
 fn main() -> Result<(), Error> {

--- a/redfish/Cargo.toml
+++ b/redfish/Cargo.toml
@@ -86,4 +86,4 @@ serde_json = { workspace = true }
 tagged-types = { workspace = true }
 
 [build-dependencies]
-csdl-compiler = { workspace = true }
+nv-redfish-csdl-compiler = { workspace = true }

--- a/redfish/build.rs
+++ b/redfish/build.rs
@@ -13,10 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use csdl_compiler::commands::process_command;
-use csdl_compiler::commands::Commands;
-use csdl_compiler::commands::DEFAULT_ROOT;
-use csdl_compiler::features_manifest::FeaturesManifest;
+use nv_redfish_csdl_compiler::commands::process_command;
+use nv_redfish_csdl_compiler::commands::Commands;
+use nv_redfish_csdl_compiler::commands::DEFAULT_ROOT;
+use nv_redfish_csdl_compiler::features_manifest::FeaturesManifest;
 use std::env::var;
 use std::error::Error as StdError;
 use std::fs::File;

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -29,4 +29,4 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 trybuild = { workspace = true }
 
 [build-dependencies]
-csdl-compiler = { workspace = true }
+nv-redfish-csdl-compiler = { workspace = true }

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -13,10 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use csdl_compiler::commands::process_command;
-use csdl_compiler::commands::Commands;
-use csdl_compiler::commands::DEFAULT_ROOT;
-use csdl_compiler::Error;
+use nv_redfish_csdl_compiler::commands::process_command;
+use nv_redfish_csdl_compiler::commands::Commands;
+use nv_redfish_csdl_compiler::commands::DEFAULT_ROOT;
+use nv_redfish_csdl_compiler::Error;
 use std::env::var;
 use std::path::PathBuf;
 


### PR DESCRIPTION
Renamed csdl-compiler to nv-redfish-csdl-compiler

To follow standart naming with nv-redfish prefix, so all crates will have common prefix name.