### PR TITLE
ci: add Windows and macOS to build/test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,12 @@ env:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
-    
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Expand the build-and-test job into a matrix running on
ubuntu-latest, windows-latest, and macos-latest with fail-fast
disabled so a failure on one platform does not cancel the others.

Recent Windows-specific issues (build script stack overflow, and the
EdmDateTimeOffset to SystemTime conversion hitting the FILETIME 1601
epoch limit) were not caught by CI and had to be discovered and fixed
manually. Running CI on all three major platforms should catch such
regressions before merge.
