### PR TITLE
fix: properly handle empty-string UUIDs for Bluefields

### DIFF
--- a/redfish/src/bmc_quirks.rs
+++ b/redfish/src/bmc_quirks.rs
@@ -126,6 +126,13 @@ impl BmcQuirks {
         self.platform == Some(Platform::AmiViking)
     }
 
+    /// Some NVIDIA chassis payloads return `UUID` as an empty string
+    /// instead of `null` or omitting the field.
+    #[cfg(feature = "chassis")]
+    pub(crate) fn bug_empty_chassis_uuid_field(&self) -> bool {
+        self.platform == Some(Platform::Nvidia)
+    }
+
     /// Missing Name property in Chassis resource. This property is
     /// required in any resource.
     #[cfg(feature = "update-service")]

--- a/redfish/src/chassis/item.rs
+++ b/redfish/src/chassis/item.rs
@@ -93,6 +93,9 @@ impl Config {
         if quirks.bug_missing_chassis_name_field() {
             patches.push(add_default_chassis_name);
         }
+        if quirks.bug_empty_chassis_uuid_field() {
+            patches.push(normalize_empty_uuid_field);
+        }
         let read_patch_fn = (!patches.is_empty())
             .then(|| Arc::new(move |v| patches.iter().fold(v, |acc, f| f(acc))) as ReadPatchFn);
         Self { read_patch_fn }
@@ -438,4 +441,16 @@ fn add_default_chassis_name(v: JsonValue) -> JsonValue {
     } else {
         v
     }
+}
+
+fn normalize_empty_uuid_field(mut v: JsonValue) -> JsonValue {
+    if let JsonValue::Object(ref mut obj) = v {
+        if let Some(uuid) = obj.get_mut("UUID") {
+            let is_empty = uuid.as_str().is_some_and(str::is_empty);
+            if is_empty {
+                *uuid = JsonValue::Null;
+            }
+        }
+    }
+    v
 }

--- a/tests/tests/test-chassis.rs
+++ b/tests/tests/test-chassis.rs
@@ -187,6 +187,98 @@ async fn anonymous_1_9_0_wrong_chassis_status_state_workaround() -> Result<(), B
 }
 
 #[test]
+async fn nvidia_empty_chassis_uuid_in_expanded_members_workaround() -> Result<(), Box<dyn StdError>>
+{
+    // Platform under test: NVIDIA chassis platforms (for example, BlueField).
+    // Quirk under test: Chassis.UUID="" in inline collection members.
+    let bmc = Arc::new(Bmc::default());
+    let ids = ids();
+    let root = expect_nvidia_service_root(
+        bmc.clone(),
+        &ids,
+        json!({
+            "Chassis": { ODATA_ID: &ids.chassis_collection_id }
+        }),
+    )
+    .await?;
+    bmc.expect(Expect::expand(
+        &ids.chassis_collection_id,
+        json!({
+            ODATA_ID: &ids.chassis_collection_id,
+            ODATA_TYPE: CHASSIS_COLLECTION_DATA_TYPE,
+            "Id": "Chassis",
+            "Name": "Chassis Collection",
+            "Members": [
+                {
+                    ODATA_ID: &ids.chassis_id,
+                    ODATA_TYPE: CHASSIS_DATA_TYPE,
+                    "Id": "1",
+                    "Name": "Chassis",
+                    "ChassisType": "RackMount",
+                    "UUID": ""
+                }
+            ]
+        }),
+    ));
+
+    let collection = root.chassis().await?.unwrap();
+    let members = collection.members().await?;
+    assert_eq!(members.len(), 1);
+    assert_eq!(members[0].raw().uuid, Some(None));
+
+    Ok(())
+}
+
+#[test]
+async fn nvidia_empty_chassis_uuid_on_member_fetch_workaround() -> Result<(), Box<dyn StdError>> {
+    // Platform under test: NVIDIA chassis platforms (for example, BlueField).
+    // Quirk under test: Chassis.UUID="" in member payload fetched by link.
+    let bmc = Arc::new(Bmc::default());
+    let ids = ids();
+    let root = expect_nvidia_service_root(
+        bmc.clone(),
+        &ids,
+        json!({
+            "Chassis": { ODATA_ID: &ids.chassis_collection_id }
+        }),
+    )
+    .await?;
+    bmc.expect(Expect::expand(
+        &ids.chassis_collection_id,
+        json!({
+            ODATA_ID: &ids.chassis_collection_id,
+            ODATA_TYPE: CHASSIS_COLLECTION_DATA_TYPE,
+            "Id": "Chassis",
+            "Name": "Chassis Collection",
+            "Members": [
+                {
+                    ODATA_ID: &ids.chassis_id
+                }
+            ]
+        }),
+    ));
+
+    let collection = root.chassis().await?.unwrap();
+    expect_chassis_get(
+        bmc.clone(),
+        &ids,
+        json!({
+            ODATA_ID: &ids.chassis_id,
+            ODATA_TYPE: CHASSIS_DATA_TYPE,
+            "Id": "1",
+            "Name": "Chassis",
+            "ChassisType": "RackMount",
+            "UUID": ""
+        }),
+    );
+    let members = collection.members().await?;
+    assert_eq!(members.len(), 1);
+    assert_eq!(members[0].raw().uuid, Some(None));
+
+    Ok(())
+}
+
+#[test]
 async fn nvswitch_wrong_location_part_location_type_workaround() -> Result<(), Box<dyn StdError>> {
     // Platform under test: NVSwitch (`Vendor=NVIDIA`, `Product=P3809`).
     // Quirk under test: invalid Location.PartLocation.LocationType="Unknown".
@@ -258,6 +350,37 @@ async fn expect_anonymous_1_9_service_root(
     bmc.expect(Expect::get(
         &ids.root_id,
         anonymous_1_9_service_root(&ids.root_id, fields),
+    ));
+    ServiceRoot::new(bmc).await.map_err(Into::into)
+}
+
+async fn expect_nvidia_service_root(
+    bmc: Arc<Bmc>,
+    ids: &Ids,
+    fields: Value,
+) -> Result<ServiceRoot<Bmc>, Box<dyn StdError>> {
+    bmc.expect(Expect::get(
+        &ids.root_id,
+        json_merge([
+            &json!({
+                ODATA_ID: &ids.root_id,
+                ODATA_TYPE: "#ServiceRoot.v1_13_0.ServiceRoot",
+                "Id": "RootService",
+                "Name": "RootService",
+                "Vendor": "NVIDIA",
+                "ProtocolFeaturesSupported": {
+                    "ExpandQuery": {
+                        "NoLinks": true
+                    }
+                },
+                "Links": {
+                    "Sessions": {
+                        ODATA_ID: format!("{}/SessionService/Sessions", ids.root_id),
+                    }
+                },
+            }),
+            &fields,
+        ]),
     ));
     ServiceRoot::new(bmc).await.map_err(Into::into)
 }


### PR DESCRIPTION
Some Bluefields report an empty-string UUID field in its Chassis object which breaks deserialization. This PR adds a bmc-quirk to convert an empty string into a null value for this scenario and corresponding unit tests.

Malformed Chassis response:
```
{
    "@odata.id": "/redfish/v1/Chassis/Card1",
    "@odata.type": "#Chassis.v1_21_0.Chassis",
    .
    .
    "Manufacturer": "Nvidia",
    "Model": "Bluefield 3 SmartNIC Main Card",
    "Name": "Card1",
    "NetworkAdapters": {
        "@odata.id": "/redfish/v1/Chassis/Card1/NetworkAdapters"
    },
    "PCIeDevices": {
        "@odata.id": "/redfish/v1/Chassis/Card1/PCIeDevices"
    },
    "PCIeSlots": {
        "@odata.id": "/redfish/v1/Chassis/Card1/PCIeSlots"
    },
    "PartNumber": "900-9D3B4-00EN-EA0",
   .
   .
    "UUID": ""
}
```

Deserialization Error:
```
{
    "Type": "RedfishError",
    "Details": "context: chassis collection; json error: UUID parsing failed: invalid length: expected length 32 for simple format, found 0",
    "ResponseBody": null,
    "ResponseCode": null
}
```