### PR TITLE
Publish all features for cargo crates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,19 +31,19 @@ jobs:
         sed -i "s/^version = .*/version = \"$VERSION\"/" Cargo.toml
         
         echo "Publishing csdl-compiler..."
-        cargo publish -p nv-redfish-csdl-compiler --allow-dirty
+        cargo publish -p nv-redfish-csdl-compiler --all-features --allow-dirty
         
         echo "Publishing nv-redfish-core..."
-        cargo publish -p nv-redfish-core --allow-dirty
+        cargo publish -p nv-redfish-core --all-features --allow-dirty
         
         echo "Publishing nv-redfish-bmc-http..."
-        cargo publish -p nv-redfish-bmc-http --allow-dirty
+        cargo publish -p nv-redfish-bmc-http --all-features --allow-dirty
         
         echo "Publishing nv-redfish..."
-        cargo publish -p nv-redfish --allow-dirty
+        cargo publish -p nv-redfish --all-features --allow-dirty
 
         echo "Publishing nv-redfish-bmc-mock..."
-        cargo publish -p nv-redfish-bmc-mock --allow-dirty
+        cargo publish -p nv-redfish-bmc-mock --all-features --allow-dirty
 
         echo "All crates published successfully!"
 


### PR DESCRIPTION
When we publish, we need to build for all features, so docs.rs will contain whole documentation.