### PR TITLE
bmc-http csdl-compiler: tighten docs/lints and credential updates

### DIFF
--- a/bmc-http/src/cache.rs
+++ b/bmc-http/src/cache.rs
@@ -81,7 +81,6 @@ struct GhostList<K> {
     size: usize,
 }
 
-#[allow(clippy::manual_let_else)]
 impl<K: Clone> GhostList<K> {
     fn new(capacity: usize) -> Self {
         Self {
@@ -150,9 +149,8 @@ impl<K: Clone> GhostList<K> {
 
     /// Remove specific slot - O(1)
     fn remove(&mut self, slot: usize) -> bool {
-        let node = match self.entries[slot].take() {
-            Some(node) => node,
-            None => return false,
+        let Some(node) = self.entries[slot].take() else {
+            return false;
         };
 
         self.free_slots.push(slot);
@@ -462,12 +460,12 @@ where
     }
 
     /// Try to replace from T1, returns the evicted entry if replacement was successful
-    #[allow(clippy::if_not_else)]
     fn try_replace_from_t1(&mut self) -> Option<CacheEntry<K, V>> {
         if let Some(head_entry) = self.t1.get_head_page() {
             // Line 25: if (the page reference bit of head page in T1 is 0) then
             // ref_bit == false
-            if !head_entry.ref_bit {
+            #[allow(clippy::bool_comparison)] // Allow to match paper
+            if head_entry.ref_bit == false {
                 // Line 26: found = 1;
                 // Line 27: Demote the head page in T1 and make it the MRU page in B1
                 if let Some(entry) = self.t1.remove_head_page() {
@@ -497,12 +495,12 @@ where
     }
 
     /// Try to replace from T2, returns the evicted entry if replacement was successful
-    #[allow(clippy::if_not_else)]
     fn try_replace_from_t2(&mut self) -> Option<CacheEntry<K, V>> {
         if let Some(head_entry) = self.t2.get_head_page() {
             // Line 32: if (the page reference bit of head page in T2 is 0), then
             // ref_bit == false
-            if !head_entry.ref_bit {
+            #[allow(clippy::bool_comparison)] // Allow to match paper
+            if head_entry.ref_bit == false {
                 // Line 33: found = 1;
                 // Line 34: Demote the head page in T2 and make it the MRU page in B2
                 if let Some(entry) = self.t2.remove_head_page() {

--- a/bmc-http/src/credentials.rs
+++ b/bmc-http/src/credentials.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! HTTP credentials type.
+
 use std::fmt;
 
 /// Credentials used to access the BMC.
@@ -26,10 +28,12 @@ pub enum BmcCredentials {
     UsernamePassword {
         /// Username to access BMC.
         username: String,
+        /// Password to access BMC.
         password: Option<String>,
     },
     /// Use Redfish session token authentication.
     Token {
+        /// Token value.
         token: String,
     },
 }

--- a/bmc-http/src/lib.rs
+++ b/bmc-http/src/lib.rs
@@ -13,6 +13,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![deny(
+    clippy::all,
+    clippy::pedantic,
+    clippy::nursery,
+    clippy::suspicious,
+    clippy::complexity,
+    clippy::perf
+)]
+#![deny(
+    clippy::absolute_paths,
+    clippy::todo,
+    clippy::unimplemented,
+    clippy::tests_outside_test_module,
+    clippy::panic,
+    clippy::unwrap_used,
+    clippy::unwrap_in_result,
+    clippy::unused_trait_names,
+    clippy::print_stdout,
+    clippy::print_stderr
+)]
+#![allow(clippy::doc_markdown)]
+#![deny(missing_docs)]
+
+//! HTTP implementation of [`nv_redfish_core::Bmc`] trait.
+
 pub mod cache;
 pub mod credentials;
 
@@ -32,18 +57,22 @@ use nv_redfish_core::ModificationResponse;
 use nv_redfish_core::ODataETag;
 use nv_redfish_core::ODataId;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use std::{
-    collections::HashMap,
-    error::Error as StdError,
-    future::Future,
-    sync::{Arc, RwLock},
-};
+use std::collections::HashMap;
+use std::error::Error as StdError;
+use std::future::Future;
+use std::sync::Arc;
+use std::sync::RwLock;
 use url::Url;
 
 #[doc(inline)]
 pub use credentials::BmcCredentials;
 
+/// HTTP Client trait.
+///
+/// nv-redfish-bmc-http supports any HTTP implementation that
+/// implements this [`HttpClient`] trait.
 pub trait HttpClient: Send + Sync {
+    /// HTTP client error.
     type Error: Send + StdError;
 
     /// Perform an HTTP GET request with optional conditional headers.
@@ -237,13 +266,13 @@ where
     ///
     /// Existing cache and ETag state is preserved.
     ///
-    /// # Errors
+    /// # Panics
     ///
-    /// Returns an error if the credentials lock is poisoned.
-    pub fn set_credentials(&self, credentials: BmcCredentials) -> Result<(), String> {
-        let mut current = self.credentials.write().expect("poisoned");
-        *current = Arc::new(credentials);
-        Ok(())
+    /// Panics if the internal credentials lock is poisoned. This should not
+    /// occur in normal operation.
+    #[allow(clippy::panic)] // See panics section.
+    pub fn set_credentials(&self, credentials: BmcCredentials) {
+        *self.credentials.write().expect("poisoned") = Arc::new(credentials);
     }
 }
 
@@ -280,6 +309,7 @@ impl RedfishEndpoint {
 }
 
 /// `CacheSettings` for internal BMC cache with etags
+#[derive(Clone, Copy)]
 pub struct CacheSettings {
     capacity: usize,
 }
@@ -291,7 +321,9 @@ impl Default for CacheSettings {
 }
 
 impl CacheSettings {
-    pub fn with_capacity(capacity: usize) -> Self {
+    /// Define capacity of the cache measured in number of items.
+    #[must_use]
+    pub const fn with_capacity(capacity: usize) -> Self {
         Self { capacity }
     }
 }
@@ -326,6 +358,7 @@ impl<C: HttpClient> HttpBmc<C>
 where
     C::Error: CacheableError + StdError + Send + Sync,
 {
+    #[allow(clippy::panic)] // See set_credentials Panic doc.
     fn read_credentials(&self) -> Arc<BmcCredentials> {
         self.credentials
             .read()

--- a/bmc-http/src/reqwest.rs
+++ b/bmc-http/src/reqwest.rs
@@ -13,10 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Implementation of [`HttpClient`] trait using reqwest crate.
+
 use crate::BmcCredentials;
 use crate::CacheableError;
 use crate::HttpClient;
-use futures_util::StreamExt;
+use futures_util::StreamExt as _;
 use http::header;
 use http::HeaderMap;
 use nv_redfish_core::AsyncTask;
@@ -24,23 +26,39 @@ use nv_redfish_core::BoxTryStream;
 use nv_redfish_core::ModificationResponse;
 use nv_redfish_core::ODataETag;
 use nv_redfish_core::ODataId;
+use reqwest::redirect::Policy as RedirectPolicy;
+use reqwest::Client as ReqwestClient;
+use reqwest::Error as ReqwestError;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
+use std::error::Error as StdError;
+use std::fmt;
 use std::time::Duration;
 use url::Url;
 
+/// Errors of reqwest implementation of the HTTP trait.
 #[derive(Debug)]
 pub enum BmcError {
+    /// Direct mapping of underlying reqwest error.
     ReqwestError(reqwest::Error),
+    /// JSON to model deserialize error with path tracking.
     JsonError(serde_path_to_error::Error<serde_json::Error>),
+    /// Unexpected HTTP response.
     InvalidResponse {
+        /// URL in request that caused error.
         url: url::Url,
+        /// Returned status.
         status: reqwest::StatusCode,
+        /// Text in the response.
         text: String,
     },
+    /// SSE stream error.
     SseStreamError(sse_stream::Error),
+    /// No resource found in cache.
     CacheMiss,
+    /// HTTP cache error.
     CacheError(String),
+    /// JSON deserialization error.
     DecodeError(serde_json::Error),
 }
 
@@ -67,9 +85,8 @@ impl CacheableError for BmcError {
     }
 }
 
-#[allow(clippy::absolute_paths)]
-impl std::fmt::Display for BmcError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for BmcError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::ReqwestError(e) => write!(f, "HTTP client error: {e:?}"),
             Self::InvalidResponse { url, status, text } => {
@@ -93,9 +110,8 @@ impl std::fmt::Display for BmcError {
     }
 }
 
-#[allow(clippy::absolute_paths)]
-impl std::error::Error for BmcError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl StdError for BmcError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match self {
             Self::ReqwestError(e) => Some(e),
             Self::JsonError(e) => Some(e.inner()),
@@ -165,65 +181,76 @@ impl Default for ClientParams {
 }
 
 impl ClientParams {
+    /// Creates new client parameters.
     #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// See: [`reqwest::ClientBuilder::timeout`].
     #[must_use]
     pub const fn timeout(mut self, timeout: Duration) -> Self {
         self.timeout = Some(timeout);
         self
     }
 
+    /// See: [`reqwest::ClientBuilder::connect_timeout`].
     #[must_use]
     pub const fn connect_timeout(mut self, timeout: Duration) -> Self {
         self.connect_timeout = Some(timeout);
         self
     }
 
+    /// See: [`reqwest::ClientBuilder::user_agent`].
     #[must_use]
     pub fn user_agent<S: Into<String>>(mut self, user_agent: S) -> Self {
         self.user_agent = Some(user_agent.into());
         self
     }
 
+    /// See: [`reqwest::ClientBuilder::danger_accept_invalid_certs`].
     #[must_use]
     pub const fn accept_invalid_certs(mut self, accept: bool) -> Self {
         self.accept_invalid_certs = accept;
         self
     }
 
+    /// See: [`reqwest::ClientBuilder::redirect`].
     #[must_use]
     pub const fn max_redirects(mut self, max: usize) -> Self {
         self.max_redirects = Some(max);
         self
     }
 
+    /// See: [`reqwest::ClientBuilder::tcp_keepalive`].
     #[must_use]
     pub const fn tcp_keepalive(mut self, keepalive: Duration) -> Self {
         self.tcp_keepalive = Some(keepalive);
         self
     }
 
+    /// See: [`reqwest::ClientBuilder::pool_max_idle_per_host`].
     #[must_use]
     pub const fn pool_max_idle_per_host(mut self, pool_max_idle_per_host: usize) -> Self {
         self.pool_max_idle_per_host = Some(pool_max_idle_per_host);
         self
     }
 
+    /// See: [`reqwest::ClientBuilder::pool_idle_timeout`].
     #[must_use]
     pub const fn idle_timeout(mut self, pool_idle_timeout: Duration) -> Self {
         self.pool_idle_timeout = Some(pool_idle_timeout);
         self
     }
 
+    /// Clears timeout for this client.
     #[must_use]
     pub const fn no_timeout(mut self) -> Self {
         self.timeout = None;
         self
     }
 
+    /// See: [`reqwest::ClientBuilder::default_headers`].
     #[must_use]
     pub fn default_headers(mut self, default_headers: HeaderMap) -> Self {
         self.default_headers = Some(default_headers);
@@ -239,18 +266,28 @@ impl ClientParams {
 ///
 #[derive(Clone)]
 pub struct Client {
-    client: reqwest::Client,
+    client: ReqwestClient,
 }
 
-#[allow(clippy::missing_errors_doc)]
-#[allow(clippy::absolute_paths)]
 impl Client {
-    pub fn new() -> Result<Self, reqwest::Error> {
+    /// Create client with default [`ClientParams`].
+    ///
+    /// # Errors
+    ///
+    /// Internally it builds [`reqwest::ClientBuilder::build`]. This function
+    /// transparently passes errors of this call to caller.
+    pub fn new() -> Result<Self, ReqwestError> {
         Self::with_params(ClientParams::default())
     }
 
+    /// Build client from parameters.
+    ///
+    /// # Errors
+    ///
+    /// Internally it builds [`reqwest::ClientBuilder::build`]. This function
+    /// transparently passes errors of this call to caller.
     pub fn with_params(params: ClientParams) -> Result<Self, reqwest::Error> {
-        let mut builder = reqwest::Client::builder();
+        let mut builder = ReqwestClient::builder();
 
         if params.use_rust_tls {
             builder = builder.use_rustls_tls();
@@ -273,7 +310,7 @@ impl Client {
         }
 
         if let Some(max_redirects) = params.max_redirects {
-            builder = builder.redirect(reqwest::redirect::Policy::limited(max_redirects));
+            builder = builder.redirect(RedirectPolicy::limited(max_redirects));
         }
 
         if let Some(keepalive) = params.tcp_keepalive {
@@ -297,8 +334,9 @@ impl Client {
         })
     }
 
+    /// Use pre-built [`reqwest::Client`] as internal client.
     #[must_use]
-    pub const fn with_client(client: reqwest::Client) -> Self {
+    pub const fn with_client(client: ReqwestClient) -> Self {
         Self { client }
     }
 }
@@ -323,7 +361,7 @@ impl Client {
         let mut value: serde_json::Value = response.json().await.map_err(BmcError::ReqwestError)?;
 
         if let Some(etag) = etag_header {
-            inject_etag(etag, &mut value);
+            inject_etag(&etag, &mut value);
         }
 
         serde_path_to_error::deserialize(value).map_err(BmcError::JsonError)
@@ -374,7 +412,7 @@ impl Client {
 
                     if value.get("@odata.id").is_some() {
                         if let Some(etag) = etag {
-                            inject_etag(etag, &mut value);
+                            inject_etag(&etag, &mut value);
                         }
                         return serde_path_to_error::deserialize(value)
                             .map(ModificationResponse::Entity)
@@ -405,16 +443,17 @@ fn location_from_headers(headers: &HeaderMap) -> Option<ODataId> {
         .get(header::LOCATION)
         .and_then(|value| value.to_str().ok())
         .map(|raw| {
-            if let Ok(url) = Url::parse(raw) {
-                let mut path = url.path().to_string();
-                if let Some(query) = url.query() {
-                    path.push('?');
-                    path.push_str(query);
-                }
-                path.into()
-            } else {
-                raw.to_string().into()
-            }
+            Url::parse(raw).map_or_else(
+                |_| raw.to_string().into(),
+                |url| {
+                    let mut path = url.path().to_string();
+                    if let Some(query) = url.query() {
+                        path.push('?');
+                        path.push_str(query);
+                    }
+                    path.into()
+                },
+            )
         })
 }
 
@@ -432,7 +471,7 @@ fn retry_after_from_headers(headers: &HeaderMap) -> Option<u64> {
         .and_then(|v| v.trim().parse::<u64>().ok())
 }
 
-fn inject_etag(etag: ODataETag, body: &mut serde_json::Value) {
+fn inject_etag(etag: &ODataETag, body: &mut serde_json::Value) {
     if let Some(obj) = body.as_object_mut() {
         let etag_value = serde_json::Value::String(etag.to_string());
 
@@ -468,7 +507,8 @@ impl HttpClient for Client {
     where
         T: DeserializeOwned,
     {
-        let mut request = auth_headers(self.client.get(url), credentials).headers(custom_headers.clone());
+        let mut request =
+            auth_headers(self.client.get(url), credentials).headers(custom_headers.clone());
 
         if let Some(etag) = etag {
             request = request.header(header::IF_NONE_MATCH, etag.to_string());

--- a/bmc-http/tests/reqwest_client_tests.rs
+++ b/bmc-http/tests/reqwest_client_tests.rs
@@ -17,8 +17,8 @@ mod common;
 
 #[cfg(feature = "reqwest")]
 mod reqwest_client_tests {
-    use nv_redfish_bmc_http::BmcCredentials;
     use nv_redfish_bmc_http::reqwest::BmcError;
+    use nv_redfish_bmc_http::BmcCredentials;
     use nv_redfish_core::{
         query::{ExpandQuery, FilterQuery},
         Bmc, ModificationResponse,
@@ -90,8 +90,7 @@ mod reqwest_client_tests {
         let first = bmc.get::<TestResource>(&first_id).await.unwrap();
         assert_eq!(first.value, 42);
 
-        bmc.set_credentials(BmcCredentials::token("new-token".to_string()))
-            .unwrap();
+        bmc.set_credentials(BmcCredentials::token("new-token".to_string()));
 
         let second_id = create_odata_id(second_resource_path);
         let second = bmc.get::<TestResource>(&second_id).await.unwrap();

--- a/csdl-compiler/src/compiler/entity_type.rs
+++ b/csdl-compiler/src/compiler/entity_type.rs
@@ -60,7 +60,7 @@ impl<'a> EntityType<'a> {
         ctx: &Context<'a>,
         stack: &Stack<'a, '_>,
     ) -> Result<Compiled<'a>, Error<'a>> {
-        let stack = stack.new_frame().with_enitity_type(name);
+        let stack = stack.new_frame().with_entity_type(name);
         // Ensure that base entity type compiled if present.
         let (base, compiled) = if let Some(base_type) = &schema_entity_type.base_type {
             let compiled = Self::ensure(base_type.into(), ctx, &stack)?;

--- a/csdl-compiler/src/compiler/mod.rs
+++ b/csdl-compiler/src/compiler/mod.rs
@@ -257,7 +257,7 @@ impl SchemaBundle {
         root_patterns: &EntityTypeFilter,
     ) -> Result<RootSet<'a>, Error<'a>> {
         // Iterate through all singletons located in
-        // EDMX documents → schemas → entity containers.
+        // EDMX documents -> schemas -> entity containers.
         //
         // If a singleton matches the requested set, collect its most recent
         // descendant type into the root set.

--- a/csdl-compiler/src/compiler/stack.rs
+++ b/csdl-compiler/src/compiler/stack.rs
@@ -47,7 +47,7 @@ impl<'a, 'stack> Stack<'a, 'stack> {
     /// Track the entity type being compiled to avoid cycles caused by
     /// navigation-property references.
     #[must_use]
-    pub const fn with_enitity_type(mut self, name: QualifiedName<'a>) -> Self {
+    pub const fn with_entity_type(mut self, name: QualifiedName<'a>) -> Self {
         self.entity_type = Some(name);
         self
     }

--- a/tests/tests/test-chassis-oem-liteon-power-supply.rs
+++ b/tests/tests/test-chassis-oem-liteon-power-supply.rs
@@ -41,12 +41,8 @@ const PSU_DATA_TYPE: &str = "#PowerSupply.v1_5_0.PowerSupply";
 async fn liteon_power_supply_links_happy_path() -> Result<(), Box<dyn StdError>> {
     let bmc = Arc::new(Bmc::default());
     let ids = ids();
-    let chassis = get_liteon_chassis(
-        bmc.clone(),
-        &ids,
-        liteon_chassis_member(&ids, json!({})),
-    )
-    .await?;
+    let chassis =
+        get_liteon_chassis(bmc.clone(), &ids, liteon_chassis_member(&ids, json!({}))).await?;
 
     expect_power_subsystem(bmc.clone(), &ids);
     expect_psu_collection(
@@ -64,10 +60,7 @@ async fn liteon_power_supply_links_happy_path() -> Result<(), Box<dyn StdError>>
 
     // Verify fetch works on the link
     let psu_id = format!("{}/0", ids.psu_collection_id);
-    bmc.expect(Expect::get(
-        &psu_id,
-        psu_payload(&psu_id, "0", true),
-    ));
+    bmc.expect(Expect::get(&psu_id, psu_payload(&psu_id, "0", true)));
     let psu = links[0].fetch().await?;
     assert_eq!(psu.power_state, Some(true));
 
@@ -78,12 +71,8 @@ async fn liteon_power_supply_links_happy_path() -> Result<(), Box<dyn StdError>>
 async fn liteon_power_supply_links_multiple_psus() -> Result<(), Box<dyn StdError>> {
     let bmc = Arc::new(Bmc::default());
     let ids = ids();
-    let chassis = get_liteon_chassis(
-        bmc.clone(),
-        &ids,
-        liteon_chassis_member(&ids, json!({})),
-    )
-    .await?;
+    let chassis =
+        get_liteon_chassis(bmc.clone(), &ids, liteon_chassis_member(&ids, json!({}))).await?;
 
     expect_power_subsystem(bmc.clone(), &ids);
     expect_psu_collection(
@@ -138,12 +127,7 @@ async fn liteon_power_supply_links_missing_manufacturer_returns_none(
 ) -> Result<(), Box<dyn StdError>> {
     let bmc = Arc::new(Bmc::default());
     let ids = ids();
-    let chassis = get_liteon_chassis(
-        bmc.clone(),
-        &ids,
-        chassis_member(&ids, json!({})),
-    )
-    .await?;
+    let chassis = get_liteon_chassis(bmc.clone(), &ids, chassis_member(&ids, json!({}))).await?;
 
     let result = chassis.oem_liteon_power_supply_links().await?;
     assert!(result.is_none());
@@ -159,16 +143,14 @@ async fn liteon_power_supply_links_missing_power_subsystem_returns_none(
     let chassis = get_liteon_chassis(
         bmc.clone(),
         &ids,
-        json_merge([
-            &json!({
-                ODATA_ID: &ids.chassis_id,
-                ODATA_TYPE: CHASSIS_DATA_TYPE,
-                "Id": "powershelf",
-                "Name": "powershelf",
-                "ChassisType": "Shelf",
-                "Manufacturer": "LITE-ON TECHNOLOGY CORP."
-            }),
-        ]),
+        json_merge([&json!({
+            ODATA_ID: &ids.chassis_id,
+            ODATA_TYPE: CHASSIS_DATA_TYPE,
+            "Id": "powershelf",
+            "Name": "powershelf",
+            "ChassisType": "Shelf",
+            "Manufacturer": "LITE-ON TECHNOLOGY CORP."
+        })]),
     )
     .await?;
 
@@ -182,12 +164,8 @@ async fn liteon_power_supply_links_missing_power_subsystem_returns_none(
 async fn liteon_power_supply_links_empty_collection() -> Result<(), Box<dyn StdError>> {
     let bmc = Arc::new(Bmc::default());
     let ids = ids();
-    let chassis = get_liteon_chassis(
-        bmc.clone(),
-        &ids,
-        liteon_chassis_member(&ids, json!({})),
-    )
-    .await?;
+    let chassis =
+        get_liteon_chassis(bmc.clone(), &ids, liteon_chassis_member(&ids, json!({}))).await?;
 
     expect_power_subsystem(bmc.clone(), &ids);
     expect_psu_collection(bmc.clone(), &ids, vec![]);
@@ -282,7 +260,10 @@ async fn get_liteon_chassis(
     let collection = service_root.chassis().await?.unwrap();
     let members = collection.members().await?;
     assert_eq!(members.len(), 1);
-    Ok(members.into_iter().next().expect("single chassis must exist"))
+    Ok(members
+        .into_iter()
+        .next()
+        .expect("single chassis must exist"))
 }
 
 async fn expect_service_root(
@@ -315,10 +296,7 @@ fn expect_power_subsystem(bmc: Arc<Bmc>, ids: &Ids) {
 }
 
 fn expect_psu_collection(bmc: Arc<Bmc>, ids: &Ids, psu_ids: Vec<String>) {
-    let members: Vec<Value> = psu_ids
-        .iter()
-        .map(|id| json!({ ODATA_ID: id }))
-        .collect();
+    let members: Vec<Value> = psu_ids.iter().map(|id| json!({ ODATA_ID: id })).collect();
     bmc.expect(Expect::get(
         &ids.psu_collection_id,
         json!({

--- a/tests/tests/test-session-service.rs
+++ b/tests/tests/test-session-service.rs
@@ -43,7 +43,10 @@ async fn list_sessions() -> Result<(), Box<dyn StdError>> {
     let bmc = Arc::new(Bmc::default());
     let root_id = ODataId::service_root();
     let session_service = get_session_service(bmc.clone(), &root_id).await?;
-    let session_id = format!("{}/Sessions/1234567890ABCDEF", session_service.raw().odata_id());
+    let session_id = format!(
+        "{}/Sessions/1234567890ABCDEF",
+        session_service.raw().odata_id()
+    );
     let sessions = get_session_collection(
         bmc.clone(),
         &session_service,
@@ -62,7 +65,10 @@ async fn list_sessions() -> Result<(), Box<dyn StdError>> {
     assert_eq!(sessions.len(), 1);
     let session = sessions.first().unwrap().raw();
     assert_eq!(session.user_name, Some(Some("Administrator".into())));
-    assert_eq!(session.session_type, Some(Some(SessionTypes::ManagerConsole)));
+    assert_eq!(
+        session.session_type,
+        Some(Some(SessionTypes::ManagerConsole))
+    );
     Ok(())
 }
 
@@ -94,8 +100,14 @@ async fn create_session() -> Result<(), Box<dyn StdError>> {
 
     let session = sessions.create_session(&create).await?.unwrap();
     assert_eq!(session.raw().user_name, Some(Some("Administrator".into())));
-    assert_eq!(session.raw().client_origin_ip_address, Some(Some("127.0.0.1".into())));
-    assert_eq!(session.raw().session_type, Some(Some(SessionTypes::ManagerConsole)));
+    assert_eq!(
+        session.raw().client_origin_ip_address,
+        Some(Some("127.0.0.1".into()))
+    );
+    assert_eq!(
+        session.raw().session_type,
+        Some(Some(SessionTypes::ManagerConsole))
+    );
     Ok(())
 }
 
@@ -104,7 +116,10 @@ async fn delete_session() -> Result<(), Box<dyn StdError>> {
     let bmc = Arc::new(Bmc::default());
     let root_id = ODataId::service_root();
     let session_service = get_session_service(bmc.clone(), &root_id).await?;
-    let session_id = format!("{}/Sessions/1234567890ABCDEF", session_service.raw().odata_id());
+    let session_id = format!(
+        "{}/Sessions/1234567890ABCDEF",
+        session_service.raw().odata_id()
+    );
     let sessions = get_session_collection(
         bmc.clone(),
         &session_service,

--- a/tests/tests/tests-base-operations.rs
+++ b/tests/tests/tests-base-operations.rs
@@ -846,4 +846,3 @@ async fn enum_unknown_value_falls_back_to_unsupported_value() {
         serde_json::to_value(ActionType::UnsupportedValue).expect("fallback must serialize");
     assert_eq!(serialized, json!("UnsupportedValue"));
 }
-


### PR DESCRIPTION
- enable strict clippy and missing_docs in bmc-http
- add crate/module/API documentation across bmc-http
- simplify HttpBmc::set_credentials to update in place without Result
- clean up reqwest implementation and helper functions
- address clippy warnings in CAR cache implementation
- fix csdl-compiler with_entity_type typo and comment wording