### PR TITLE
nv-redfish: LiteOn OEM power supply links via chassis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ compile-one-feature = $(indent)cargo build -p nv-redfish --features $1$(new-line
 define build-and-test
 	cargo build -p nv-redfish --features managers,oem-hpe
 	cargo build -p nv-redfish --features managers,oem-supermicro
+	cargo build -p nv-redfish --features chassis,power-supplies,oem-liteon
 	cargo build
 	cargo build -p nv-redfish
 	cargo build -p nv-redfish-tests --tests

--- a/redfish/Cargo.toml
+++ b/redfish/Cargo.toml
@@ -90,6 +90,7 @@ oem-supermicro = ["oem"]
 oem-dell = ["oem"]
 oem-ami = ["oem"]
 oem-nvidia = ["oem"]
+oem-liteon = ["oem"]
 
 # OEM product features support
 oem-nvidia-bluefield = ["oem-nvidia"]

--- a/redfish/features.toml
+++ b/redfish/features.toml
@@ -278,11 +278,13 @@ csdl_files = [
     "PowerSupply_v1.xml",
     "PowerSupplyCollection_v1.xml",
     "PowerSupplyMetrics_v1.xml",
+    "PowerSubsystem_v1.xml",
 ]
 patterns = [
     "PowerSupply.*",
     "PowerSupplyCollection.*",
     "PowerSupplyMetrics.*",
+    "PowerSubsystem.*",
 ]
 
 [[features]]
@@ -454,3 +456,19 @@ oem_csdl_files = [
     "AmiManager_v1.xml",
 ]
 csdl_files = []
+
+[[oem-features]]
+vendor = "liteon"
+name = "power-supplies"
+oem_csdl_files = [
+    "LiteonPowerSupplyCollection_v1.xml",
+    "LiteonPowerSupply_v1.xml",
+]
+csdl_files = [
+    "PowerSupply_v1.xml",
+    "Circuit_v1.xml",
+    "PhysicalContext_v1.xml",
+]
+patterns = [
+    "PowerSupply.*",
+]

--- a/redfish/schemas/oem/liteon/LiteonPowerSupplyCollection_v1.xml
+++ b/redfish/schemas/oem/liteon/LiteonPowerSupplyCollection_v1.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+  <edmx:DataServices>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="LiteonPowerSupplyCollection">
+      <EntityType Name="LiteonPowerSupplyCollection" BaseType="Resource.v1_0_0.ResourceCollection">
+        <Annotation Term="OData.Description" String="The collection of `PowerSupply` resource instances defined by LiteOn."/>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <NavigationProperty Name="Members" Type="Collection(LiteonPowerSupply.LiteonPowerSupply)">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The members of this collection."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the members of this collection."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+          <Annotation Term="Redfish.Required"/>
+        </NavigationProperty>
+      </EntityType>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/redfish/schemas/oem/liteon/LiteonPowerSupply_v1.xml
+++ b/redfish/schemas/oem/liteon/LiteonPowerSupply_v1.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+  <edmx:DataServices>
+    <!-- This is how LiteOn extended standard PowerSupply object with
+         PowerState field (it is absent in standard Redfish). -->
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="LiteonPowerSupply">
+      <EntityType Name="LiteonPowerSupply" BaseType="PowerSupply.v1_6_0.PowerSupply"/>
+    </Schema>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="LiteonPowerSupply.v1_0_0">
+      <EntityType Name="LiteonPowerSupply" BaseType="LiteonPowerSupply.LiteonPowerSupply">
+        <Property Name="PowerState" Type="Edm.Boolean" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+        </Property>
+      </EntityType>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/redfish/src/chassis/item.rs
+++ b/redfish/src/chassis/item.rs
@@ -47,6 +47,8 @@ use crate::chassis::PowerSupply;
 use crate::chassis::Thermal;
 #[cfg(feature = "log-services")]
 use crate::log_service::LogService;
+#[cfg(all(feature = "oem-liteon", feature = "power-supplies"))]
+use crate::oem::liteon;
 #[cfg(feature = "oem-nvidia-baseboard")]
 use crate::oem::nvidia::baseboard::NvidiaCbcChassis;
 #[cfg(feature = "pcie-devices")]
@@ -206,6 +208,18 @@ impl<B: Bmc> Chassis<B> {
         }
 
         Ok(Vec::new())
+    }
+
+    /// Get LiteOn OEM power supplies from this chassis.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if fetching power supply data fails.
+    #[cfg(all(feature = "oem-liteon", feature = "power-supplies"))]
+    pub async fn oem_liteon_power_supply_links(
+        &self,
+    ) -> Result<Option<Vec<liteon::power_supply::LiteonPowerSupplyLink<B>>>, Error<B>> {
+        liteon::power_supply::chassis_fetch_links(&self.bmc, self).await
     }
 
     /// Get legacy Power resource (for older BMCs).

--- a/redfish/src/oem/liteon/mod.rs
+++ b/redfish/src/oem/liteon/mod.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,30 +13,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Different vendor OEM externsions to Resdish.
+//! Support of LiteOn OEM extensions to Redfish.
 
-mod identifier;
+pub(crate) mod schema;
 
-#[cfg(feature = "oem-ami")]
-pub mod ami;
+/// Support of LiteOn PowerSupplies.
+#[cfg(feature = "power-supplies")]
+pub mod power_supply;
 
-#[cfg(feature = "oem-nvidia")]
-pub mod nvidia;
+#[cfg(feature = "chassis")]
+use crate::chassis;
 
-#[cfg(feature = "oem-dell")]
-pub mod dell;
-
-#[cfg(feature = "oem-lenovo")]
-pub mod lenovo;
-
-#[cfg(feature = "oem-hpe")]
-pub mod hpe;
-
-#[cfg(feature = "oem-supermicro")]
-pub mod supermicro;
-
-#[cfg(feature = "oem-liteon")]
-pub mod liteon;
-
-#[doc(inline)]
-pub use identifier::Identifier as OemIdentifier;
+/// Manufacturer reported in chassis collection memeber.
+#[cfg(feature = "chassis")]
+pub const CHASSIS_MANUFACTURER: chassis::Manufacturer<&'static str> =
+    chassis::Manufacturer::new("LITE-ON TECHNOLOGY CORP.");

--- a/redfish/src/oem/liteon/power_supply.rs
+++ b/redfish/src/oem/liteon/power_supply.rs
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::entity_link::EntityLink;
+use crate::oem::liteon::schema::redfish::liteon_power_supply::LiteonPowerSupply as LiteonPowerSupplySchema;
+use crate::oem::liteon::schema::redfish::liteon_power_supply_collection::LiteonPowerSupplyCollection as LiteonPowerSupplyCollectionSchema;
+
+use crate::chassis::Chassis;
+use crate::core::Bmc;
+use crate::core::EntityTypeRef as _;
+use crate::core::NavProperty;
+use crate::Error;
+use crate::NvBmc;
+
+/// Link for LiteOn power supply.
+pub type LiteonPowerSupplyLink<B> = EntityLink<B, LiteonPowerSupplySchema>;
+
+pub(crate) async fn chassis_fetch_links<B: Bmc>(
+    bmc: &NvBmc<B>,
+    chassis: &Chassis<B>,
+) -> Result<Option<Vec<LiteonPowerSupplyLink<B>>>, Error<B>> {
+    use crate::oem::liteon::CHASSIS_MANUFACTURER;
+    if chassis.hardware_id().manufacturer != Some(CHASSIS_MANUFACTURER) {
+        return Ok(None);
+    }
+    let Some(power_subsystem) = &chassis.raw().power_subsystem else {
+        return Ok(None);
+    };
+    let power_subsystem = power_subsystem
+        .get(bmc.as_ref())
+        .await
+        .map_err(Error::Bmc)?;
+    let Some(power_supplies) = &power_subsystem.power_supplies else {
+        return Ok(None);
+    };
+    // Convert link to OEM format:
+    NavProperty::<LiteonPowerSupplyCollectionSchema>::new_reference(
+        power_supplies.odata_id().clone(),
+    )
+    .get(bmc.as_ref())
+    .await
+    .map_err(Error::Bmc)
+    .map(|v| {
+        v.members
+            .iter()
+            .map(|v| LiteonPowerSupplyLink::new(bmc, NavProperty::new_reference(v.id().clone())))
+            .collect()
+    })
+    .map(Some)
+}

--- a/redfish/src/oem/liteon/schema.rs
+++ b/redfish/src/oem/liteon/schema.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,30 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Different vendor OEM externsions to Resdish.
+//! AMI OEM Schema.
 
-mod identifier;
-
-#[cfg(feature = "oem-ami")]
-pub mod ami;
-
-#[cfg(feature = "oem-nvidia")]
-pub mod nvidia;
-
-#[cfg(feature = "oem-dell")]
-pub mod dell;
-
-#[cfg(feature = "oem-lenovo")]
-pub mod lenovo;
-
-#[cfg(feature = "oem-hpe")]
-pub mod hpe;
-
-#[cfg(feature = "oem-supermicro")]
-pub mod supermicro;
-
-#[cfg(feature = "oem-liteon")]
-pub mod liteon;
-
-#[doc(inline)]
-pub use identifier::Identifier as OemIdentifier;
+#[allow(dead_code)]
+#[allow(clippy::doc_markdown)]
+#[allow(clippy::absolute_paths)]
+#[allow(clippy::option_option)]
+#[allow(clippy::missing_const_for_fn)]
+#[allow(clippy::struct_field_names)]
+#[allow(missing_docs)]
+pub mod redfish {
+    include!(concat!(env!("OUT_DIR"), "/oem-liteon.rs"));
+}

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -28,6 +28,8 @@ nv-redfish = { workspace = true, features = [
     "oem-nvidia-bluefield",
     "oem-nvidia-baseboard",
     "oem-supermicro",
+    "oem-liteon",
+    "power-supplies",
     "session-service",
     "update-service",
 ] }

--- a/tests/tests/test-chassis-oem-liteon-power-supply.rs
+++ b/tests/tests/test-chassis-oem-liteon-power-supply.rs
@@ -1,0 +1,332 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//! Integration tests for LiteOn OEM power supply links via chassis.
+
+#![recursion_limit = "256"]
+
+use nv_redfish::chassis::Chassis;
+use nv_redfish::ServiceRoot;
+use nv_redfish_core::ODataId;
+use nv_redfish_tests::anonymous_1_9_service_root;
+use nv_redfish_tests::json_merge;
+use nv_redfish_tests::Bmc;
+use nv_redfish_tests::Expect;
+use nv_redfish_tests::ODATA_ID;
+use nv_redfish_tests::ODATA_TYPE;
+use serde_json::json;
+use serde_json::Value;
+use std::error::Error as StdError;
+use std::sync::Arc;
+use tokio::test;
+
+const CHASSIS_COLLECTION_DATA_TYPE: &str = "#ChassisCollection.ChassisCollection";
+const CHASSIS_DATA_TYPE: &str = "#Chassis.v1_23_0.Chassis";
+const POWER_SUBSYSTEM_DATA_TYPE: &str = "#PowerSubsystem.v1_1_0.PowerSubsystem";
+const PSU_COLLECTION_DATA_TYPE: &str = "#PowerSupplyCollection.PowerSupplyCollection";
+const PSU_DATA_TYPE: &str = "#PowerSupply.v1_5_0.PowerSupply";
+
+#[test]
+async fn liteon_power_supply_links_happy_path() -> Result<(), Box<dyn StdError>> {
+    let bmc = Arc::new(Bmc::default());
+    let ids = ids();
+    let chassis = get_liteon_chassis(
+        bmc.clone(),
+        &ids,
+        liteon_chassis_member(&ids, json!({})),
+    )
+    .await?;
+
+    expect_power_subsystem(bmc.clone(), &ids);
+    expect_psu_collection(
+        bmc.clone(),
+        &ids,
+        vec![format!("{}/0", ids.psu_collection_id)],
+    );
+
+    let links = chassis.oem_liteon_power_supply_links().await?.unwrap();
+    assert_eq!(links.len(), 1);
+    assert_eq!(
+        links[0].odata_id().to_string(),
+        format!("{}/0", ids.psu_collection_id)
+    );
+
+    // Verify fetch works on the link
+    let psu_id = format!("{}/0", ids.psu_collection_id);
+    bmc.expect(Expect::get(
+        &psu_id,
+        psu_payload(&psu_id, "0", true),
+    ));
+    let psu = links[0].fetch().await?;
+    assert_eq!(psu.power_state, Some(true));
+
+    Ok(())
+}
+
+#[test]
+async fn liteon_power_supply_links_multiple_psus() -> Result<(), Box<dyn StdError>> {
+    let bmc = Arc::new(Bmc::default());
+    let ids = ids();
+    let chassis = get_liteon_chassis(
+        bmc.clone(),
+        &ids,
+        liteon_chassis_member(&ids, json!({})),
+    )
+    .await?;
+
+    expect_power_subsystem(bmc.clone(), &ids);
+    expect_psu_collection(
+        bmc.clone(),
+        &ids,
+        vec![
+            format!("{}/0", ids.psu_collection_id),
+            format!("{}/1", ids.psu_collection_id),
+        ],
+    );
+
+    let links = chassis.oem_liteon_power_supply_links().await?.unwrap();
+    assert_eq!(links.len(), 2);
+    assert_eq!(
+        links[0].odata_id().to_string(),
+        format!("{}/0", ids.psu_collection_id)
+    );
+    assert_eq!(
+        links[1].odata_id().to_string(),
+        format!("{}/1", ids.psu_collection_id)
+    );
+
+    Ok(())
+}
+
+#[test]
+async fn liteon_power_supply_links_wrong_manufacturer_returns_none() -> Result<(), Box<dyn StdError>>
+{
+    let bmc = Arc::new(Bmc::default());
+    let ids = ids();
+    let chassis = get_liteon_chassis(
+        bmc.clone(),
+        &ids,
+        chassis_member(
+            &ids,
+            json!({
+                "Manufacturer": "ACME Corp.",
+                "PowerSubsystem": { ODATA_ID: &ids.power_subsystem_id }
+            }),
+        ),
+    )
+    .await?;
+
+    let result = chassis.oem_liteon_power_supply_links().await?;
+    assert!(result.is_none());
+
+    Ok(())
+}
+
+#[test]
+async fn liteon_power_supply_links_missing_manufacturer_returns_none(
+) -> Result<(), Box<dyn StdError>> {
+    let bmc = Arc::new(Bmc::default());
+    let ids = ids();
+    let chassis = get_liteon_chassis(
+        bmc.clone(),
+        &ids,
+        chassis_member(&ids, json!({})),
+    )
+    .await?;
+
+    let result = chassis.oem_liteon_power_supply_links().await?;
+    assert!(result.is_none());
+
+    Ok(())
+}
+
+#[test]
+async fn liteon_power_supply_links_missing_power_subsystem_returns_none(
+) -> Result<(), Box<dyn StdError>> {
+    let bmc = Arc::new(Bmc::default());
+    let ids = ids();
+    let chassis = get_liteon_chassis(
+        bmc.clone(),
+        &ids,
+        json_merge([
+            &json!({
+                ODATA_ID: &ids.chassis_id,
+                ODATA_TYPE: CHASSIS_DATA_TYPE,
+                "Id": "powershelf",
+                "Name": "powershelf",
+                "ChassisType": "Shelf",
+                "Manufacturer": "LITE-ON TECHNOLOGY CORP."
+            }),
+        ]),
+    )
+    .await?;
+
+    let result = chassis.oem_liteon_power_supply_links().await?;
+    assert!(result.is_none());
+
+    Ok(())
+}
+
+#[test]
+async fn liteon_power_supply_links_empty_collection() -> Result<(), Box<dyn StdError>> {
+    let bmc = Arc::new(Bmc::default());
+    let ids = ids();
+    let chassis = get_liteon_chassis(
+        bmc.clone(),
+        &ids,
+        liteon_chassis_member(&ids, json!({})),
+    )
+    .await?;
+
+    expect_power_subsystem(bmc.clone(), &ids);
+    expect_psu_collection(bmc.clone(), &ids, vec![]);
+
+    let links = chassis.oem_liteon_power_supply_links().await?.unwrap();
+    assert!(links.is_empty());
+
+    Ok(())
+}
+
+// --- Helpers ---
+
+struct Ids {
+    root_id: ODataId,
+    chassis_collection_id: String,
+    chassis_id: String,
+    power_subsystem_id: String,
+    psu_collection_id: String,
+}
+
+fn ids() -> Ids {
+    let root_id = ODataId::service_root();
+    let chassis_collection_id = format!("{root_id}/Chassis");
+    let chassis_id = format!("{chassis_collection_id}/powershelf");
+    let power_subsystem_id = format!("{chassis_id}/PowerSubsystem");
+    let psu_collection_id = format!("{power_subsystem_id}/PowerSupplies");
+    Ids {
+        root_id,
+        chassis_collection_id,
+        chassis_id,
+        power_subsystem_id,
+        psu_collection_id,
+    }
+}
+
+fn chassis_member(ids: &Ids, fields: Value) -> Value {
+    let base = json!({
+        ODATA_ID: &ids.chassis_id,
+        ODATA_TYPE: CHASSIS_DATA_TYPE,
+        "Id": "powershelf",
+        "Name": "powershelf",
+        "ChassisType": "Shelf"
+    });
+    json_merge([&base, &fields])
+}
+
+fn liteon_chassis_member(ids: &Ids, extra: Value) -> Value {
+    chassis_member(
+        ids,
+        json_merge([
+            &json!({
+                "Manufacturer": "LITE-ON TECHNOLOGY CORP.",
+                "PowerSubsystem": { ODATA_ID: &ids.power_subsystem_id }
+            }),
+            &extra,
+        ]),
+    )
+}
+
+fn psu_payload(psu_id: &str, id: &str, power_state: bool) -> Value {
+    json!({
+        ODATA_ID: psu_id,
+        ODATA_TYPE: PSU_DATA_TYPE,
+        "Id": id,
+        "Name": format!("Power Supply {id}"),
+        "Manufacturer": "LITE-ON TECHNOLOGY CORP.",
+        "Model": "SP-2552-1R",
+        "PowerState": power_state,
+        "Status": {
+            "Health": "OK",
+            "State": "Enabled"
+        }
+    })
+}
+
+async fn get_liteon_chassis(
+    bmc: Arc<Bmc>,
+    ids: &Ids,
+    member: Value,
+) -> Result<Chassis<Bmc>, Box<dyn StdError>> {
+    let service_root = expect_service_root(bmc.clone(), ids).await?;
+    bmc.expect(Expect::get(
+        &ids.chassis_collection_id,
+        json!({
+            ODATA_ID: &ids.chassis_collection_id,
+            ODATA_TYPE: CHASSIS_COLLECTION_DATA_TYPE,
+            "Id": "Chassis",
+            "Name": "Chassis Collection",
+            "Members": [member]
+        }),
+    ));
+    let collection = service_root.chassis().await?.unwrap();
+    let members = collection.members().await?;
+    assert_eq!(members.len(), 1);
+    Ok(members.into_iter().next().expect("single chassis must exist"))
+}
+
+async fn expect_service_root(
+    bmc: Arc<Bmc>,
+    ids: &Ids,
+) -> Result<ServiceRoot<Bmc>, Box<dyn StdError>> {
+    bmc.expect(Expect::get(
+        &ids.root_id,
+        anonymous_1_9_service_root(
+            &ids.root_id,
+            json!({
+                "Chassis": { ODATA_ID: &ids.chassis_collection_id }
+            }),
+        ),
+    ));
+    ServiceRoot::new(bmc).await.map_err(Into::into)
+}
+
+fn expect_power_subsystem(bmc: Arc<Bmc>, ids: &Ids) {
+    bmc.expect(Expect::get(
+        &ids.power_subsystem_id,
+        json!({
+            ODATA_ID: &ids.power_subsystem_id,
+            ODATA_TYPE: POWER_SUBSYSTEM_DATA_TYPE,
+            "Id": "PowerSubsystem",
+            "Name": "Power Subsystem",
+            "PowerSupplies": { ODATA_ID: &ids.psu_collection_id }
+        }),
+    ));
+}
+
+fn expect_psu_collection(bmc: Arc<Bmc>, ids: &Ids, psu_ids: Vec<String>) {
+    let members: Vec<Value> = psu_ids
+        .iter()
+        .map(|id| json!({ ODATA_ID: id }))
+        .collect();
+    bmc.expect(Expect::get(
+        &ids.psu_collection_id,
+        json!({
+            ODATA_ID: &ids.psu_collection_id,
+            ODATA_TYPE: PSU_COLLECTION_DATA_TYPE,
+            "Id": "PowerSupplies",
+            "Name": "Power Supply Collection",
+            "Members": members
+        }),
+    ));
+}


### PR DESCRIPTION
LiteOn powershelf platforms extend standard Redfish PowerSupply with a PowerState boolean field. Add OEM schema, feature-gated support (oem-liteon + power-supplies), and Chassis::oem_liteon_power_supply_links() using EntityLink<B, T>.

Integration tests cover happy path with fetch, multiple PSUs, wrong/missing manufacturer, missing PowerSubsystem, and empty collection.