### PR TITLE
csdl-compiler, log-service: support compilation of Event/EventRecord

### DIFF
--- a/csdl-compiler/examples/schema-compilation.rs
+++ b/csdl-compiler/examples/schema-compilation.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 use nv_redfish_csdl_compiler::compiler::Config;
+use nv_redfish_csdl_compiler::compiler::EntityTypeFilter;
 use nv_redfish_csdl_compiler::compiler::NavProperty;
 use nv_redfish_csdl_compiler::compiler::NavPropertyExpandable;
 use nv_redfish_csdl_compiler::compiler::NavPropertyType;
@@ -61,7 +62,11 @@ fn main() -> Result<(), Error> {
                 Ok(schema_bundle)
             })?;
     let compiled = schema_bundle
-        .compile(&[root_service], Config::default())
+        .compile(
+            &[root_service],
+            &EntityTypeFilter::new_restrictive(vec![]),
+            Config::default(),
+        )
         .inspect_err(|e| println!("{e}"))
         .map_err(|_| Error::Compile("compilation error".into()))?;
     let compiled = optimize(compiled, &OptimizerConfig::default());

--- a/csdl-compiler/examples/schema-rust-gen.rs
+++ b/csdl-compiler/examples/schema-rust-gen.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 use nv_redfish_csdl_compiler::compiler::Config as CompilerConfig;
+use nv_redfish_csdl_compiler::compiler::EntityTypeFilter;
 use nv_redfish_csdl_compiler::compiler::SchemaBundle;
 use nv_redfish_csdl_compiler::edmx::attribute_values::Error as AttributeValuesError;
 use nv_redfish_csdl_compiler::edmx::Edmx;
@@ -60,7 +61,11 @@ fn main() -> Result<(), Error> {
                 Ok(schema_bundle)
             })?;
     let compiled = schema_bundle
-        .compile(&[root_service], CompilerConfig::default())
+        .compile(
+            &[root_service],
+            &EntityTypeFilter::new_restrictive(vec![]),
+            CompilerConfig::default(),
+        )
         .inspect_err(|e| println!("{e}"))
         .map_err(|_| Error::Compile("compilation error".into()))?;
     let compiled = optimize(compiled, &OptimizerConfig::default());

--- a/csdl-compiler/src/compiler/context.rs
+++ b/csdl-compiler/src/compiler/context.rs
@@ -53,22 +53,48 @@ pub struct Config {
 }
 
 /// Entity type filter specified by wildcard patterns.
-#[derive(Default)]
 pub struct EntityTypeFilter {
     patterns: Vec<EntityTypeFilterPattern>,
+    permissive: bool,
+}
+
+impl Default for EntityTypeFilter {
+    fn default() -> Self {
+        Self {
+            patterns: Vec::default(),
+            permissive: true,
+        }
+    }
 }
 
 impl EntityTypeFilter {
-    /// Create a new filter from a list of patterns.
+    /// Create a new filter from a list of patterns. If patterns empty
+    /// then matches anything.
     #[must_use]
-    pub const fn new(patterns: Vec<EntityTypeFilterPattern>) -> Self {
-        Self { patterns }
+    pub const fn new_restrictive(patterns: Vec<EntityTypeFilterPattern>) -> Self {
+        Self {
+            patterns,
+            permissive: false,
+        }
+    }
+    /// Create a new filter from a list of patterns. If patterns empty
+    /// then matches nothing.
+    #[must_use]
+    pub const fn new_permissive(patterns: Vec<EntityTypeFilterPattern>) -> Self {
+        Self {
+            patterns,
+            permissive: true,
+        }
     }
 
     /// Check whether the filter matches a qualified entity type name.
     #[must_use]
     pub fn matches(&self, typename: &QualifiedName<'_>) -> bool {
-        self.patterns.is_empty() || self.patterns.iter().any(|p| p.matches(typename))
+        if self.permissive {
+            self.patterns.is_empty() || self.patterns.iter().any(|p| p.matches(typename))
+        } else {
+            self.patterns.iter().any(|p| p.matches(typename))
+        }
     }
 }
 

--- a/csdl-compiler/src/features_manifest.rs
+++ b/csdl-compiler/src/features_manifest.rs
@@ -68,16 +68,18 @@ impl FeaturesManifest {
         Vec<&'a String>,
         Vec<&'a String>,
         Vec<&'a EntityTypeFilterPattern>,
+        Vec<&'a EntityTypeFilterPattern>,
     ) {
         self.features.iter().fold(
-            (Vec::new(), Vec::new(), Vec::new()),
-            |(mut files, mut swordfish_files, mut patterns), f| {
+            (Vec::new(), Vec::new(), Vec::new(), Vec::new()),
+            |(mut files, mut swordfish_files, mut patterns, mut root_patterns), f| {
                 if features.contains(&&f.name) {
                     files.extend(f.csdl_files.iter());
                     swordfish_files.extend(f.swordfish_csdl_files.iter());
                     patterns.extend(f.patterns.iter());
+                    root_patterns.extend(f.root_patterns.iter());
                 }
-                (files, swordfish_files, patterns)
+                (files, swordfish_files, patterns, root_patterns)
             },
         )
     }
@@ -136,6 +138,8 @@ pub struct Feature {
     #[serde(default)]
     pub swordfish_csdl_files: Vec<String>,
     pub patterns: Vec<EntityTypeFilterPattern>,
+    #[serde(default)]
+    pub root_patterns: Vec<EntityTypeFilterPattern>,
 }
 
 /// OEM-specific feature.

--- a/csdl-compiler/src/optimizer/mod.rs
+++ b/csdl-compiler/src/optimizer/mod.rs
@@ -45,7 +45,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            never_prune: EntityTypeFilter::new(
+            never_prune: EntityTypeFilter::new_permissive(
                 ["Resource.Item", "Resource.ItemOrCollection"]
                     .iter()
                     .map(|f| f.parse().expect("must be correct filter"))

--- a/examples/redfish-std/build.rs
+++ b/examples/redfish-std/build.rs
@@ -66,6 +66,7 @@ fn main() -> Result<(), Error> {
 
     process_command(&Commands::Compile {
         root: DEFAULT_ROOT.into(),
+        include_root_patterns: vec![],
         output,
         csdls,
         entity_type_patterns: [

--- a/redfish/build.rs
+++ b/redfish/build.rs
@@ -67,7 +67,7 @@ fn main() -> Result<(), Box<dyn StdError>> {
         .map(|v| v.parse())
         .collect::<Result<Vec<_>, _>>()
         .expect("must be successfuly parsed");
-    let (features_csdls, features_swordfish_csdls, features_patterns) =
+    let (features_csdls, features_swordfish_csdls, features_patterns, root_patterns) =
         manifest.collect(&target_features);
     let csdls = redfish_csdl
         .iter()
@@ -89,6 +89,7 @@ fn main() -> Result<(), Box<dyn StdError>> {
 
     process_command(&Commands::Compile {
         root: DEFAULT_ROOT.into(),
+        include_root_patterns: root_patterns.into_iter().cloned().collect(),
         output,
         csdls,
         entity_type_patterns: service_root_pattens

--- a/redfish/features.toml
+++ b/redfish/features.toml
@@ -143,7 +143,9 @@ patterns = [
     "LogServiceCollection.*",
     "LogEntry.*",
     "LogEntryCollection.*",
+    "Event.*.*"
 ]
+root_patterns = [ "Event.v1_0_0.Event" ]
 
 [[features]]
 name = "managers"

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -40,6 +40,7 @@ fn main() -> Result<(), Error> {
         output: base_output,
         csdls: base_csdls,
         entity_type_patterns: vec![],
+        include_root_patterns: vec![],
     })?;
     Ok(())
 }


### PR DESCRIPTION
Before CSDL compiler only compiled data types that were referenced from root object. This PR adds possibility to include additional type to compilation to support types like Event/EventRecord that are not referenced from ServiceRoot. 