### PR TITLE
nv-redfish: handle empty UUIDs for DPU systems

### DIFF
--- a/redfish/src/bmc_quirks.rs
+++ b/redfish/src/bmc_quirks.rs
@@ -33,6 +33,7 @@ enum Platform {
     Dell,
     AmiViking,
     Nvidia,
+    NvidiaDpu,
     Anonymous1_9_0,
     NvSwitch,
 }
@@ -48,6 +49,7 @@ impl BmcQuirks {
             Some("AMI") if redfish_version_str == Some("1.11.0") => Some(Platform::AmiViking),
             Some("NVIDIA") if product_str == Some("P3809") => Some(Platform::NvSwitch),
             Some("NVIDIA") => Some(Platform::Nvidia),
+            Some("Nvidia") if product_str == Some("Nvidia-BMCMezz") => Some(Platform::NvidiaDpu),
             None if redfish_version_str == Some("1.9.0") => Some(Platform::Anonymous1_9_0),
             _ => None,
         };
@@ -126,11 +128,11 @@ impl BmcQuirks {
         self.platform == Some(Platform::AmiViking)
     }
 
-    /// Some NVIDIA chassis payloads return `UUID` as an empty string
-    /// instead of `null` or omitting the field.
-    #[cfg(feature = "chassis")]
-    pub(crate) fn bug_empty_chassis_uuid_field(&self) -> bool {
-        self.platform == Some(Platform::Nvidia)
+    /// NVIDIA DPU sometimes returns empty string UUID in
+    /// chassis/computer system payloads when DPU is in NIC mode.
+    #[cfg(any(feature = "chassis", feature = "computer-systems"))]
+    pub(crate) fn bug_empty_uuid_field(&self) -> bool {
+        self.platform == Some(Platform::NvidiaDpu)
     }
 
     /// Missing Name property in Chassis resource. This property is

--- a/redfish/src/chassis/item.rs
+++ b/redfish/src/chassis/item.rs
@@ -93,7 +93,7 @@ impl Config {
         if quirks.bug_missing_chassis_name_field() {
             patches.push(add_default_chassis_name);
         }
-        if quirks.bug_empty_chassis_uuid_field() {
+        if quirks.bug_empty_uuid_field() {
             patches.push(normalize_empty_uuid_field);
         }
         let read_patch_fn = (!patches.is_empty())

--- a/redfish/src/computer_system/mod.rs
+++ b/redfish/src/computer_system/mod.rs
@@ -109,7 +109,10 @@ impl<B: Bmc> SystemCollection<B> {
             }));
         }
         if bmc.quirks.computer_systems_wrong_last_reset_time() {
-            patches.push(computer_systems_wrong_last_reset_time);
+            patches.push(computer_systems_wrong_last_reset_time as fn(JsonValue) -> JsonValue);
+        }
+        if bmc.quirks.bug_empty_uuid_field() {
+            patches.push(normalize_empty_uuid_field);
         }
         let read_patch_fn = (!patches.is_empty())
             .then(|| Arc::new(move |v| patches.iter().fold(v, |acc, f| f(acc))) as ReadPatchFn);
@@ -182,4 +185,16 @@ fn computer_systems_wrong_last_reset_time(v: JsonValue) -> JsonValue {
     } else {
         v
     }
+}
+
+fn normalize_empty_uuid_field(mut v: JsonValue) -> JsonValue {
+    if let JsonValue::Object(ref mut obj) = v {
+        if let Some(uuid) = obj.get_mut("UUID") {
+            let is_empty = uuid.as_str().is_some_and(str::is_empty);
+            if is_empty {
+                *uuid = JsonValue::Null;
+            }
+        }
+    }
+    v
 }

--- a/tests/tests/test-chassis.rs
+++ b/tests/tests/test-chassis.rs
@@ -187,10 +187,11 @@ async fn anonymous_1_9_0_wrong_chassis_status_state_workaround() -> Result<(), B
 }
 
 #[test]
-async fn nvidia_empty_chassis_uuid_in_expanded_members_workaround() -> Result<(), Box<dyn StdError>>
-{
-    // Platform under test: NVIDIA chassis platforms (for example, BlueField).
-    // Quirk under test: Chassis.UUID="" in inline collection members.
+async fn nvidia_dpu_empty_chassis_uuid_in_expanded_members_workaround(
+) -> Result<(), Box<dyn StdError>> {
+    // Platform under test: NVIDIA DPU.
+    // Quirk under test: Sometimes Chassis.UUID="" in inline
+    // collection members when DPU is in NIC mode.
     let bmc = Arc::new(Bmc::default());
     let ids = ids();
     let root = expect_nvidia_service_root(
@@ -230,9 +231,11 @@ async fn nvidia_empty_chassis_uuid_in_expanded_members_workaround() -> Result<()
 }
 
 #[test]
-async fn nvidia_empty_chassis_uuid_on_member_fetch_workaround() -> Result<(), Box<dyn StdError>> {
-    // Platform under test: NVIDIA chassis platforms (for example, BlueField).
-    // Quirk under test: Chassis.UUID="" in member payload fetched by link.
+async fn nvidia_dpu_empty_chassis_uuid_on_member_fetch_workaround() -> Result<(), Box<dyn StdError>>
+{
+    // Platform under test: NVIDIA DPU.
+    // Quirk under test: Sometimes Chassis.UUID="" in member payload
+    // fetched by link.
     let bmc = Arc::new(Bmc::default());
     let ids = ids();
     let root = expect_nvidia_service_root(
@@ -367,7 +370,8 @@ async fn expect_nvidia_service_root(
                 ODATA_TYPE: "#ServiceRoot.v1_13_0.ServiceRoot",
                 "Id": "RootService",
                 "Name": "RootService",
-                "Vendor": "NVIDIA",
+                "Vendor": "Nvidia",
+                "Product": "Nvidia-BMCMezz",
                 "ProtocolFeaturesSupported": {
                     "ExpandQuery": {
                         "NoLinks": true

--- a/tests/tests/test-computer-system.rs
+++ b/tests/tests/test-computer-system.rs
@@ -103,6 +103,70 @@ async fn anonymous_1_9_0_missing_root_systems_nav_workaround() -> Result<(), Box
     Ok(())
 }
 
+#[test]
+async fn nvidia_dpu_empty_system_uuid_in_expanded_members_workaround(
+) -> Result<(), Box<dyn StdError>> {
+    // Platform under test: NVIDIA DPU (`Vendor=Nvidia`, `Product=Nvidia-BMCMezz`).
+    // Quirk under test: ComputerSystem.UUID="" in inline collection members.
+    let bmc = Arc::new(Bmc::default());
+    let ids = computer_system_ids();
+    let service_root = expect_nvidia_dpu_service_root(bmc.clone(), &ids).await?;
+    bmc.expect(Expect::expand(
+        &ids.systems_id,
+        json!({
+            ODATA_ID: &ids.systems_id,
+            ODATA_TYPE: &SYSTEM_COLLECTION_DATA_TYPE,
+            "Id": resource_name(&ids.systems_id),
+            "Name": "Computer System Collection",
+            "Members": [
+                computer_system(&ids, json!({ "UUID": "" }))
+            ]
+        }),
+    ));
+
+    let systems = service_root.systems().await?.unwrap();
+    let members = systems.members().await?;
+    assert_eq!(members.len(), 1);
+    assert_eq!(members[0].raw().uuid, Some(None));
+
+    Ok(())
+}
+
+#[test]
+async fn nvidia_dpu_empty_system_uuid_on_member_fetch_workaround() -> Result<(), Box<dyn StdError>>
+{
+    // Platform under test: NVIDIA DPU (`Vendor=Nvidia`, `Product=Nvidia-BMCMezz`).
+    // Quirk under test: ComputerSystem.UUID="" in member payload fetched by link.
+    let bmc = Arc::new(Bmc::default());
+    let ids = computer_system_ids();
+    let service_root = expect_nvidia_dpu_service_root(bmc.clone(), &ids).await?;
+    bmc.expect(Expect::expand(
+        &ids.systems_id,
+        json!({
+            ODATA_ID: &ids.systems_id,
+            ODATA_TYPE: &SYSTEM_COLLECTION_DATA_TYPE,
+            "Id": resource_name(&ids.systems_id),
+            "Name": "Computer System Collection",
+            "Members": [
+                {
+                    ODATA_ID: &ids.system_id
+                }
+            ]
+        }),
+    ));
+
+    let systems = service_root.systems().await?.unwrap();
+    bmc.expect(Expect::get(
+        &ids.system_id,
+        computer_system(&ids, json!({ "UUID": "" })),
+    ));
+    let members = systems.members().await?;
+    assert_eq!(members.len(), 1);
+    assert_eq!(members[0].raw().uuid, Some(None));
+
+    Ok(())
+}
+
 async fn get_systems(
     bmc: Arc<Bmc>,
     ids: &ComputerSystemIds,
@@ -127,6 +191,36 @@ async fn get_systems(
         .await
         .map(Option::unwrap)
         .map_err(Into::into)
+}
+
+async fn expect_nvidia_dpu_service_root(
+    bmc: Arc<Bmc>,
+    ids: &ComputerSystemIds,
+) -> Result<ServiceRoot<Bmc>, Box<dyn StdError>> {
+    bmc.expect(Expect::get(
+        &ids.root_id,
+        json!({
+            ODATA_ID: &ids.root_id,
+            ODATA_TYPE: SERVICE_ROOT_DATA_TYPE,
+            "Id": "RootService",
+            "Name": "RootService",
+            "ProtocolFeaturesSupported": {
+                "ExpandQuery": {
+                    "NoLinks": true
+                }
+            },
+            "Systems": { ODATA_ID: &ids.systems_id },
+            "Vendor": "Nvidia",
+            "Product": "Nvidia-BMCMezz",
+            "Links": {
+                "Sessions": {
+                    ODATA_ID: format!("{}/SessionService/Sessions", ids.root_id),
+                }
+            },
+        }),
+    ));
+
+    ServiceRoot::new(bmc).await.map_err(Into::into)
 }
 
 async fn expect_service_root(


### PR DESCRIPTION
Scope the empty UUID workaround to NVIDIA DPU BMCs and apply it to both chassis and computer system payloads. Add tests covering expanded members and linked member fetches for computer systems.