### PR TITLE
centralize Send/Sync bounds and drop client recursion_limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,6 @@ For smaller binaries and faster compilation, enable only the specific service/OE
 Minimal shape:
 
 ```rust
-// Recursion limit is need to be increased because Redfish has deep
-// tree of types reference to each other.
-#![recursion_limit = "256"]
-
 use nv_redfish::ServiceRoot;
 use nv_redfish_bmc_http::reqwest::Client;
 use nv_redfish_bmc_http::{BmcCredentials, CacheSettings, HttpBmc};

--- a/bmc-http/src/lib.rs
+++ b/bmc-http/src/lib.rs
@@ -122,7 +122,7 @@ pub trait HttpClient: Send + Sync {
         T: DeserializeOwned + Send + Sync;
 
     /// Open an SSE stream
-    fn sse<T: Sized + for<'a> Deserialize<'a> + Send + 'static>(
+    fn sse<T: Sized + for<'de> Deserialize<'de> + Send>(
         &self,
         url: Url,
         credentials: &BmcCredentials,
@@ -374,9 +374,7 @@ where
     /// - Handling 304 Not Modified responses from cache
     /// - Updating cache and `ETag` storage on success
     #[allow(clippy::significant_drop_tightening)]
-    async fn get_with_cache<
-        T: EntityTypeRef + Sized + for<'de> Deserialize<'de> + 'static + Send + Sync,
-    >(
+    async fn get_with_cache<T: EntityTypeRef + for<'de> Deserialize<'de> + 'static>(
         &self,
         endpoint_url: Url,
         id: &ODataId,
@@ -449,7 +447,7 @@ where
 {
     type Error = C::Error;
 
-    async fn get<T: EntityTypeRef + Sized + for<'de> Deserialize<'de> + 'static + Send + Sync>(
+    async fn get<T: EntityTypeRef + for<'de> Deserialize<'de> + 'static>(
         &self,
         id: &ODataId,
     ) -> Result<Arc<T>, Self::Error> {
@@ -457,7 +455,7 @@ where
         self.get_with_cache(endpoint_url, id).await
     }
 
-    async fn expand<T: Expandable + Send + Sync + 'static>(
+    async fn expand<T: Expandable + 'static>(
         &self,
         id: &ODataId,
         query: ExpandQuery,
@@ -514,10 +512,7 @@ where
             .await
     }
 
-    async fn action<
-        T: Sync + Send + Serialize,
-        R: Sync + Send + Sized + for<'de> Deserialize<'de>,
-    >(
+    async fn action<T: Send + Sync + Serialize, R: Send + Sync + for<'de> Deserialize<'de>>(
         &self,
         action: &Action<T, R>,
         params: &T,
@@ -534,7 +529,7 @@ where
             .await
     }
 
-    async fn filter<T: EntityTypeRef + Sized + for<'a> Deserialize<'a> + 'static + Send + Sync>(
+    async fn filter<T: EntityTypeRef + for<'de> Deserialize<'de> + 'static>(
         &self,
         id: &ODataId,
         query: FilterQuery,
@@ -546,7 +541,7 @@ where
         self.get_with_cache(endpoint_url, id).await
     }
 
-    async fn stream<T: Sized + for<'a> Deserialize<'a> + Send + 'static>(
+    async fn stream<T: Send + Sized + for<'de> Deserialize<'de>>(
         &self,
         uri: &str,
     ) -> Result<BoxTryStream<T, Self::Error>, Self::Error> {

--- a/bmc-http/src/reqwest.rs
+++ b/bmc-http/src/reqwest.rs
@@ -576,7 +576,7 @@ impl HttpClient for Client {
         self.handle_modification_response(response).await
     }
 
-    async fn sse<T: Sized + for<'a> serde::Deserialize<'a> + Send + 'static>(
+    async fn sse<T: Send + Sized + for<'de> serde::Deserialize<'de>>(
         &self,
         url: Url,
         credentials: &BmcCredentials,

--- a/bmc-mock/src/lib.rs
+++ b/bmc-mock/src/lib.rs
@@ -23,6 +23,7 @@ use nv_redfish_core::action::ActionTarget;
 use nv_redfish_core::query::ExpandQuery;
 use nv_redfish_core::ActionError;
 use nv_redfish_core::Bmc as NvRedfishBmc;
+use nv_redfish_core::EntityTypeRef;
 use nv_redfish_core::Expandable;
 use nv_redfish_core::ModificationResponse;
 use nv_redfish_core::ODataETag;
@@ -157,7 +158,7 @@ where
         }
     }
 
-    async fn get<T: nv_redfish_core::EntityTypeRef + Sized + for<'a> serde::Deserialize<'a>>(
+    async fn get<T: EntityTypeRef + for<'de> serde::Deserialize<'de>>(
         &self,
         in_id: &ODataId,
     ) -> Result<Arc<T>, Self::Error> {
@@ -182,7 +183,7 @@ where
 
     async fn update<
         V: Sync + Send + Serialize,
-        R: Sync + Send + Sized + for<'a> serde::Deserialize<'a>,
+        R: Sync + Send + Sized + for<'de> serde::Deserialize<'de>,
     >(
         &self,
         in_id: &ODataId,
@@ -215,7 +216,7 @@ where
 
     async fn create<
         V: Sync + Send + Serialize,
-        R: Sync + Send + Sized + for<'a> serde::Deserialize<'a>,
+        R: Sync + Send + Sized + for<'de> serde::Deserialize<'de>,
     >(
         &self,
         in_id: &ODataId,
@@ -245,9 +246,7 @@ where
         }
     }
 
-    async fn delete<
-        R: nv_redfish_core::EntityTypeRef + Sync + Send + for<'de> serde::Deserialize<'de>,
-    >(
+    async fn delete<R: EntityTypeRef + for<'de> serde::Deserialize<'de>>(
         &self,
         in_id: &ODataId,
     ) -> Result<ModificationResponse<R>, Self::Error> {
@@ -268,7 +267,7 @@ where
 
     async fn action<
         T: Send + Sync + serde::Serialize,
-        R: Send + Sync + Sized + for<'a> serde::Deserialize<'a>,
+        R: Send + Sync + Sized + for<'de> serde::Deserialize<'de>,
     >(
         &self,
         action: &nv_redfish_core::Action<T, R>,
@@ -298,14 +297,7 @@ where
         }
     }
 
-    async fn filter<
-        T: nv_redfish_core::EntityTypeRef
-            + Sized
-            + for<'a> serde::Deserialize<'a>
-            + 'static
-            + Send
-            + Sync,
-    >(
+    async fn filter<T: EntityTypeRef + for<'de> serde::Deserialize<'de>>(
         &self,
         _id: &ODataId,
         _query: nv_redfish_core::FilterQuery,
@@ -313,7 +305,7 @@ where
         todo!("unimplemented")
     }
 
-    async fn stream<T: Sized + for<'a> serde::Deserialize<'a> + Send + 'static>(
+    async fn stream<T: Sized + for<'de> serde::Deserialize<'de> + Send + 'static>(
         &self,
         in_uri: &str,
     ) -> Result<nv_redfish_core::BoxTryStream<T, Self::Error>, Self::Error> {

--- a/core/src/action.rs
+++ b/core/src/action.rs
@@ -101,7 +101,7 @@ pub trait ActionError {
     fn not_supported() -> Self;
 }
 
-impl<T: Send + Sync + Serialize, R: Send + Sync + Sized + for<'a> Deserialize<'a>> Action<T, R> {
+impl<T: Send + Sync + Serialize, R: Send + Sync + Sized + for<'de> Deserialize<'de>> Action<T, R> {
     /// Run specific action with parameters passed as argument.
     ///
     /// # Errors

--- a/core/src/bmc.rs
+++ b/core/src/bmc.rs
@@ -74,7 +74,7 @@ pub trait Bmc: Send + Sync {
     /// Expand any expandable object (navigation property or entity).
     ///
     /// `T` is structure that is used for return type.
-    fn expand<T: Expandable + Send + Sync + 'static>(
+    fn expand<T: Expandable>(
         &self,
         id: &ODataId,
         query: ExpandQuery,
@@ -83,7 +83,7 @@ pub trait Bmc: Send + Sync {
     /// Get data of the object (navigation property or entity).
     ///
     /// `T` is structure that is used for return type.
-    fn get<T: EntityTypeRef + Sized + for<'a> Deserialize<'a> + 'static + Send + Sync>(
+    fn get<T: EntityTypeRef + for<'de> Deserialize<'de> + 'static>(
         &self,
         id: &ODataId,
     ) -> impl Future<Output = Result<Arc<T>, Self::Error>> + Send;
@@ -91,7 +91,7 @@ pub trait Bmc: Send + Sync {
     /// Get and filters data of the object (navigation property or entity).
     ///
     /// `T` is structure that is used for return type.
-    fn filter<T: EntityTypeRef + Sized + for<'a> Deserialize<'a> + 'static + Send + Sync>(
+    fn filter<T: EntityTypeRef + for<'de> Deserialize<'de> + 'static>(
         &self,
         id: &ODataId,
         query: FilterQuery,
@@ -101,7 +101,7 @@ pub trait Bmc: Send + Sync {
     ///
     /// `V` is structure that is used for create.
     /// `R` is structure that is used for return type.
-    fn create<V: Sync + Send + Serialize, R: Send + Sync + Sized + for<'a> Deserialize<'a>>(
+    fn create<V: Send + Sync + Serialize, R: Send + Sync + for<'de> Deserialize<'de>>(
         &self,
         id: &ODataId,
         query: &V,
@@ -111,7 +111,7 @@ pub trait Bmc: Send + Sync {
     ///
     /// `V` is structure that is used for update.
     /// `R` is structure that is used for return type (updated entity).
-    fn update<V: Sync + Send + Serialize, R: Send + Sync + Sized + for<'a> Deserialize<'a>>(
+    fn update<V: Sync + Send + Serialize, R: Send + Sync + Sized + for<'de> Deserialize<'de>>(
         &self,
         id: &ODataId,
         etag: Option<&ODataETag>,
@@ -119,7 +119,7 @@ pub trait Bmc: Send + Sync {
     ) -> impl Future<Output = Result<ModificationResponse<R>, Self::Error>> + Send;
 
     /// Delete entity.
-    fn delete<R: EntityTypeRef + Sync + Send + for<'de> Deserialize<'de>>(
+    fn delete<R: EntityTypeRef + for<'de> Deserialize<'de>>(
         &self,
         id: &ODataId,
     ) -> impl Future<Output = Result<ModificationResponse<R>, Self::Error>> + Send;
@@ -128,7 +128,7 @@ pub trait Bmc: Send + Sync {
     ///
     /// `T` is structure that contains action parameters.
     /// `R` is structure with return type.
-    fn action<T: Send + Sync + Serialize, R: Send + Sync + Sized + for<'a> Deserialize<'a>>(
+    fn action<T: Send + Sync + Serialize, R: Send + Sync + Sized + for<'de> Deserialize<'de>>(
         &self,
         action: &Action<T, R>,
         params: &T,
@@ -137,7 +137,7 @@ pub trait Bmc: Send + Sync {
     /// Stream data for the URI.
     ///
     /// `T` is structure that is used for the stream return type.
-    fn stream<T: Sized + for<'a> Deserialize<'a> + Send + 'static>(
+    fn stream<T: Sized + for<'de> Deserialize<'de> + Send + 'static>(
         &self,
         uri: &str,
     ) -> impl Future<Output = Result<BoxTryStream<T, Self::Error>, Self::Error>> + Send;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -129,9 +129,9 @@ pub use serde_json::Value as AdditionalProperties;
 pub use uuid::Uuid as EdmGuid;
 
 /// Entity type reference trait implemented by the CSDL compiler
-/// for all generated entity types and for all `NavProperty<T>` where
+/// for all generated entity types and for all [`NavProperty<T>`] where
 /// `T` is a struct for an entity type.
-pub trait EntityTypeRef {
+pub trait EntityTypeRef: Send + Sync + Sized {
     /// Value of `@odata.id` field of the Entity.
     fn odata_id(&self) -> &ODataId;
 
@@ -141,16 +141,14 @@ pub trait EntityTypeRef {
     /// Refresh the entity by fetching it again from the BMC.
     fn refresh<B: Bmc>(&self, bmc: &B) -> impl Future<Output = Result<Arc<Self>, B::Error>> + Send
     where
-        Self: Sync + Send + 'static + Sized + for<'de> Deserialize<'de>,
+        Self: for<'de> Deserialize<'de> + 'static,
     {
         bmc.get::<Self>(self.odata_id())
     }
 }
 
 /// Defines entity types that support `$expand` via query parameters.
-pub trait Expandable:
-    EntityTypeRef + Send + Sync + Sized + 'static + for<'a> Deserialize<'a>
-{
+pub trait Expandable: EntityTypeRef + for<'de> Deserialize<'de> + 'static {
     /// Expand the entity according to the provided query.
     fn expand<B: Bmc>(
         &self,
@@ -187,8 +185,8 @@ pub enum ModificationResponse<T> {
 
 /// This trait is assigned to the collections that are marked as
 /// creatable in the CSDL specification.
-pub trait Creatable<V: Sync + Send + Serialize, R: Sync + Send + Sized + for<'de> Deserialize<'de>>:
-    EntityTypeRef + Sized
+pub trait Creatable<V: Send + Sync + Serialize, R: Send + Sync + for<'de> Deserialize<'de>>:
+    EntityTypeRef
 {
     /// Create an entity using `create` as payload.
     fn create<B: Bmc>(
@@ -202,10 +200,7 @@ pub trait Creatable<V: Sync + Send + Serialize, R: Sync + Send + Sized + for<'de
 
 /// This trait is assigned to entity types that are marked as
 /// updatable in the CSDL specification.
-pub trait Updatable<V: Sync + Send + Serialize>: EntityTypeRef + Sized
-where
-    Self: Sync + Send + Sized + for<'de> Deserialize<'de>,
-{
+pub trait Updatable<V: Sync + Send + Serialize>: EntityTypeRef + for<'de> Deserialize<'de> {
     /// Update an entity using `update` as payload.
     fn update<B: Bmc>(
         &self,
@@ -218,7 +213,7 @@ where
 
 /// This trait is assigned to entity types that are marked as
 /// deletable in the CSDL specification.
-pub trait Deletable: EntityTypeRef + Sized + Sync + Send + for<'de> Deserialize<'de> {
+pub trait Deletable: EntityTypeRef + for<'de> Deserialize<'de> {
     /// Delete current entity.
     fn delete<B: Bmc>(
         &self,

--- a/core/src/nav_property.rs
+++ b/core/src/nav_property.rs
@@ -122,7 +122,7 @@ pub enum NavProperty<T: EntityTypeRef> {
 
 impl<'de, T> Deserialize<'de> for NavProperty<T>
 where
-    T: EntityTypeRef + for<'a> Deserialize<'a>,
+    T: EntityTypeRef + for<'dt> Deserialize<'dt>,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -164,8 +164,8 @@ impl<T: EntityTypeRef> EntityTypeRef for NavProperty<T> {
 
 impl<C, R, T: Creatable<C, R>> Creatable<C, R> for NavProperty<T>
 where
-    C: Sync + Send + Sized + Serialize,
-    R: Sync + Send + Sized + for<'de> Deserialize<'de>,
+    C: Send + Sync + Serialize,
+    R: Send + Sync + for<'de> Deserialize<'de>,
 {
 }
 impl<U, T: Updatable<U>> Updatable<U> for NavProperty<T> where U: Sync + Send + Sized + Serialize {}
@@ -207,7 +207,7 @@ impl<T: EntityTypeRef> NavProperty<T> {
     }
 }
 
-impl<T: EntityTypeRef + Sized + for<'a> Deserialize<'a> + 'static + Send + Sync> NavProperty<T> {
+impl<T: EntityTypeRef + for<'de> Deserialize<'de> + 'static> NavProperty<T> {
     /// Get the property value.
     ///
     /// # Errors

--- a/csdl-compiler/src/generator/rust/struct_def.rs
+++ b/csdl-compiler/src/generator/rust/struct_def.rs
@@ -172,11 +172,27 @@ impl<'a> StructDef<'a> {
         content.extend(all_properties);
 
         let name = self.name;
+        // Note: Manual implementation of Send and Sync is needed to
+        // help compiler. It goes through all properties deeper and
+        // deepr in the Redfish tree until it hits the recursion
+        // limit. Increasing recursion limit to 256 helps with the
+        // regular Redfish tree but it should be done client code on
+        // top level of module and this is sucks. We guarantee that
+        // all types inside tree are primitive (Strings, integers
+        // DateTimes) or entity reference wich can contain Arc but
+        // still they are Send and Sync.
+        //
+        // So, we create shortcut for compiler and state that we
+        // guarantee Send and Sync here and below.
         tokens.extend([
             doc_format_and_generate(self.name, &self.odata),
             quote! {
                 #[derive(Deserialize, Debug)]
                 pub struct #name { #content }
+                #[doc = "SAFETY: All generated data types are Send"]
+                unsafe impl Send for #name {}
+                #[doc = "SAFETY: All generated data types are Sync"]
+                unsafe impl Sync for #name {}
             },
         ]);
 

--- a/examples/event-stream-console/src/main.rs
+++ b/examples/event-stream-console/src/main.rs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![recursion_limit = "256"]
-
 use clap::Parser;
 use futures_util::TryStreamExt;
 use nv_redfish::bmc_http::reqwest::{Client, ClientParams};

--- a/examples/explore-with-dummy-bmc/src/main.rs
+++ b/examples/explore-with-dummy-bmc/src/main.rs
@@ -495,7 +495,7 @@ impl Bmc for MockBmc {
         todo!("unimplimented")
     }
 
-    async fn filter<T: EntityTypeRef + Sized + for<'a> Deserialize<'a> + 'static + Send + Sync>(
+    async fn filter<T: EntityTypeRef + for<'de> Deserialize<'de>>(
         &self,
         _id: &ODataId,
         _query: nv_redfish_core::FilterQuery,
@@ -503,7 +503,7 @@ impl Bmc for MockBmc {
         todo!("unimplimented")
     }
 
-    async fn get<T: EntityTypeRef + Sized + for<'a> Deserialize<'a>>(
+    async fn get<T: EntityTypeRef + for<'de> Deserialize<'de>>(
         &self,
         id: &ODataId,
     ) -> Result<Arc<T>, Self::Error> {
@@ -516,7 +516,7 @@ impl Bmc for MockBmc {
 
     async fn update<
         V: Sync + Send + Serialize,
-        R: Sync + Send + Sized + for<'a> Deserialize<'a>,
+        R: Sync + Send + Sized + for<'de> Deserialize<'de>,
     >(
         &self,
         id: &ODataId,
@@ -535,7 +535,7 @@ impl Bmc for MockBmc {
 
     async fn create<
         V: Sync + Send + Serialize,
-        R: Sync + Send + Sized + for<'a> Deserialize<'a>,
+        R: Sync + Send + Sized + for<'de> Deserialize<'de>,
     >(
         &self,
         id: &ODataId,
@@ -551,7 +551,7 @@ impl Bmc for MockBmc {
         Ok(ModificationResponse::Entity(result))
     }
 
-    async fn delete<R: EntityTypeRef + Sync + Send + for<'de> Deserialize<'de>>(
+    async fn delete<R: EntityTypeRef + for<'de> Deserialize<'de>>(
         &self,
         _id: &ODataId,
     ) -> Result<ModificationResponse<R>, Self::Error> {
@@ -560,22 +560,17 @@ impl Bmc for MockBmc {
 
     async fn action<
         T: Send + Sync + serde::Serialize,
-        R: Send + Sync + Sized + for<'a> Deserialize<'a>,
+        R: Send + Sync + Sized + for<'de> Deserialize<'de>,
     >(
         &self,
         _action: &Action<T, R>,
         _params: &T,
     ) -> Result<ModificationResponse<R>, Self::Error> {
-        //println!(
-        //    "BMC Action {}: {}",
-        //    action.target,
-        //    serde_json::to_string(params).expect("serializable")
-        //);
         let result: R = serde_json::from_str("null").map_err(Error::ParseError)?;
         Ok(ModificationResponse::Entity(result))
     }
 
-    async fn stream<T: Sized + for<'a> Deserialize<'a> + Send + 'static>(
+    async fn stream<T: Send + Sized + for<'de> Deserialize<'de> + 'static>(
         &self,
         _id: &str,
     ) -> Result<nv_redfish_core::BoxTryStream<T, Self::Error>, Self::Error> {

--- a/examples/readme-minimal/src/main.rs
+++ b/examples/readme-minimal/src/main.rs
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Recursion limit is need to be increased because Redfish has deep
-// tree of types reference to each other.
-#![recursion_limit = "256"]
-
 use nv_redfish::ServiceRoot;
 use nv_redfish_bmc_http::reqwest::Client;
 use nv_redfish_bmc_http::{BmcCredentials, CacheSettings, HttpBmc};

--- a/redfish/src/entity_link.rs
+++ b/redfish/src/entity_link.rs
@@ -81,7 +81,7 @@ impl<B: Bmc, T: EntityTypeRef> EntityLink<B, T> {
 impl<B, T> EntityLink<B, T>
 where
     B: Bmc,
-    T: EntityTypeRef + for<'de> Deserialize<'de> + Send + Sync + 'static,
+    T: EntityTypeRef + for<'de> Deserialize<'de> + 'static,
 {
     /// Fetch the entity from the BMC.
     ///
@@ -138,7 +138,7 @@ where
 /// `NavProperty<T>` to be constructed (i.e., no extra context).
 pub trait FromLink<B: Bmc>: Sized {
     /// The schema type this wrapper is built from.
-    type Schema: EntityTypeRef + for<'de> Deserialize<'de> + Send + Sync + 'static;
+    type Schema: EntityTypeRef + for<'de> Deserialize<'de>;
 
     /// Construct the full wrapper by fetching entity data.
     fn from_link(

--- a/redfish/src/lib.rs
+++ b/redfish/src/lib.rs
@@ -43,6 +43,8 @@
 //! - Additional services and OEM extensions continue to be added over time.
 //!
 
+// Recursion limit still needed in this crate because otherwise doc
+// generation failed...
 #![recursion_limit = "256"]
 #![deny(
     clippy::all,

--- a/redfish/src/patch_support/collection.rs
+++ b/redfish/src/patch_support/collection.rs
@@ -46,8 +46,8 @@ use serde::Serialize;
 /// Example of usage is in `AccountCollection` implementation.
 pub trait CollectionWithPatch<T, M, B>
 where
-    T: EntityTypeRef + Expandable + Send + Sync + 'static,
-    M: EntityTypeRef + Send + Sync + for<'de> Deserialize<'de>,
+    T: Expandable + 'static,
+    M: EntityTypeRef + for<'de> Deserialize<'de>,
     B: Bmc,
 {
     fn convert_patched(base: ResourceCollection, members: Vec<NavProperty<M>>) -> T;
@@ -81,7 +81,7 @@ where
 #[cfg(feature = "patch-collection-create")]
 pub trait CreateWithPatch<T, M, C, B>
 where
-    T: EntityTypeRef + Creatable<C, M> + Sync + Send,
+    T: Creatable<C, M>,
     C: Serialize + Sync + Send,
     M: for<'de> Deserialize<'de> + Sync + Send,
     B: Bmc,
@@ -125,7 +125,7 @@ impl Collection {
         f: F,
     ) -> Result<ModificationResponse<V>, Error<B>>
     where
-        T: EntityTypeRef + Sync + Send,
+        T: EntityTypeRef,
         V: for<'de> Deserialize<'de>,
         B: Bmc,
         C: Serialize + Sync + Send,

--- a/redfish/src/patch_support/payload.rs
+++ b/redfish/src/patch_support/payload.rs
@@ -47,7 +47,7 @@ use serde::Serialize;
 pub trait UpdateWithPatch<T, V, B>
 where
     V: Serialize + Send + Sync,
-    T: EntityTypeRef + Updatable<V> + Sync + Send,
+    T: Updatable<V>,
     B: Bmc,
 {
     fn entity_ref(&self) -> &T;
@@ -88,7 +88,7 @@ impl Payload {
         f: F,
     ) -> Result<Arc<T>, Error<B>>
     where
-        T: EntityTypeRef + for<'a> Deserialize<'a> + Send + Sync + 'static,
+        T: EntityTypeRef + for<'de> Deserialize<'de> + 'static,
         B: Bmc,
         F: FnOnce(JsonValue) -> JsonValue,
     {
@@ -200,7 +200,7 @@ impl Updator<'_> {
     ) -> Result<ModificationResponse<T>, Error<B>>
     where
         B: Bmc,
-        T: EntityTypeRef + for<'de> Deserialize<'de> + Sync + Send,
+        T: EntityTypeRef + for<'de> Deserialize<'de>,
         U: Serialize + Send + Sync,
         F: Fn(JsonValue) -> JsonValue + Sync + Send,
     {

--- a/tests/tests/test-assembly-wiwynn-missing-odata-type.rs
+++ b/tests/tests/test-assembly-wiwynn-missing-odata-type.rs
@@ -14,8 +14,6 @@
 // limitations under the License.
 //! Integration tests for WIWYNN assembly payloads missing `@odata.type`.
 
-#![recursion_limit = "256"]
-
 use nv_redfish::chassis::Chassis;
 use nv_redfish::hardware_id::Model;
 use nv_redfish::hardware_id::PartNumber;

--- a/tests/tests/test-bios.rs
+++ b/tests/tests/test-bios.rs
@@ -14,8 +14,6 @@
 // limitations under the License.
 //! Integration tests of BIOS support.
 
-#![recursion_limit = "256"]
-
 use nv_redfish::computer_system::Bios;
 use nv_redfish::computer_system::ComputerSystem;
 use nv_redfish::ServiceRoot;

--- a/tests/tests/test-chassis-oem-liteon-power-supply.rs
+++ b/tests/tests/test-chassis-oem-liteon-power-supply.rs
@@ -14,8 +14,6 @@
 // limitations under the License.
 //! Integration tests for LiteOn OEM power supply links via chassis.
 
-#![recursion_limit = "256"]
-
 use nv_redfish::chassis::Chassis;
 use nv_redfish::ServiceRoot;
 use nv_redfish_core::ODataId;

--- a/tests/tests/test-chassis-oem-nvidia-baseboard.rs
+++ b/tests/tests/test-chassis-oem-nvidia-baseboard.rs
@@ -14,8 +14,6 @@
 // limitations under the License.
 //! Integration tests for NVIDIA Baseboard CBC chassis OEM extension.
 
-#![recursion_limit = "256"]
-
 use nv_redfish::chassis::Chassis;
 use nv_redfish::ServiceRoot;
 use nv_redfish_core::ODataId;

--- a/tests/tests/test-chassis.rs
+++ b/tests/tests/test-chassis.rs
@@ -14,8 +14,6 @@
 // limitations under the License.
 //! Integration tests for Chassis collection workaround behavior.
 
-#![recursion_limit = "256"]
-
 use nv_redfish::ServiceRoot;
 use nv_redfish_core::ODataId;
 use nv_redfish_tests::ami_viking_service_root;

--- a/tests/tests/test-computer-system-oem-lenovo.rs
+++ b/tests/tests/test-computer-system-oem-lenovo.rs
@@ -14,8 +14,6 @@
 // limitations under the License.
 //! Integration tests for Lenovo ComputerSystem OEM support.
 
-#![recursion_limit = "256"]
-
 use nv_redfish::computer_system::ComputerSystem;
 use nv_redfish::oem::lenovo::computer_system::FpMode;
 use nv_redfish::oem::lenovo::computer_system::PortSwitchingTo;

--- a/tests/tests/test-computer-system-oem-nvidia-bluefield.rs
+++ b/tests/tests/test-computer-system-oem-nvidia-bluefield.rs
@@ -14,8 +14,6 @@
 // limitations under the License.
 //! Integration tests for NVIDIA Bluefield ComputerSystem OEM support.
 
-#![recursion_limit = "256"]
-
 use nv_redfish::computer_system::ComputerSystem;
 use nv_redfish::oem::nvidia::bluefield::nvidia_computer_system::Mode;
 use nv_redfish::ServiceRoot;

--- a/tests/tests/test-computer-system.rs
+++ b/tests/tests/test-computer-system.rs
@@ -14,8 +14,6 @@
 // limitations under the License.
 //! Integration tests for Computer System resources.
 
-#![recursion_limit = "256"]
-
 use nv_redfish::computer_system::SystemCollection;
 use nv_redfish::Resource;
 use nv_redfish::ServiceRoot;

--- a/tests/tests/test-manager-oem-ami.rs
+++ b/tests/tests/test-manager-oem-ami.rs
@@ -14,8 +14,6 @@
 // limitations under the License.
 //! Integration tests for AMI Manager OEM ConfigBMC support.
 
-#![recursion_limit = "256"]
-
 use nv_redfish::manager::Manager;
 use nv_redfish::oem::ami::config_bmc::LockdownBiosSettingsChangeState;
 use nv_redfish::oem::ami::config_bmc::LockdownBiosUpgradeDowngradeState;

--- a/tests/tests/test-manager-oem-dell-attributes.rs
+++ b/tests/tests/test-manager-oem-dell-attributes.rs
@@ -14,8 +14,6 @@
 // limitations under the License.
 //! Integration tests for Manager DellAttributes OEM extension.
 
-#![recursion_limit = "256"]
-
 use nv_redfish::manager::Manager;
 use nv_redfish::ServiceRoot;
 use nv_redfish_core::ODataId;

--- a/tests/tests/test-manager-oem-hpe.rs
+++ b/tests/tests/test-manager-oem-hpe.rs
@@ -14,8 +14,6 @@
 // limitations under the License.
 //! Integration tests for HPE Manager OEM support.
 
-#![recursion_limit = "256"]
-
 use nv_redfish::manager::Manager;
 use nv_redfish::ServiceRoot;
 use nv_redfish_core::ODataId;

--- a/tests/tests/test-manager-oem-lenovo.rs
+++ b/tests/tests/test-manager-oem-lenovo.rs
@@ -14,8 +14,6 @@
 // limitations under the License.
 //! Integration tests for Lenovo Manager OEM support.
 
-#![recursion_limit = "256"]
-
 use nv_redfish::manager::Manager;
 use nv_redfish::oem::lenovo::manager::KcsState;
 use nv_redfish::oem::lenovo::security_service::FwRollbackState;

--- a/tests/tests/test-manager-oem-supermicro.rs
+++ b/tests/tests/test-manager-oem-supermicro.rs
@@ -14,8 +14,6 @@
 // limitations under the License.
 //! Integration tests for Supermicro Manager OEM support.
 
-#![recursion_limit = "256"]
-
 use nv_redfish::manager::Manager;
 use nv_redfish::oem::supermicro::Privilege;
 use nv_redfish::ServiceRoot;

--- a/tests/tests/test-manager.rs
+++ b/tests/tests/test-manager.rs
@@ -14,8 +14,6 @@
 // limitations under the License.
 //! Integration tests for Manager collection behavior.
 
-#![recursion_limit = "256"]
-
 use nv_redfish::Resource;
 use nv_redfish::ServiceRoot;
 use nv_redfish_core::ODataId;

--- a/tests/tests/test-service-root-oem-hpe.rs
+++ b/tests/tests/test-service-root-oem-hpe.rs
@@ -14,8 +14,6 @@
 // limitations under the License.
 //! Integration tests for HPE ServiceRoot OEM extension support.
 
-#![recursion_limit = "256"]
-
 use nv_redfish::oem::hpe::ilo_service_ext::ManagerType;
 use nv_redfish::ServiceRoot;
 use nv_redfish_core::ODataId;

--- a/tests/tests/test-session-service.rs
+++ b/tests/tests/test-session-service.rs
@@ -15,8 +15,6 @@
 
 //! Integration tests of Session Service.
 
-#![recursion_limit = "256"]
-
 use nv_redfish::session_service::SessionCollection;
 use nv_redfish::session_service::SessionCreate;
 use nv_redfish::session_service::SessionService;

--- a/tests/tests/test-update-service.rs
+++ b/tests/tests/test-update-service.rs
@@ -15,8 +15,6 @@
 
 //! Integration tests of Update Service.
 
-#![recursion_limit = "256"]
-
 use nv_redfish::update_service::UpdateService;
 use nv_redfish::ServiceRoot;
 use nv_redfish_core::EntityTypeRef;

--- a/tests/tests/tests-account-service.rs
+++ b/tests/tests/tests-account-service.rs
@@ -15,8 +15,6 @@
 
 //! Integration tests of Account Service.
 
-#![recursion_limit = "256"]
-
 use nv_redfish::account::AccountCollection;
 use nv_redfish::account::AccountService;
 use nv_redfish::account::AccountTypes;

--- a/tests/tests/tests-base-operations.rs
+++ b/tests/tests/tests-base-operations.rs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![recursion_limit = "256"]
-
 use nv_redfish_core::Creatable;
 use nv_redfish_core::EntityTypeRef;
 use nv_redfish_core::ModificationResponse;


### PR DESCRIPTION
- make `EntityTypeRef` require `Send + Sync + Sized`
- simplify redundant trait bounds across core, bmc-http, bmc-mock, redfish, examples
- align `Expandable`, `Creatable`, `Updatable`, and `Deletable` with the new base bounds
- update generated structs to provide `Send`/`Sync` explicitly to avoid deep trait recursion
- remove unnecessary `#![recursion_limit = "256"]` from README examples, examples, and tests
- keep recursion limit only where still needed in `redfish` crate for doc generation