### PR TITLE
revert rust version to 1.90

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,5 +24,5 @@ jobs:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.95.0"
+          toolchain: "1.90.0"
       - run: make ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Rust
       uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: "1.95.0"
+        toolchain: "1.90.0"
 
     - name: Publish Crates
       run: |

--- a/bmc-http/src/lib.rs
+++ b/bmc-http/src/lib.rs
@@ -34,6 +34,7 @@
     clippy::print_stderr
 )]
 #![allow(clippy::doc_markdown)]
+#![allow(clippy::duration_suboptimal_units)]
 #![deny(missing_docs)]
 
 //! HTTP implementation of [`nv_redfish_core::Bmc`] trait.

--- a/bmc-http/src/reqwest.rs
+++ b/bmc-http/src/reqwest.rs
@@ -167,12 +167,12 @@ pub struct ClientParams {
 impl Default for ClientParams {
     fn default() -> Self {
         Self {
-            timeout: Some(Duration::from_mins(2)),
+            timeout: Some(Duration::from_secs(120)),
             connect_timeout: Some(Duration::from_secs(5)),
             user_agent: Some("nv-redfish/v1".to_string()),
             accept_invalid_certs: false,
             max_redirects: Some(10),
-            tcp_keepalive: Some(Duration::from_mins(1)),
+            tcp_keepalive: Some(Duration::from_secs(60)),
             pool_idle_timeout: Some(Duration::from_secs(90)),
             pool_max_idle_per_host: Some(1),
             default_headers: None,


### PR DESCRIPTION
Version 1.95 enables lint for Duration, but uses unstable feature in 1.90, so we revert it for now, so downstream consumers can still use it properly.