### PR TITLE
nv-redfish: fix feature deps and cfg/Clone bounds

### DIFF
--- a/redfish/features.toml
+++ b/redfish/features.toml
@@ -118,7 +118,8 @@ patterns = [
 name = "network-device-functions"
 csdl_files = [
     "NetworkDeviceFunctionCollection_v1.xml",
-    "NetworkDeviceFunction_v1.xml"
+    "NetworkDeviceFunction_v1.xml",
+    "Protocol_v1.xml",
 ]
 patterns = [
     "NetworkDeviceFunctionCollection.*",

--- a/redfish/src/oem/dell/attributes.rs
+++ b/redfish/src/oem/dell/attributes.rs
@@ -15,17 +15,22 @@
 
 use crate::core::Bmc;
 use crate::core::EdmPrimitiveType;
-use crate::core::EntityTypeRef as _;
-use crate::core::NavProperty;
-use crate::core::ODataId;
 use crate::oem::dell::schema::dell_attributes::DellAttributes as DellAttributesSchema;
-use crate::Error;
-use crate::NvBmc;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
 #[cfg(feature = "managers")]
+use crate::core::EntityTypeRef as _;
+#[cfg(feature = "managers")]
+use crate::core::NavProperty;
+#[cfg(feature = "managers")]
+use crate::core::ODataId;
+#[cfg(feature = "managers")]
 use crate::schema::manager::Manager as ManagerSchema;
+#[cfg(feature = "managers")]
+use crate::Error;
+#[cfg(feature = "managers")]
+use crate::NvBmc;
 
 /// Dell OEM Attributes.
 pub struct DellAttributes<B: Bmc> {

--- a/redfish/src/service_root.rs
+++ b/redfish/src/service_root.rs
@@ -75,12 +75,22 @@ pub type RedfishVersion<'a> = TaggedType<&'a str, RedfishVersionTag>;
 pub enum RedfishVersionTag {}
 
 /// Represents `ServiceRoot` in the BMC model.
-#[derive(Clone)]
 pub struct ServiceRoot<B: Bmc> {
     /// Content of the root.
     pub root: Arc<SchemaServiceRoot>,
     #[allow(dead_code)] // feature-enabled field
     bmc: NvBmc<B>,
+}
+
+// Implement Clone manually to avoid requiring B: Clone; cloning only
+// needs Arc/NvBmc clones.
+impl<B: Bmc> Clone for ServiceRoot<B> {
+    fn clone(&self) -> Self {
+        Self {
+            root: self.root.clone(),
+            bmc: self.bmc.clone(),
+        }
+    }
 }
 
 impl<B: Bmc> ServiceRoot<B> {


### PR DESCRIPTION
- add Protocol_v1.xml to network-device-functions feature inputs
- cfg-gate Dell attributes imports used only with managers feature
- implement ServiceRoot<B> Clone manually to avoid requiring B: Clone