### PR TITLE
fix: clippy `enum_variant_names` Self hints and rustdoc broken links

### DIFF
--- a/core/src/query.rs
+++ b/core/src/query.rs
@@ -425,10 +425,10 @@ enum FilterExpr {
         operator: &'static str,
         value: FilterLiteral,
     },
-    And(Box<FilterExpr>, Box<FilterExpr>),
-    Or(Box<FilterExpr>, Box<FilterExpr>),
-    Not(Box<FilterExpr>),
-    Group(Box<FilterExpr>),
+    And(Box<Self>, Box<Self>),
+    Or(Box<Self>, Box<Self>),
+    Not(Box<Self>),
+    Group(Box<Self>),
 }
 
 impl FilterExpr {

--- a/csdl-compiler/src/compiler/error.rs
+++ b/csdl-compiler/src/compiler/error.rs
@@ -45,27 +45,27 @@ pub enum Error<'a> {
     /// Resource.ResourceCollection type was not found.
     ResourceCollectionTypeNotFound,
     /// Error while compiling an entity type.
-    EntityType(QualifiedName<'a>, Box<Error<'a>>),
+    EntityType(QualifiedName<'a>, Box<Self>),
     /// Type was not found.
     TypeNotFound(QualifiedName<'a>),
     /// Type definition is not a primitive type.
     TypeDefinitionOfNotPrimitiveType(QualifiedName<'a>),
     /// Error while compiling a type definition.
-    TypeDefinition(QualifiedName<'a>, Box<Error<'a>>),
+    TypeDefinition(QualifiedName<'a>, Box<Self>),
     /// Error while compiling a type.
-    Type(QualifiedName<'a>, Box<Error<'a>>),
+    Type(QualifiedName<'a>, Box<Self>),
     /// Error while compiling a property.
-    Property(&'a PropertyName, Box<Error<'a>>),
+    Property(&'a PropertyName, Box<Self>),
     /// Error while compiling an action.
-    Action(&'a ActionName, Box<Error<'a>>),
+    Action(&'a ActionName, Box<Self>),
     /// Error while compiling an action return type.
-    ActionReturnType(Box<Error<'a>>),
+    ActionReturnType(Box<Self>),
     /// Error while compiling an action parameter.
-    ActionParameter(&'a ParameterName, Box<Error<'a>>),
+    ActionParameter(&'a ParameterName, Box<Self>),
     /// Error while compiling a singleton.
-    Singleton(&'a SimpleIdentifier, Box<Error<'a>>),
+    Singleton(&'a SimpleIdentifier, Box<Self>),
     /// Error while compiling a schema.
-    Schema(&'a Namespace, Box<Error<'a>>),
+    Schema(&'a Namespace, Box<Self>),
 }
 
 impl Display for Error<'_> {

--- a/csdl-compiler/src/compiler/stack.rs
+++ b/csdl-compiler/src/compiler/stack.rs
@@ -24,7 +24,7 @@ use crate::compiler::TypeInfo;
 /// via `done()`.
 #[derive(Default)]
 pub struct Stack<'a, 'stack> {
-    parent: Option<&'stack Stack<'a, 'stack>>,
+    parent: Option<&'stack Self>,
     // If entity type is currently being compiled we use this
     // field to prevent infinite recursion.
     entity_type: Option<QualifiedName<'a>>,

--- a/csdl-compiler/src/edmx/annotation.rs
+++ b/csdl-compiler/src/edmx/annotation.rs
@@ -90,7 +90,7 @@ pub enum Error {
     NoEnumMemberName,
     BadTypeName(AttributeValuesError),
     BadMemberName(AttributeValuesError),
-    InvalidEnumMember(String, Box<Error>),
+    InvalidEnumMember(String, Box<Self>),
 }
 
 impl Display for Error {

--- a/csdl-compiler/src/edmx/validate_error.rs
+++ b/csdl-compiler/src/edmx/validate_error.rs
@@ -40,15 +40,15 @@ pub enum ValidateError {
     /// This is the case for Redfish. Keep it this way for parser.
     ManyContainersNotSupported,
     /// Schema validation error.
-    Schema(Namespace, Box<ValidateError>),
+    Schema(Namespace, Box<Self>),
     /// `ComplexType` validation error.
-    ComplexType(LocalTypeName, Box<ValidateError>),
+    ComplexType(LocalTypeName, Box<Self>),
     /// `EntityType` validation error.
-    EntityType(LocalTypeName, Box<ValidateError>),
+    EntityType(LocalTypeName, Box<Self>),
     /// `NavigationProperty` validation error.
-    NavigationProperty(PropertyName, Box<ValidateError>),
+    NavigationProperty(PropertyName, Box<Self>),
     /// `Action` validation error.
-    Action(ActionName, Box<ValidateError>),
+    Action(ActionName, Box<Self>),
 }
 
 impl Display for ValidateError {

--- a/csdl-compiler/src/generator/rust/mod.rs
+++ b/csdl-compiler/src/generator/rust/mod.rs
@@ -92,8 +92,8 @@ pub use type_name::TypeName;
 pub enum Error<'a> {
     BaseTypeConflict,
     NameConflict,
-    CreateStruct(TypeName<'a>, Box<Error<'a>>),
-    CreateSimplType(QualifiedName<'a>, Box<Error<'a>>),
+    CreateStruct(TypeName<'a>, Box<Self>),
+    CreateSimplType(QualifiedName<'a>, Box<Self>),
 }
 
 impl Display for Error<'_> {

--- a/csdl-compiler/src/generator/rust/mod_def.rs
+++ b/csdl-compiler/src/generator/rust/mod_def.rs
@@ -50,7 +50,7 @@ pub struct ModDef<'a> {
     typedefs: HashMap<TypeName<'a>, TypeDef<'a>>,
     enums: HashMap<TypeName<'a>, EnumDef<'a>>,
     structs: HashMap<TypeName<'a>, StructDef<'a>>,
-    sub_mods: HashMap<ModName<'a>, ModDef<'a>>,
+    sub_mods: HashMap<ModName<'a>, Self>,
     depth: usize,
 }
 

--- a/redfish/src/entity_link.rs
+++ b/redfish/src/entity_link.rs
@@ -15,13 +15,13 @@
 
 //! Generic lightweight entity link.
 //!
-//! [`EntityLink<B, T>`] is an owned handle that pairs a BMC client with a
+//! [`EntityLink<B, T>`](crate::entity_link::EntityLink) is an owned handle that pairs a BMC client with a
 //! navigation property. It provides lazy access to any Redfish entity
 //! without eagerly fetching it.
 //!
 //! Capabilities are determined by trait bounds on the schema type `T`:
-//! - [`fetch`](EntityLink::fetch) — always available (requires `T: EntityTypeRef + Deserialize + Send + Sync`)
-//! - [`delete`](EntityLink::delete) — available when `T: Deletable`
+//! - [`fetch`](crate::entity_link::EntityLink::fetch) — always available (requires `T: EntityTypeRef + Deserialize + Send + Sync`)
+//! - [`delete`](crate::entity_link::EntityLink::delete) — available when `T: Deletable`
 //!
 //! Concrete link types are defined as type aliases:
 //! ```ignore

--- a/redfish/src/telemetry_service/mod.rs
+++ b/redfish/src/telemetry_service/mod.rs
@@ -124,10 +124,10 @@ impl<B: Bmc> TelemetryService<B> {
         }
     }
 
-    /// Get `Vec<MetricReportRef>` associated with this telemetry service.
+    /// Get `Vec<MetricReportLink>` associated with this telemetry service.
     ///
     /// Fetches the metric report collection and returns a list of
-    /// [`MetricReportRef`] handles.
+    /// [`MetricReportLink`] handles.
     ///
     /// # Errors
     ///


### PR DESCRIPTION
- Replace explicit enum/struct self-references with `Self` in `Box<>`, addressing clippy::use_self lint (Rust 1.87+):
  - core: FilterExpr variants
  - csdl-compiler: compiler::Error, ValidateError, annotation::Error, generator::rust::Error, Stack, ModDef

- Fix rustdoc broken intra-doc links in entity_link module by using fully qualified `crate::entity_link::EntityLink` paths in module-level doc comments (bare names don't resolve from `//!` docs)

- Fix stale `MetricReportRef` references in telemetry_service docs, renamed to `MetricReportLink`