### PR TITLE
nv-redfish: Support WIWYNN non-standard response of chassis assembly

### DIFF
--- a/redfish/Cargo.toml
+++ b/redfish/Cargo.toml
@@ -45,7 +45,7 @@ std-redfish = [
     "update-service",
 ]
 
-assembly = []
+assembly = ["patch-payload-expand"]
 accounts = ["patch-payload-get", "patch-payload-update", "patch-collection-create"]
 bios = []
 boot-options = []
@@ -84,6 +84,7 @@ oem-nvidia-baseboard = ["oem-nvidia"]
 patch = []
 patch-payload = ["patch"]
 patch-payload-get = ["patch-payload"]
+patch-payload-expand = ["patch-payload"]
 patch-payload-update = ["patch-payload"]
 patch-collection = ["nv-bmc-expand"]
 patch-collection-create = ["patch-collection"]

--- a/redfish/src/assembly.rs
+++ b/redfish/src/assembly.rs
@@ -21,12 +21,16 @@ use crate::hardware_id::Manufacturer as HardwareIdManufacturer;
 use crate::hardware_id::Model as HardwareIdModel;
 use crate::hardware_id::PartNumber as HardwareIdPartNumber;
 use crate::hardware_id::SerialNumber as HardwareIdSerialNumber;
+use crate::patch_support::JsonValue;
+use crate::patch_support::Payload;
+use crate::patch_support::ReadPatchFn;
 use crate::schema::redfish::assembly::Assembly as AssemblySchema;
 use crate::schema::redfish::assembly::AssemblyData as AssemblyDataSchema;
 use crate::Error;
 use crate::NvBmc;
 use crate::Resource;
 use crate::ResourceSchema;
+use crate::ServiceRoot;
 use nv_redfish_core::Bmc;
 use nv_redfish_core::NavProperty;
 use std::marker::PhantomData;
@@ -47,6 +51,30 @@ pub type PartNumber<T> = HardwareIdPartNumber<T, AssemblyTag>;
 /// Assembly number.
 pub type SerialNumber<T> = HardwareIdSerialNumber<T, AssemblyTag>;
 
+/// Configuration of the Assembly.
+pub struct Config {
+    read_patch_fn: Option<ReadPatchFn>,
+}
+
+impl Config {
+    /// New configuration of the assembly from parametes of the
+    /// service root.
+    pub fn new<B: Bmc>(root: &ServiceRoot<B>) -> Self {
+        let mut patches = Vec::new();
+        if root.assembly_assemblies_without_odata_type() {
+            patches.push(add_odata_type_to_assemblies);
+        }
+        let read_patch_fn = if patches.is_empty() {
+            None
+        } else {
+            let read_patch_fn: ReadPatchFn =
+                Arc::new(move |v| patches.iter().fold(v, |acc, f| f(acc)));
+            Some(read_patch_fn)
+        };
+        Self { read_patch_fn }
+    }
+}
+
 /// Assembly.
 ///
 /// Provides functions to access assembly.
@@ -60,11 +88,17 @@ impl<B: Bmc> Assembly<B> {
     pub(crate) async fn new(
         bmc: &NvBmc<B>,
         nav: &NavProperty<AssemblySchema>,
+        config: &Config,
     ) -> Result<Self, Error<B>> {
         // We use expand here becuase Assembly/Assemblies are
         // navigation properties, so we want to take them using one
         // get.
-        bmc.expand_property(nav).await.map(|data| Self {
+        if let Some(read_patch_fn) = &config.read_patch_fn {
+            Payload::expand_property(bmc, nav, read_patch_fn.as_ref()).await
+        } else {
+            bmc.expand_property(nav).await
+        }
+        .map(|data| Self {
             bmc: bmc.clone(),
             data,
         })
@@ -156,4 +190,24 @@ impl<B: Bmc> AssemblyData<B> {
                 .map(SerialNumber::new),
         }
     }
+}
+
+fn add_odata_type_to_assemblies(mut v: JsonValue) -> JsonValue {
+    if let Some(assemblies) = v
+        .as_object_mut()
+        .and_then(|obj| obj.get_mut("Assemblies"))
+        .and_then(|assemblies| assemblies.as_array_mut())
+    {
+        for assembly in assemblies.iter_mut() {
+            if let Some(obj) = assembly.as_object_mut() {
+                if obj.len() > 1 && !obj.contains_key("@odata.type") {
+                    obj.insert(
+                        "@odata.type".to_string(),
+                        "#Assembly.v1_5_1.AssemblyData".into(),
+                    );
+                }
+            }
+        }
+    }
+    v
 }

--- a/redfish/src/patch_support/payload.rs
+++ b/redfish/src/patch_support/payload.rs
@@ -32,6 +32,9 @@ use nv_redfish_core::Updatable;
 #[cfg(feature = "patch-payload-update")]
 use serde::Serialize;
 
+#[cfg(feature = "patch-payload-expand")]
+use crate::NvBmc;
+
 #[cfg(feature = "patch-payload-update")]
 pub trait UpdateWithPatch<T, V, B>
 where
@@ -86,6 +89,27 @@ impl Payload {
             NavProperty::Reference(_) => {
                 let getter = NavProperty::<Getter>::new_reference(nav.id().clone());
                 let v = getter.get(bmc).await.map_err(Error::Bmc)?;
+                v.payload.to_target(f).map(Arc::new)
+            }
+        }
+    }
+
+    #[cfg(feature = "patch-payload-expand")]
+    pub(crate) async fn expand_property<T, B, F>(
+        bmc: &NvBmc<B>,
+        nav: &NavProperty<T>,
+        f: F,
+    ) -> Result<Arc<T>, Error<B>>
+    where
+        T: EntityTypeRef + for<'a> Deserialize<'a> + Send + Sync + 'static,
+        B: Bmc,
+        F: FnOnce(JsonValue) -> JsonValue,
+    {
+        match nav {
+            NavProperty::Expanded(_) => nav.get(bmc.as_ref()).await.map_err(Error::Bmc),
+            NavProperty::Reference(_) => {
+                let getter = NavProperty::<Getter>::new_reference(nav.id().clone());
+                let v = bmc.expand_property(&getter).await?;
                 v.payload.to_target(f).map(Arc::new)
             }
         }

--- a/redfish/src/service_root.rs
+++ b/redfish/src/service_root.rs
@@ -13,16 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::schema::redfish::service_root::ServiceRoot as SchemaServiceRoot;
-use crate::Error;
-use crate::NvBmc;
-use crate::ProtocolFeatures;
-use crate::Resource;
-use crate::ResourceSchema;
-use nv_redfish_core::Bmc;
-use nv_redfish_core::NavProperty;
-use nv_redfish_core::ODataId;
 use std::sync::Arc;
+
+use nv_redfish_core::{Bmc, NavProperty, ODataId};
 use tagged_types::TaggedType;
 
 #[cfg(feature = "accounts")]
@@ -35,8 +28,10 @@ use crate::chassis::ChassisCollection;
 use crate::computer_system::SystemCollection;
 #[cfg(feature = "managers")]
 use crate::manager::ManagerCollection;
+use crate::schema::redfish::service_root::ServiceRoot as SchemaServiceRoot;
 #[cfg(feature = "update-service")]
 use crate::update_service::UpdateService;
+use crate::{Error, NvBmc, ProtocolFeatures, Resource, ResourceSchema};
 
 /// The vendor or manufacturer associated with Redfish service.
 pub type Vendor<T> = TaggedType<T, VendorTag>;
@@ -238,6 +233,18 @@ impl<B: Bmc> ServiceRoot<B> {
             .as_ref()
             .and_then(Option::as_ref)
             .is_some_and(|v| v == "Dell")
+    }
+
+    /// In some implementations Assembly/Assemblies doens't
+    /// "@odata.type". This is spec violation but we support patching
+    /// such systems.
+    #[cfg(feature = "assembly")]
+    pub(crate) fn assembly_assemblies_without_odata_type(&self) -> bool {
+        self.root
+            .vendor
+            .as_ref()
+            .and_then(Option::as_ref)
+            .is_some_and(|v| v == "WIWYNN")
     }
 
     /// In some cases we expand is not working according to spec,

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -16,6 +16,7 @@ nv-redfish-core = { workspace = true }
 nv-redfish-bmc-mock = { workspace = true }
 nv-redfish = { workspace = true, features = [
     "accounts",
+    "assembly",
     "bios",
     "chassis",
     "computer-systems",

--- a/tests/tests/test-assembly-wiwynn-missing-odata-type.rs
+++ b/tests/tests/test-assembly-wiwynn-missing-odata-type.rs
@@ -1,0 +1,220 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//! Integration tests for WIWYNN assembly payloads missing `@odata.type`.
+
+#![recursion_limit = "256"]
+
+use nv_redfish::chassis::Chassis;
+use nv_redfish::ServiceRoot;
+use nv_redfish_core::ODataId;
+use nv_redfish_tests::json_merge;
+use nv_redfish_tests::Bmc;
+use nv_redfish_tests::Expect;
+use nv_redfish_tests::ODATA_ID;
+use nv_redfish_tests::ODATA_TYPE;
+use serde_json::json;
+use serde_json::Value;
+use std::error::Error as StdError;
+use std::sync::Arc;
+use tokio::test;
+
+const SERVICE_ROOT_DATA_TYPE: &str = "#ServiceRoot.v1_13_0.ServiceRoot";
+const CHASSIS_COLLECTION_DATA_TYPE: &str = "#ChassisCollection.ChassisCollection";
+const CHASSIS_DATA_TYPE: &str = "#Chassis.v1_22_0.Chassis";
+const ASSEMBLY_DATA_TYPE: &str = "#Assembly.v1_3_0.Assembly";
+const ASSEMBLY_MEMBER_DATA_TYPE: &str = "#Assembly.v1_5_1.AssemblyData";
+const DUMMY_SERIAL: &str = "B8111801000851800AAAY0ZZ";
+
+#[test]
+async fn wiwynn_assembly_without_member_odata_type_is_supported() -> Result<(), Box<dyn StdError>> {
+    let bmc = Arc::new(Bmc::default());
+    let ids = test_ids();
+    let chassis = get_chassis(bmc.clone(), &ids, "WIWYNN").await?;
+
+    bmc.expect(Expect::expand(
+        &ids.assembly_id,
+        assembly_payload(&ids, false, DUMMY_SERIAL),
+    ));
+    let assembly = chassis.assembly().await?;
+    let members = assembly.assemblies().await?;
+    assert_eq!(members.len(), 1);
+
+    let hw = members[0].hardware_id();
+    assert_eq!(hw.model.map(|v| v.inner().as_str()), Some("GB200 NVL"));
+    assert_eq!(
+        hw.part_number.map(|v| v.inner().as_str()),
+        Some("B81.11801.0008")
+    );
+    assert_eq!(hw.serial_number.map(|v| v.inner().as_str()), Some(DUMMY_SERIAL));
+
+    Ok(())
+}
+
+#[test]
+async fn non_wiwynn_assembly_without_member_odata_type_fails() -> Result<(), Box<dyn StdError>> {
+    let bmc = Arc::new(Bmc::default());
+    let ids = test_ids();
+    let chassis = get_chassis(bmc.clone(), &ids, "Generic").await?;
+
+    bmc.expect(Expect::expand(
+        &ids.assembly_id,
+        assembly_payload(&ids, false, DUMMY_SERIAL),
+    ));
+    assert!(chassis.assembly().await.is_err());
+
+    Ok(())
+}
+
+#[test]
+async fn wiwynn_assembly_with_member_odata_type_still_supported() -> Result<(), Box<dyn StdError>> {
+    let bmc = Arc::new(Bmc::default());
+    let ids = test_ids();
+    let chassis = get_chassis(bmc.clone(), &ids, "WIWYNN").await?;
+
+    bmc.expect(Expect::expand(
+        &ids.assembly_id,
+        assembly_payload(&ids, true, DUMMY_SERIAL),
+    ));
+    let assembly = chassis.assembly().await?;
+    let members = assembly.assemblies().await?;
+    assert_eq!(members.len(), 1);
+
+    Ok(())
+}
+
+async fn get_chassis(
+    bmc: Arc<Bmc>,
+    ids: &TestIds,
+    vendor: &str,
+) -> Result<Chassis<Bmc>, Box<dyn StdError>> {
+    let service_root = expect_service_root(bmc.clone(), ids, vendor).await?;
+    bmc.expect(Expect::expand(
+        &ids.chassis_collection_id,
+        json!({
+            ODATA_ID: &ids.chassis_collection_id,
+            ODATA_TYPE: CHASSIS_COLLECTION_DATA_TYPE,
+            "Id": "Chassis",
+            "Name": "Chassis Collection",
+            "Members": [chassis_member(ids)]
+        }),
+    ));
+    let collection = service_root.chassis().await?;
+    let members = collection.members().await?;
+    assert_eq!(members.len(), 1);
+    Ok(members
+        .into_iter()
+        .next()
+        .expect("single chassis must exist"))
+}
+
+async fn expect_service_root(
+    bmc: Arc<Bmc>,
+    ids: &TestIds,
+    vendor: &str,
+) -> Result<ServiceRoot<Bmc>, Box<dyn StdError>> {
+    bmc.expect(Expect::get(
+        &ids.root_id,
+        json!({
+            ODATA_ID: &ids.root_id,
+            ODATA_TYPE: SERVICE_ROOT_DATA_TYPE,
+            "Id": "RootService",
+            "Name": "RootService",
+            "ProtocolFeaturesSupported": {
+                "ExpandQuery": {
+                    "NoLinks": true
+                }
+            },
+            "Vendor": vendor,
+            "Chassis": { ODATA_ID: &ids.chassis_collection_id },
+            "Links": {},
+        }),
+    ));
+    ServiceRoot::new(bmc).await.map_err(Into::into)
+}
+
+struct TestIds {
+    root_id: ODataId,
+    chassis_collection_id: String,
+    chassis_id: String,
+    assembly_id: String,
+    assembly_member_id: String,
+}
+
+fn test_ids() -> TestIds {
+    let root_id = ODataId::service_root();
+    let chassis_collection_id = format!("{root_id}/Chassis");
+    let chassis_id = format!("{chassis_collection_id}/Chassis_0");
+    let assembly_id = format!("{chassis_id}/Assembly");
+    let assembly_member_id = format!("{assembly_id}#/Assemblies/0");
+    TestIds {
+        root_id,
+        chassis_collection_id,
+        chassis_id,
+        assembly_id,
+        assembly_member_id,
+    }
+}
+
+fn chassis_member(ids: &TestIds) -> Value {
+    json!({
+        ODATA_ID: &ids.chassis_id,
+        ODATA_TYPE: CHASSIS_DATA_TYPE,
+        "Id": "Chassis_0",
+        "Name": "Chassis_0",
+        "ChassisType": "RackMount",
+        "Assembly": {
+            ODATA_ID: &ids.assembly_id
+        },
+        "Status": {
+            "Health": "OK",
+            "State": "Enabled"
+        }
+    })
+}
+
+fn assembly_payload(ids: &TestIds, include_member_odata_type: bool, serial_number: &str) -> Value {
+    let member_base = json!({
+        ODATA_ID: &ids.assembly_member_id,
+        "Location": {
+            "PartLocation": {
+                "LocationType": "Embedded"
+            }
+        },
+        "MemberId": "0",
+        "Model": "GB200 NVL",
+        "Name": "PDB Chassis FRU Assembly0",
+        "PartNumber": "B81.11801.0008",
+        "SerialNumber": serial_number,
+        "Vendor": "NVIDIA"
+    });
+    let member = if include_member_odata_type {
+        json_merge([
+            &member_base,
+            &json!({
+                ODATA_TYPE: ASSEMBLY_MEMBER_DATA_TYPE
+            }),
+        ])
+    } else {
+        member_base
+    };
+
+    json!({
+        ODATA_ID: &ids.assembly_id,
+        ODATA_TYPE: ASSEMBLY_DATA_TYPE,
+        "Id": "Assembly",
+        "Name": "Assembly data for Chassis_0",
+        "Assemblies": [member]
+    })
+}


### PR DESCRIPTION
Support of WIWYNN's non-standard response on Assembly resource in Chassis which doesn't contain required "@data.type" field.