### PR TITLE
fix: don't parse Dell FW release date if it's 0000-00-00T00:00:00Z

### DIFF
--- a/redfish/src/update_service/mod.rs
+++ b/redfish/src/update_service/mod.rs
@@ -259,7 +259,7 @@ impl<B: Bmc> Resource for UpdateService<B> {
 fn fw_inventory_patch_wrong_release_date(v: JsonValue) -> JsonValue {
     if let JsonValue::Object(mut obj) = v {
         if let Some(JsonValue::String(date)) = obj.get("ReleaseDate") {
-            if date == "00:00:00Z" {
+            if date == "00:00:00Z" || date == "0000-00-00T00:00:00Z" {
                 obj.remove("ReleaseDate");
             }
         }

--- a/tests/tests/test-update-service.rs
+++ b/tests/tests/test-update-service.rs
@@ -45,6 +45,8 @@ async fn list_dell_fw_inventores() -> Result<(), Box<dyn StdError>> {
     let fw_inventories_id = format!("{update_service_id}/FirmwareInventory");
     let fw_inventory_id =
         format!("{fw_inventories_id}/Installed-0-2.1.3__Disk.Bay.0:Enclosure.Internal.0-1");
+    let fw_inventory_id2 =
+        format!("{fw_inventories_id}/Installed-0-3.0.0__Disk.Bay.1:Enclosure.Internal.0-1");
     bmc.expect(Expect::expand(
         &fw_inventories_id,
         json!({
@@ -65,13 +67,28 @@ async fn list_dell_fw_inventores() -> Result<(), Box<dyn StdError>> {
                     },
                     "Updateable": true,
                     "Version": "1.0.0"
+                },
+                {
+                    "@odata.id": &fw_inventory_id2,
+                    "@odata.type": &SW_INVENTORY_DATA_TYPE,
+                    "Id": "Installed-0-3.0.0__Disk.Bay.1:Enclosure.Internal.0-1",
+                    "Name": "PCIe SSD in Slot 0 in Bay 2",
+                    "ReleaseDate": "0000-00-00T00:00:00Z",
+                    "SoftwareId": "0",
+                    "Status": {
+                        "Health": "OK",
+                        "State": "Enabled"
+                    },
+                    "Updateable": true,
+                    "Version": "3.0.0"
                 }
             ]
         }),
     ));
     let inventories = update_service.firmware_inventories().await?.unwrap();
-    assert_eq!(inventories.len(), 1);
+    assert_eq!(inventories.len(), 2);
     assert!(inventories[0].raw().release_date.is_none());
+    assert!(inventories[1].raw().release_date.is_none());
     Ok(())
 }
 


### PR DESCRIPTION
Newer iDRAC firmware (7.30.10.50+) returns `0000-00-00T00:00:00Z` as a placeholder `ReleaseDate` for firmware entries with no known release date. This is an invalid RFC 3339 date (month 00 is out of range) and causes downstream parsing failures. The existing quirk already stripped the legacy `00:00:00Z` form from older iDRAC versions; this extends it to also strip the newer zeroed-out datetime form.

```
 level=INFO span_id=0x614a682534e41a1d msg="Failed to explore <bmc-ip>:443: Error while performing Redfish request:
 context: firmware inventories; json error: the \'month\' component could not be parsed: None (response code: None) (state:
 Ready)" error="Error while performing Redfish request: context: firmware inventories; json error: the \'month\' component
 could not be parsed: None (response code: None)" location="crates/api/src/site_explorer/mod.rs:1538
```