### PR TITLE
Scheduler api apdate for dispatcher crate

### DIFF
--- a/dispatcher/Cargo.toml
+++ b/dispatcher/Cargo.toml
@@ -41,3 +41,4 @@ futures-util = { workspace = true }
 serde = { workspace = true, optional = true, features = ["derive"] }
 
 [dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/dispatcher/examples/composable_tree.rs
+++ b/dispatcher/examples/composable_tree.rs
@@ -1,0 +1,253 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Composable scheduler tree + runtime + dynamic mutation.
+//!
+//! Tree we build at startup:
+//!
+//! ```text
+//!     RoundRobin (root, Meta = ())
+//!     ├─ PollLeaf("sensor-A")
+//!     └─ PollLeaf("sensor-B")
+//! ```
+//!
+//! Then we mutate it at runtime through `RuntimeHandle::with_root_mut`:
+//!
+//! - add a third leaf to the existing root,
+//! - add a sub-branch with two more leaves under the root.
+//!
+//! Final shape:
+//!
+//! ```text
+//!     RoundRobin (root)
+//!     ├─ PollLeaf("sensor-A")
+//!     ├─ PollLeaf("sensor-B")
+//!     ├─ PollLeaf("sensor-C")
+//!     └─ RoundRobin (subnet)
+//!        ├─ PollLeaf("subnet-1-a")
+//!        └─ PollLeaf("subnet-1-b")
+//! ```
+//!
+//! The runtime never sees this tree; it just drives the root. Children are
+//! added through the branch's own API, reached by downcasting the root to
+//! its concrete type.
+//!
+//! NOTE: the dispatcher is currently a scaffold. `Runtime::new`, `next`, and
+//! `with_root_mut` panic with `unimplemented!`; the example illustrates the
+//! API shape and will run unchanged once the runtime body lands.
+
+use core::marker::PhantomData;
+use core::time::Duration;
+use std::time::Instant;
+
+use nv_redfish_dispatcher::Completion;
+use nv_redfish_dispatcher::FutureWork;
+use nv_redfish_dispatcher::Readiness;
+use nv_redfish_dispatcher::Runtime;
+use nv_redfish_dispatcher::RuntimeConfig;
+use nv_redfish_dispatcher::RuntimeOutput;
+use nv_redfish_dispatcher::ScheduledWork;
+use nv_redfish_dispatcher::Scheduler;
+use nv_redfish_dispatcher::WorkMeta;
+
+// ──────────────────────────────────────────────────────────────────────
+// Application types
+// ──────────────────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+#[allow(dead_code)] // fields are consumed only via Debug in this demo
+enum Event {
+    Polled { source: String },
+}
+
+#[derive(Debug)]
+#[allow(dead_code)]
+struct Error(String);
+
+// Convenience alias for "the payload this runtime executes".
+type Work = FutureWork<Event, Error>;
+
+// ──────────────────────────────────────────────────────────────────────
+// Leaf: periodically emits one Event::Polled
+// ──────────────────────────────────────────────────────────────────────
+
+struct PollLeaf {
+    name: String,
+    interval: Duration,
+    next_due: Option<Instant>,
+}
+
+impl PollLeaf {
+    fn new(name: impl Into<String>, interval: Duration) -> Self {
+        Self {
+            name: name.into(),
+            interval,
+            next_due: None,
+        }
+    }
+}
+
+impl Scheduler<Work> for PollLeaf {
+    type Meta = ();
+
+    fn update_ready(&mut self, now: Instant) -> Readiness {
+        match self.next_due {
+            Some(due) if now < due => Readiness::not_ready(Some(due)),
+            _ => Readiness::ready(None),
+        }
+    }
+
+    fn take_next(&mut self) -> Option<ScheduledWork<Work, ()>> {
+        let now = Instant::now();
+        self.next_due = Some(now + self.interval);
+
+        let name = self.name.clone();
+        let payload: Work = Box::pin(async move { Ok(vec![Event::Polled { source: name }]) });
+
+        Some(ScheduledWork::new((), payload))
+    }
+
+    fn on_complete(&mut self, _: &mut Completion<()>) {
+        // Leaves typically use this to update local stats / backoff.
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Branch: round-robin over heterogeneous children
+// ──────────────────────────────────────────────────────────────────────
+//
+// Children are stored type-erased so leaves and sub-branches mix freely as
+// long as they share the same payload `T` and meta `M`.
+
+struct RoundRobin<T, M: WorkMeta> {
+    children: Vec<Box<dyn Scheduler<T, Meta = M>>>,
+    cursor: usize,
+    _payload: PhantomData<fn() -> T>,
+}
+
+impl<T, M: WorkMeta> RoundRobin<T, M> {
+    fn new() -> Self {
+        Self {
+            children: Vec::new(),
+            cursor: 0,
+            _payload: PhantomData,
+        }
+    }
+
+    fn add_child<S: Scheduler<T, Meta = M>>(&mut self, child: S) {
+        self.children.push(Box::new(child));
+    }
+}
+
+impl<T, M> Scheduler<T> for RoundRobin<T, M>
+where
+    T: Send + 'static,
+    M: WorkMeta,
+{
+    // RoundRobin is policy-light: it doesn't add a meta layer, just forwards
+    // the child's meta upward.
+    type Meta = M;
+
+    fn update_ready(&mut self, now: Instant) -> Readiness {
+        let mut ready = false;
+        let mut next_at: Option<Instant> = None;
+        for child in &mut self.children {
+            let r = child.update_ready(now);
+            ready |= r.ready;
+            next_at = match (next_at, r.next_update_at) {
+                (Some(a), Some(b)) => Some(a.min(b)),
+                (a, b) => a.or(b),
+            };
+        }
+        Readiness {
+            ready,
+            next_update_at: next_at,
+            next_cost: None,
+        }
+    }
+
+    fn take_next(&mut self) -> Option<ScheduledWork<T, Self::Meta>> {
+        let n = self.children.len();
+        if n == 0 {
+            return None;
+        }
+        // Try every child once before giving up; honours `take_next`'s
+        // "may return None, keep scanning" contract.
+        for _ in 0..n {
+            let idx = self.cursor;
+            self.cursor = (self.cursor + 1) % n;
+            if let Some(mut work) = self.children[idx].take_next() {
+                // Branch contract: stamp the chosen child index.
+                work.routing.push(idx as u32);
+                return Some(work);
+            }
+        }
+        None
+    }
+
+    fn on_complete(&mut self, completion: &mut Completion<Self::Meta>) {
+        // Branch contract: pop our tag and forward to the originating child.
+        if let Some(idx) = completion.routing.pop() {
+            if let Some(child) = self.children.get_mut(idx as usize) {
+                child.on_complete(completion);
+            }
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Driver
+// ──────────────────────────────────────────────────────────────────────
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    // 1. Build the initial tree.
+    let mut root: RoundRobin<Work, ()> = RoundRobin::new();
+    root.add_child(PollLeaf::new("sensor-A", Duration::from_secs(1)));
+    root.add_child(PollLeaf::new("sensor-B", Duration::from_secs(2)));
+
+    // 2. Hand the root to the runtime. The runtime takes ownership and
+    //    boxes it behind an internal mutex.
+    let mut runtime: Runtime<Event, Error, ()> = Runtime::new(RuntimeConfig::default(), root);
+    let handle = runtime.handle();
+
+    // 3a. Add another leaf to the root, dynamically.
+    handle.with_root_mut(|root: &mut RoundRobin<Work, ()>| {
+        root.add_child(PollLeaf::new("sensor-C", Duration::from_secs(3)));
+    });
+
+    // 3b. Add an entirely new sub-branch with its own children.
+    handle.with_root_mut(|root: &mut RoundRobin<Work, ()>| {
+        let mut subnet: RoundRobin<Work, ()> = RoundRobin::new();
+        subnet.add_child(PollLeaf::new("subnet-1-a", Duration::from_secs(5)));
+        subnet.add_child(PollLeaf::new("subnet-1-b", Duration::from_secs(5)));
+        root.add_child(subnet);
+    });
+
+    // 4. Drive the runtime. `next()` is the single ordered output stream.
+    loop {
+        match runtime.next().await {
+            RuntimeOutput::Work { result, latency } => match result {
+                Ok(events) => println!("got {} events in {:?}", events.len(), latency),
+                Err(Error(msg)) => eprintln!("work failed in {:?}: {}", latency, msg),
+            },
+            RuntimeOutput::Runtime(_) => {
+                // Out-of-band runtime events; only constructible with the
+                // `runtime-events` feature. Ignored here.
+            }
+            RuntimeOutput::Shutdown => break,
+        }
+    }
+}

--- a/dispatcher/src/event.rs
+++ b/dispatcher/src/event.rs
@@ -13,22 +13,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Runtime event types.
+//! Out-of-band runtime events (throttling, queue pressure, …).
 //!
-//! Runtime events describe out-of-band scheduler, executor, and queue facts
-//! such as lag, starvation, throttling, and queue pressure. They are
-//! compile-time feature gated. When the `runtime-events` feature is disabled,
-//! [`RuntimeEventType`] is [`Infallible`] and emission paths are not compiled.
+//! Feature-gated by `runtime-events`. When the feature is off,
+//! [`RuntimeEventType`] is [`core::convert::Infallible`] and emission
+//! paths are not compiled.
 
 #[cfg(not(feature = "runtime-events"))]
 use core::convert::Infallible;
 
 /// Concrete payload carried by [`crate::RuntimeOutput::Runtime`].
-///
-/// When the `runtime-events` feature is enabled, this aliases the
-/// [`RuntimeEvent`] enum. Otherwise it aliases [`Infallible`], making the
-/// `Runtime` variant uninhabited and therefore impossible to construct from
-/// outside the crate.
 #[cfg(feature = "runtime-events")]
 pub type RuntimeEventType = RuntimeEvent;
 
@@ -38,58 +32,28 @@ pub type RuntimeEventType = Infallible;
 
 #[cfg(feature = "runtime-events")]
 mod with_events {
-    use crate::ids::NodeId;
-
-    /// Out-of-band scheduler, executor, and queue events emitted by the
-    /// runtime when the `runtime-events` feature is enabled.
-    ///
-    /// These events are interleaved with work outputs in
-    /// [`crate::Runtime::next`] preserving causal ordering. They never carry
-    /// user work payloads.
+    /// Out-of-band runtime events emitted when `runtime-events` is on.
+    /// Interleaved with work outputs in [`crate::Runtime::next`] in causal
+    /// order; they never carry user payloads.
     #[derive(Debug, Clone, PartialEq, Eq)]
     #[non_exhaustive]
     pub enum RuntimeEvent {
-        /// A node is lagging behind its requested rate.
-        NodeLagging {
-            /// The lagging node.
-            node_id: NodeId,
-        },
-        /// A previously-lagging node has caught up.
-        NodeRecovered {
-            /// The recovered node.
-            node_id: NodeId,
-        },
-        /// A node is being starved by other flows.
-        NodeStarved {
-            /// The starved node.
-            node_id: NodeId,
-        },
-        /// The runtime is being throttled by global capacity.
+        /// Throttled by the global in-flight cap.
         GlobalThrottled,
-        /// The output queue is under pressure.
+        /// Output queue is under pressure.
         EventQueuePressure {
             /// Current queue depth.
             queued: usize,
         },
-        /// Work was dispatched and started executing.
-        WorkStarted {
-            /// The root node the work was dispatched under.
-            node_id: NodeId,
-        },
-        /// Work completed successfully. Brackets the corresponding
-        /// `RuntimeOutput::Work(Ok(_))` together with [`RuntimeEvent::WorkStarted`].
-        WorkCompleted {
-            /// The root node the work was dispatched under.
-            node_id: NodeId,
-        },
-        /// Work failed. Brackets the corresponding `RuntimeOutput::Work(Err(_))`
-        /// together with [`RuntimeEvent::WorkStarted`].
-        WorkFailed {
-            /// The root node the work was dispatched under.
-            node_id: NodeId,
-        },
-        /// A point-in-time snapshot of scheduler statistics. Reserved
-        /// variant; concrete payload fields are added in later phases.
+        /// A payload was dispatched.
+        WorkStarted,
+        /// A payload completed successfully; brackets a `Work { Ok, .. }`
+        /// output together with [`RuntimeEvent::WorkStarted`].
+        WorkCompleted,
+        /// A payload failed; brackets a `Work { Err, .. }` output together
+        /// with [`RuntimeEvent::WorkStarted`].
+        WorkFailed,
+        /// Reserved snapshot variant; payload fields land later.
         SchedulerStatsSnapshot,
     }
 }

--- a/dispatcher/src/lib.rs
+++ b/dispatcher/src/lib.rs
@@ -15,33 +15,46 @@
 
 //! Generic cooperative task dispatcher with composable scheduling.
 //!
-//! `nv-redfish-dispatcher` is a Redfish-free, application-agnostic dispatcher
-//! parameterized by a user work event type `Ev` and a work error type `Err`.
-//! Its central abstraction is the [`Scheduler`] trait — every node in the
-//! dispatcher's scheduling tree implements it, whether it is a *leaf* (a node
-//! that produces work directly) or a *branch* (a node that composes children
-//! using a scheduling policy: weighted DRR, round-robin, priority,
-//! token-bucket admission, etc.).
-//!
-//! The runtime drives only the *root* node. Branches recurse internally, and
-//! completions are forwarded back to the originating leaf via a per-work
+//! Every node in the scheduling tree implements one trait, [`Scheduler`].
+//! Leaves produce work; branches compose children with a policy (DRR,
+//! round-robin, priority, token bucket, …). The runtime drives only the
+//! *root*; branches recurse, and completions flow back via a per-work
 //! [`RoutingPath`] breadcrumb.
 //!
-//! Public surface:
+//! [`Scheduler<T>`] is parameterized only by an opaque payload `T`. The
+//! scheduler tree never inspects it; the runtime does. This crate's
+//! [`Runtime`] uses `T = FutureWork<Ev, Err>` (boxed futures returning
+//! `Result<Vec<Ev>, Err>`); other runtimes can pick another shape and
+//! reuse the same scheduler types.
 //!
-//! - the [`Scheduler`] trait and its [`ScheduledWork`] / [`ScheduledWorkResult`] types,
-//! - data types in [`work`]: [`WorkMeta`], [`Readiness`], [`CostUnits`],
-//!   [`WorkCompletion`], [`CompletionOutcome`], [`RoutingPath`],
-//! - opaque [`NodeId`] addressing every node in the tree,
-//! - the single ordered output stream ([`RuntimeOutput`], [`WorkResult`], ...),
-//! - optional out-of-band runtime events ([`RuntimeEventType`]),
-//! - a cloneable synchronous control surface ([`RuntimeHandle`]),
-//! - a single-consumer driver ([`Runtime`]) with [`Runtime::next`].
+//! ## Layered metadata
 //!
-//! This crate is currently a **scaffold**: the public types and signatures
-//! are frozen, but bodies are stubbed with [`unimplemented!`]. Built-in
-//! branch implementations (weighted DRR, round-robin, token bucket, etc.)
-//! land in a follow-up phase.
+//! [`WorkMeta`] is a marker bound (`Debug + Clone + Send + 'static`) — any
+//! matching type is meta, and `()` is the canonical no-policy meta. Policy
+//! data is added by *wrappers* ([`WithCost`], [`WithPriority`]) that
+//! implement *projection traits* ([`HasCost`], [`HasPriority`]); schedulers
+//! ask for the projections they need and leave the rest alone.
+//! [`RoutingPath`] is a structural sibling of meta on [`ScheduledWork`] and
+//! [`Completion`], not a meta concern.
+//!
+//! ## Public surface
+//!
+//! - [`Scheduler`], [`ScheduledWork`], [`Completion`],
+//! - [`WorkMeta`], wrappers [`WithCost`] / [`WithPriority`], projections
+//!   [`HasCost`] / [`HasPriority`],
+//! - [`Readiness`], [`CostUnits`], [`CompletionOutcome`], [`RoutingPath`],
+//! - [`Runtime`] + [`RuntimeConfig`], [`RuntimeHandle`] (with
+//!   [`RuntimeHandle::with_root`] / [`with_root_mut`][`RuntimeHandle::with_root_mut`]),
+//!   [`RuntimeOutput`], the [`FutureWork`] payload alias,
+//! - optional out-of-band [`RuntimeEventType`].
+//!
+//! The runtime does *not* enumerate the scheduler tree, and exposes no
+//! per-leaf identity or telemetry. Schedulers that need such observability
+//! expose it through their own API, reached via [`RuntimeHandle::with_root`].
+//!
+//! This crate is currently a **scaffold**: signatures are frozen, bodies
+//! are stubbed with [`unimplemented!`]. Built-in branch policies land in a
+//! follow-up phase.
 
 #![deny(
     clippy::all,
@@ -77,34 +90,46 @@ pub mod scheduler;
 pub mod stats;
 pub mod work;
 
-#[doc(inline)]
-pub use event::RuntimeEventType;
 #[cfg(feature = "runtime-events")]
 #[doc(inline)]
 pub use event::RuntimeEvent;
 #[doc(inline)]
+pub use event::RuntimeEventType;
+#[doc(inline)]
+pub use runtime::FutureWork;
+#[doc(inline)]
 pub use runtime::Runtime;
+#[doc(inline)]
+pub use runtime::RuntimeConfig;
+#[doc(inline)]
+pub use runtime::RuntimeHandle;
+#[doc(inline)]
+pub use runtime::RuntimeOutput;
 #[doc(inline)]
 pub use scheduler::ScheduledWork;
 #[doc(inline)]
-pub use scheduler::ScheduledWorkResult;
-#[doc(inline)]
 pub use scheduler::Scheduler;
 #[doc(inline)]
-pub use stats::NodeStats;
+pub use stats::OutputQueueStats;
 #[doc(inline)]
 pub use stats::RuntimeStats;
 #[doc(inline)]
-pub use stats::WorkStats;
+pub use work::Completion;
 #[doc(inline)]
 pub use work::CompletionOutcome;
 #[doc(inline)]
 pub use work::CostUnits;
 #[doc(inline)]
+pub use work::HasCost;
+#[doc(inline)]
+pub use work::HasPriority;
+#[doc(inline)]
 pub use work::Readiness;
 #[doc(inline)]
 pub use work::RoutingPath;
 #[doc(inline)]
-pub use work::WorkCompletion;
+pub use work::WithCost;
+#[doc(inline)]
+pub use work::WithPriority;
 #[doc(inline)]
 pub use work::WorkMeta;

--- a/dispatcher/src/runtime.rs
+++ b/dispatcher/src/runtime.rs
@@ -13,85 +13,111 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! The generic dispatcher runtime.
+//! Generic dispatcher runtime.
 //!
-//! [`Runtime::next`] is the single ordered output and execution interface.
-//! Each call advances the runtime by at most one selected work item, drains
-//! at most one in-flight completion to the output queue, and returns the
-//! oldest queued output. When nothing can make progress, the future parks
-//! until a control-plane mutation or an in-flight task completes.
+//! [`Runtime::next`] is the single ordered execution and output interface.
+//! Each call advances by at most one selected item, drains at most one
+//! completion, and returns the oldest queued output; otherwise it parks.
 //!
-//! The runtime is policy-free: every scheduling decision lives inside the
-//! installed root [`Scheduler`] subtree. The runtime is responsible for:
+//! The runtime is policy-free and meta-blind. All scheduling lives in the
+//! root [`Scheduler`] subtree; the runtime only dispatches payloads, polls
+//! the in-flight set, forwards completions back through the tree, enforces
+//! the runtime-wide caps in [`RuntimeConfig`], and emits [`RuntimeOutput`].
 //!
-//! - dispatching work futures returned by `root.take_next()`,
-//! - polling the in-flight set,
-//! - delivering completions back through `root.on_complete(&mut completion)`
-//!   (branches recurse via [`crate::RoutingPath`]),
-//! - enforcing only runtime-wide invariants ([`RuntimeConfig::global_max_in_flight`],
-//!   [`RuntimeConfig::output_queue_capacity`]),
-//! - producing the single ordered [`crate::RuntimeOutput`] stream.
+//! The root sits behind an internal mutex. The driver and
+//! [`RuntimeHandle::with_root`] / [`RuntimeHandle::with_root_mut`] share
+//! the same lock, so user mutations and driver steps serialize naturally.
 
 use core::future::Future;
 use core::marker::PhantomData;
 use core::pin::Pin;
 use core::task::Context;
 use core::task::Poll;
+use core::time::Duration;
 
 use crate::RuntimeEventType;
 use crate::scheduler::Scheduler;
 use crate::stats::RuntimeStats;
-use crate::work::WorkResult;
+use crate::work::WorkMeta;
 
-/// Generic dispatcher runtime parameterized by application work event type
-/// `Ev` and work error type `Err`.
+/// `PhantomData` alias for the runtime's three type parameters; factored
+/// to keep struct types simple under `clippy::type_complexity`.
+type RuntimePhantom<Ev, Err, M> = PhantomData<fn() -> (Ev, Err, M)>;
+
+/// Work payload consumed by this runtime: a boxed future with terminal
+/// value `Result<Vec<Ev>, Err>`. Schedulers parameterized as
+/// `Scheduler<FutureWork<Ev, Err>>` are compatible with [`Runtime::new`].
 ///
-/// The runtime is *not* `Clone`. Only one consumer drives the output stream
-/// via [`Runtime::next`]. Use [`Runtime::handle`] to obtain cloneable control
-/// handles for cross-task control operations.
-pub struct Runtime<Ev, Err> {
-    // Scaffold-only placeholder. Replaced with real
-    // `Arc<Shared<Ev, Err>>` + `FuturesUnordered` + bookkeeping fields when
-    // the runtime body lands.
-    _phantom: PhantomData<fn() -> (Ev, Err)>,
+/// [`crate::Scheduler`] is generic over the payload and never inspects it,
+/// so alternate runtimes can pick another shape (sync closures, batched
+/// descriptors, …) and reuse the same scheduler types.
+pub type FutureWork<Ev, Err> =
+    Pin<Box<dyn Future<Output = Result<Vec<Ev>, Err>> + Send + 'static>>;
+
+/// Generic dispatcher runtime, parameterized by event type `Ev`, error
+/// type `Err`, and root meta type `M`.
+///
+/// `M` is whatever the root scheduler exposes as `Self::Meta` — typically
+/// a stack of wrappers like `WithPriority<WithCost<()>>`.
+///
+/// Not `Clone`: only one consumer drives [`Runtime::next`]. Use
+/// [`Runtime::handle`] for cloneable control handles.
+pub struct Runtime<Ev, Err, M: WorkMeta> {
+    // Scaffold placeholder. Becomes
+    // `Arc<Shared<Ev, Err, M>>` with a mutex-guarded
+    // `Box<dyn private::SchedulerObj<FutureWork<Ev, Err>, M> + Send>`,
+    // a `FuturesUnordered`, and bookkeeping.
+    _phantom: RuntimePhantom<Ev, Err, M>,
 }
 
-impl<Ev, Err> Runtime<Ev, Err>
+impl<Ev, Err, M> Runtime<Ev, Err, M>
 where
     Ev: Send + 'static,
     Err: Send + 'static,
+    M: WorkMeta,
 {
-    /// Build a new runtime with the given configuration.
+    /// Build a runtime with the given configuration and root scheduler.
+    ///
+    /// The bound `S: Scheduler<FutureWork<Ev, Err>, Meta = M>` ties the
+    /// tree's payload to the shape this runtime executes. The root is
+    /// consumed and stored behind a mutex; reach into it later with
+    /// [`RuntimeHandle::with_root`] / [`RuntimeHandle::with_root_mut`] by
+    /// supplying the same concrete type for the downcast.
+    ///
+    /// A blanket `impl Scheduler for Box<S>` lets you pass an existing
+    /// `Box<dyn Scheduler<FutureWork<Ev, Err>, Meta = M>>` directly.
     #[must_use]
-    pub fn new(_config: RuntimeConfig, _root: Box<dyn Scheduler<Ev, Err> + Send>) -> Self {
+    pub fn new<S>(_config: RuntimeConfig, _root: S) -> Self
+    where
+        S: Scheduler<FutureWork<Ev, Err>, Meta = M>,
+    {
         unimplemented!("scaffold")
     }
 
-    /// Return a cloneable handle that exposes the synchronous control surface.
+    /// Cloneable handle for synchronous control and typed root access.
     #[must_use]
-    pub fn handle(&self) -> RuntimeHandle<Ev, Err> {
+    pub fn handle(&self) -> RuntimeHandle<Ev, Err, M> {
         unimplemented!("scaffold")
     }
 
-    /// Drive the runtime by one step and return the next ordered output.
+    /// Advance one step and return the next output.
     ///
-    /// Behavior summary:
+    /// Step order:
     ///
-    /// 1. If a sticky shutdown has been emitted, return it again.
-    /// 2. Drain at most one already-queued output and return it.
-    /// 3. Poll in-flight work; on completion enqueue the corresponding
-    ///    [`crate::RuntimeOutput::Work`] and call
-    ///    [`Scheduler::on_complete`] on the root exactly once. Branches
-    ///    propagate the call to the originating child by popping their
-    ///    [`crate::RoutingPath`] tag.
-    /// 4. If shutdown has started and there is no further in-flight work or
-    ///    queued output, emit the sticky shutdown output.
-    /// 5. Otherwise call `root.update_ready(now)`; if ready, call
-    ///    `root.take_next()` and admit the resulting future to the in-flight
-    ///    set, subject to [`RuntimeConfig::global_max_in_flight`].
-    /// 6. If nothing can make progress, register the current waker and park.
+    /// 1. If shutdown was already emitted, return it again.
+    /// 2. Drain one queued output if any.
+    /// 3. Poll in-flight payloads; enqueue [`RuntimeOutput::Work`] on
+    ///    completion and call `root.on_complete` exactly once (branches
+    ///    recurse via [`crate::RoutingPath`]).
+    /// 4. After shutdown, once nothing remains, emit the sticky shutdown.
+    /// 5. Otherwise refresh readiness and dispatch one item, subject to
+    ///    [`RuntimeConfig::global_max_in_flight`].
+    /// 6. Park otherwise.
+    ///
+    /// Shares the root lock with [`RuntimeHandle::with_root_mut`]; both
+    /// hold it briefly.
     #[allow(clippy::should_implement_trait)]
-    pub fn next(&mut self) -> NextFuture<'_, Ev, Err> {
+    pub fn next(&mut self) -> NextFuture<'_, Ev, Err, M> {
         NextFuture {
             runtime: self,
             _phantom: PhantomData,
@@ -99,17 +125,18 @@ where
     }
 }
 
-/// Future returned by [`Runtime::next`]. See its docs for behavior.
-pub struct NextFuture<'r, Ev, Err> {
-    // Borrow the runtime exclusively to enforce the single-driver invariant.
-    runtime: &'r mut Runtime<Ev, Err>,
-    _phantom: PhantomData<fn() -> (Ev, Err)>,
+/// Future returned by [`Runtime::next`].
+pub struct NextFuture<'r, Ev, Err, M: WorkMeta> {
+    // Exclusive borrow enforces the single-driver invariant.
+    runtime: &'r mut Runtime<Ev, Err, M>,
+    _phantom: RuntimePhantom<Ev, Err, M>,
 }
 
-impl<Ev, Err> Future for NextFuture<'_, Ev, Err>
+impl<Ev, Err, M> Future for NextFuture<'_, Ev, Err, M>
 where
     Ev: Send + 'static,
     Err: Send + 'static,
+    M: WorkMeta,
 {
     type Output = RuntimeOutput<Ev, Err>;
 
@@ -119,38 +146,28 @@ where
     }
 }
 
-
-/// Runtime-wide configuration set when the runtime is constructed.
-///
-/// Per-node policy lives inside each [`Scheduler`] implementation; this
-/// struct is intentionally minimal and only carries runtime-wide knobs that
-/// no individual node owns.
+/// Runtime-wide configuration. Per-node policy lives inside each
+/// [`Scheduler`]; this struct only carries knobs no node owns.
 #[derive(Debug, Clone, Default)]
 pub struct RuntimeConfig {
-    /// Optional global maximum number of in-flight work items.
-    ///
-    /// Enforced by the runtime on dispatch admission, in addition to whatever
-    /// per-subtree admission a branch node may impose.
+    /// Optional global cap on in-flight items, applied at dispatch
+    /// admission on top of any per-subtree admission a branch enforces.
     pub global_max_in_flight: Option<u32>,
-    /// Optional bound on the output queue. When `None` the queue is unbounded.
+    /// Optional output queue bound. `None` means unbounded.
     pub output_queue_capacity: Option<usize>,
 }
 
-/// Cloneable handle to a running [`crate::Runtime`].
+/// Cloneable handle to a running [`Runtime`].
 ///
-/// `RuntimeHandle` exposes the synchronous control surface. It can be cloned
-/// and shared across tasks; mutating operations may briefly lock internal
-/// state but never wait on work futures.
-///
-/// The runtime itself is *not* `Clone` — only one consumer drives the output
-/// stream via [`crate::Runtime::next`].
-pub struct RuntimeHandle<Ev, Err> {
-    // Scaffold-only placeholder. Replaced with `Arc<Shared<Ev, Err>>` once the
-    // runtime body is filled in.
-    _phantom: PhantomData<fn() -> (Ev, Err)>,
+/// Exposes synchronous control plus typed root access. Mutating ops take
+/// the internal lock briefly and never wait on work payloads. The runtime
+/// itself is not `Clone`.
+pub struct RuntimeHandle<Ev, Err, M: WorkMeta> {
+    // Scaffold placeholder; becomes `Arc<Shared<Ev, Err, M>>`.
+    _phantom: RuntimePhantom<Ev, Err, M>,
 }
 
-impl<Ev, Err> Clone for RuntimeHandle<Ev, Err> {
+impl<Ev, Err, M: WorkMeta> Clone for RuntimeHandle<Ev, Err, M> {
     fn clone(&self) -> Self {
         Self {
             _phantom: PhantomData,
@@ -158,13 +175,15 @@ impl<Ev, Err> Clone for RuntimeHandle<Ev, Err> {
     }
 }
 
-impl<Ev, Err> RuntimeHandle<Ev, Err> {   
-    /// Begin graceful shutdown. Idempotent: subsequent calls do nothing.
-    ///
-    /// After shutdown starts, mutating control operations reject new node
-    /// installations; in-flight work is allowed to complete; queued outputs
-    /// are still delivered, and finally the sticky shutdown output is
-    /// emitted by [`crate::Runtime::next`].
+impl<Ev, Err, M> RuntimeHandle<Ev, Err, M>
+where
+    Ev: Send + 'static,
+    Err: Send + 'static,
+    M: WorkMeta,
+{
+    /// Begin graceful shutdown. Idempotent. In-flight items still complete,
+    /// queued outputs still drain, then [`Runtime::next`] emits a sticky
+    /// shutdown.
     pub fn graceful_shutdown(&self) {
         unimplemented!("scaffold")
     }
@@ -174,21 +193,48 @@ impl<Ev, Err> RuntimeHandle<Ev, Err> {
     pub fn stats(&self) -> RuntimeStats {
         unimplemented!("scaffold")
     }
+
+    /// Run `f` with shared access to the root downcast to `S`. `None` if
+    /// the downcast fails.
+    ///
+    /// Holds the root lock for the duration of `f`; keep it short and do
+    /// not re-enter the runtime from inside.
+    pub fn with_root<S, R>(&self, _f: impl FnOnce(&S) -> R) -> Option<R>
+    where
+        S: 'static,
+    {
+        unimplemented!("scaffold")
+    }
+
+    /// Run `f` with exclusive access to the root downcast to `S`. `None`
+    /// if the downcast fails.
+    ///
+    /// Holds the root lock for the duration of `f`; keep it short and do
+    /// not re-enter the runtime from inside (it will deadlock).
+    pub fn with_root_mut<S, R>(&self, _f: impl FnOnce(&mut S) -> R) -> Option<R>
+    where
+        S: 'static,
+    {
+        unimplemented!("scaffold")
+    }
 }
 
-/// Single ordered output value emitted by the runtime.
+/// Single ordered output emitted by the runtime.
 ///
-/// `R` defaults to [`crate::RuntimeEventType`] which is
-/// [`core::convert::Infallible`] when the `runtime-events` feature is
-/// disabled, making `RuntimeOutput::Runtime(_)` impossible to construct.
+/// `R` defaults to [`crate::RuntimeEventType`], which is
+/// [`core::convert::Infallible`] when the `runtime-events` feature is off
+/// — `RuntimeOutput::Runtime(_)` is then unconstructible.
 pub enum RuntimeOutput<Ev, Err, R = RuntimeEventType> {
-    /// Application or adapter work output.
-    Work(WorkResult<Ev, Err>),
-    /// Out-of-band runtime event. Only constructible when `runtime-events`
-    /// is enabled (otherwise `R = Infallible`).
+    /// Terminal value of one work payload, plus its wall-clock latency.
+    Work {
+        /// `Ok(events)` (one or more events in order) or `Err(error)`.
+        result: Result<Vec<Ev>, Err>,
+        /// Latency between dispatch and completion.
+        latency: Duration,
+    },
+    /// Out-of-band runtime event (only when `runtime-events` is enabled).
     Runtime(R),
-    /// Sticky terminal output emitted after graceful shutdown drains in-flight
-    /// work and prior queued output. Subsequent `next()` calls return this
-    /// variant immediately.
+    /// Sticky terminal output after graceful shutdown drains. Subsequent
+    /// `next()` calls return this immediately.
     Shutdown,
 }

--- a/dispatcher/src/scheduler.rs
+++ b/dispatcher/src/scheduler.rs
@@ -13,105 +13,144 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! The unified [`Scheduler`] trait — every node in the dispatcher's scheduling
-//! tree implements it.
+//! The unified [`Scheduler`] trait — every node in the scheduling tree
+//! implements it.
 //!
-//! The trait subsumes both *leaves* (nodes that produce work directly, the
-//! role today's `Generator` plays) and *branches* (nodes that compose
-//! children using a scheduling policy: weighted DRR, round-robin, priority,
-//! token-bucket admission, etc.). The runtime treats every node identically:
-//! it queries readiness, asks for one work item, and forwards completions.
-//!
-//! Branch nodes implement scheduling policy by:
-//!
-//! - aggregating child readiness in [`Scheduler::update_ready`],
-//! - selecting a child in [`Scheduler::take_next`], pushing the child index
-//!   onto the returned work's [`crate::RoutingPath`] before returning upward,
-//! - popping the routing tag in [`Scheduler::on_complete`] and forwarding to
-//!   the originating child.
-//!
-//! Leaf nodes ignore the routing path; they account locally and produce work
-//! futures that close over whatever the application needs.
+//! Leaves produce work directly; branches compose children with a policy.
+//! The runtime treats both alike: query readiness, pull one item, forward
+//! the completion. `Scheduler<T>` is generic over the payload `T` and
+//! never inspects it; the runtime decides what shape `T` takes (the
+//! bundled [`crate::Runtime`] uses [`crate::FutureWork<Ev, Err>`]).
 
-use core::future::Future;
-use core::pin::Pin;
 use std::time::Instant;
 
+use crate::work::Completion;
 use crate::work::Readiness;
-use crate::work::WorkCompletion;
+use crate::work::RoutingPath;
 use crate::work::WorkMeta;
 
-/// Result type returned by a [`ScheduledWork`] future.
-///
-/// On success the work returns a vector of work events of type `Ev`. Multiple
-/// events from one work item preserve order. On failure the work returns a
-/// generic application or adapter error of type `Err`.
-pub type ScheduledWorkResult<Ev, Err> = Result<Vec<Ev>, Err>;
-
-/// Executable unit of work returned by a selected [`Scheduler`] node.
-///
-/// `ScheduledWork` carries scheduler-visible metadata together with the
-/// actual work future. The future closes over whatever the leaf needs.
-///
-/// The future is required to be `Send + 'static` so it can live in the
-/// runtime's in-flight set; this matches the `Scheduler<Ev, Err>` storage
-/// shape (`Box<dyn Scheduler<...> + Send>`) inside the runtime.
-pub struct ScheduledWork<Ev, Err> {
-    /// Scheduler-visible metadata for this work item, including its
-    /// [`crate::RoutingPath`].
-    pub meta: WorkMeta,
-    /// Future producing the work result.
-    pub future: Pin<Box<dyn Future<Output = ScheduledWorkResult<Ev, Err>> + Send + 'static>>,
+/// Unit of work returned by [`Scheduler::take_next`].
+pub struct ScheduledWork<T, M: WorkMeta> {
+    /// Meta as observed at the producing node.
+    pub meta: M,
+    /// Breadcrumb stack stamped by branches on the way up. See
+    /// [`RoutingPath`].
+    pub routing: RoutingPath,
+    /// Opaque payload; only the runtime executes it.
+    pub payload: T,
 }
 
-impl<Ev, Err> ScheduledWork<Ev, Err> {
-    /// Build a [`ScheduledWork`] from work meta and a boxed future.
+impl<T, M: WorkMeta> ScheduledWork<T, M> {
+    /// Build a [`ScheduledWork`] with an empty routing path. Typical for
+    /// leaves; branches re-use the child's path and stamp their own tag.
     #[must_use]
-    pub fn new(
-        meta: WorkMeta,
-        future: Pin<Box<dyn Future<Output = ScheduledWorkResult<Ev, Err>> + Send + 'static>>,
-    ) -> Self {
-        Self { meta, future }
+    pub const fn new(meta: M, payload: T) -> Self {
+        Self {
+            meta,
+            routing: RoutingPath::empty(),
+            payload,
+        }
     }
 }
 
-/// Composable scheduler node interface.
+/// Composable scheduler node, parameterized by the opaque payload `T`.
 ///
-/// The runtime drives the *root* node by:
+/// The runtime drives the root: refresh readiness, pull a payload when
+/// admission permits, report completion exactly once. Branches recurse
+/// into their selected child and may stamp the routing path and/or wrap
+/// the child's meta on the way up; on completion they pop their tag,
+/// unwrap their layer, and forward.
 ///
-/// 1. querying readiness via [`Scheduler::update_ready`] before selection,
-/// 2. pulling executable work via [`Scheduler::take_next`] when admission
-///    permits,
-/// 3. reporting completion via [`Scheduler::on_complete`] exactly once per
-///    dispatched work item.
-///
-/// Branch implementations recurse: their `take_next` calls a chosen child's
-/// `take_next`, their `on_complete` pops a routing tag and forwards to the
-/// indicated child. Leaf implementations produce work and account locally.
-///
-/// Removed nodes are never queried again.
-pub trait Scheduler<Ev, Err> {
-    /// Refresh readiness using the supplied reference clock.
-    ///
-    /// Branches should aggregate across children (any-ready -> ready,
-    /// `next_update_at` = min over children, `next_cost` per branch policy).
+/// `Send + 'static` is required so the runtime can store a node behind a
+/// trait object and downcast it via [`core::any::Any`].
+pub trait Scheduler<T>: Send + 'static {
+    /// Meta produced at `take_next` and consumed at `on_complete`. `()`
+    /// for meta-naive leaves; branches wrap the child meta with a layer
+    /// like [`crate::WithCost`].
+    type Meta: WorkMeta;
+
+    /// Refresh readiness against `now`. Branches aggregate across
+    /// children (ready iff any child is ready; `next_update_at` is the
+    /// min; `next_cost` follows the branch policy).
     fn update_ready(&mut self, now: Instant) -> Readiness;
 
-    /// Produce the next executable work item, if any.
+    /// Pull the next item, or `None` if nothing is currently available.
     ///
-    /// Called only when the runtime selects this node (or, recursively, when
-    /// a parent branch selects this node). May return `None` to indicate that
-    /// no work is currently available; the runtime/parent will then continue
-    /// scanning other ready children.
-    ///
-    /// Branch contract: after a successful child selection, push the chosen
-    /// child index onto `work.meta.routing` before returning.
-    fn take_next(&mut self) -> Option<ScheduledWork<Ev, Err>>;
+    /// Branches must push the selected child index onto `work.routing`
+    /// before returning, and replace `work.meta` if they add a layer.
+    fn take_next(&mut self) -> Option<ScheduledWork<T, Self::Meta>>;
 
-    /// Receive the completion summary for a previously dispatched work item.
+    /// Report the completion of a dispatched item, exactly once.
     ///
-    /// Reported exactly once per dispatched work item. The runtime delivers
-    /// completions to the *root* node; branches pop their own routing tag
-    /// from `completion.routing` and forward to the originating child.
-    fn on_complete(&mut self, completion: &mut WorkCompletion);
+    /// Branches pop their routing tag from `completion.routing`, read
+    /// their layer's annotations off `completion.meta`, and forward a
+    /// `&mut Completion<C::Meta>` (with the unwrapped meta) to the chosen
+    /// child.
+    fn on_complete(&mut self, completion: &mut Completion<Self::Meta>);
+}
+
+impl<T, S> Scheduler<T> for Box<S>
+where
+    T: 'static,
+    S: Scheduler<T> + ?Sized,
+{
+    type Meta = S::Meta;
+
+    fn update_ready(&mut self, now: Instant) -> Readiness {
+        (**self).update_ready(now)
+    }
+
+    fn take_next(&mut self) -> Option<ScheduledWork<T, S::Meta>> {
+        (**self).take_next()
+    }
+
+    fn on_complete(&mut self, completion: &mut Completion<S::Meta>) {
+        (**self).on_complete(completion);
+    }
+}
+
+pub(crate) mod private {
+    //! Sealed object-safe extension of [`super::Scheduler`] used as the
+    //! runtime's internal root type. Adopts every [`super::Scheduler`] via
+    //! a blanket impl; users never implement it.
+
+    use core::any::Any;
+    use std::time::Instant;
+
+    use super::ScheduledWork;
+    use crate::work::Completion;
+    use crate::work::Readiness;
+    use crate::work::WorkMeta;
+
+    /// Object-safe scheduler view used by the runtime's internal storage.
+    pub trait SchedulerObj<T, M: WorkMeta>: Send + 'static {
+        fn update_ready(&mut self, now: Instant) -> Readiness;
+        fn take_next(&mut self) -> Option<ScheduledWork<T, M>>;
+        fn on_complete(&mut self, completion: &mut Completion<M>);
+        fn as_any(&self) -> &dyn Any;
+        fn as_any_mut(&mut self) -> &mut dyn Any;
+    }
+
+    impl<T, M, S> SchedulerObj<T, M> for S
+    where
+        T: 'static,
+        M: WorkMeta,
+        S: super::Scheduler<T, Meta = M>,
+    {
+        fn update_ready(&mut self, now: Instant) -> Readiness {
+            <Self as super::Scheduler<T>>::update_ready(self, now)
+        }
+        fn take_next(&mut self) -> Option<ScheduledWork<T, M>> {
+            <Self as super::Scheduler<T>>::take_next(self)
+        }
+        fn on_complete(&mut self, completion: &mut Completion<M>) {
+            <Self as super::Scheduler<T>>::on_complete(self, completion);
+        }
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+        fn as_any_mut(&mut self) -> &mut dyn Any {
+            self
+        }
+    }
 }

--- a/dispatcher/src/stats.rs
+++ b/dispatcher/src/stats.rs
@@ -13,75 +13,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Statistics snapshot types.
+//! Point-in-time stats snapshots.
 //!
-//! Snapshots are point-in-time views and do not require atomic reads across
-//! multiple sub-snapshots. The dispatcher reports per-node and runtime-wide
-//! counters; per-node-type policy details (DRR weights, token-bucket levels,
-//! etc.) live with each branch implementation and are inspected through that
-//! impl's own API.
+//! Only runtime-wide aggregates live here; per-node policy details (DRR
+//! weights, token-bucket levels, leaf lag, …) are a scheduler concern,
+//! reachable via [`crate::RuntimeHandle::with_root`].
 
-use core::time::Duration;
-
-use crate::work::NodeId;
-
-/// Per-work statistics owned by the runtime.
-///
-/// The runtime attaches `WorkStats` to every successful and failed work
-/// output. Nodes do not fabricate runtime statistics themselves.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct WorkStats {
-    /// Wall-clock latency between dispatch and completion.
-    pub latency: Duration,
-}
-
-/// Per-node statistics snapshot.
-///
-/// Reported uniformly for every node in the tree (leaves and branches alike).
-/// For branch nodes, the counters aggregate dispatches and completions that
-/// flowed through the node.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct NodeStats {
-    /// Number of work items dispatched through this node.
-    pub dispatched: u64,
-    /// Number of successfully completed work items.
-    pub succeeded: u64,
-    /// Number of failed work items.
-    pub failed: u64,
-    /// Number of work items currently in flight.
-    pub in_flight: u64,
-    /// Lag behind the requested rate (leaf-only; branches report 0).
-    pub missed_intervals: u64,
-    /// Most recently observed actual interval between dispatches
-    /// (leaf-only; branches report `None`).
-    pub actual_interval: Option<Duration>,
-}
-
-/// Top-level runtime statistics snapshot.
+/// Runtime-wide statistics snapshot.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RuntimeStats {
-    /// Number of registered nodes (root + every child in the tree).
-    pub nodes: u64,
-    /// Number of work items currently in flight runtime-wide.
+    /// Items currently in flight.
     pub in_flight: u64,
-    /// Number of work items dispatched runtime-wide.
+    /// Items dispatched since startup.
     pub dispatched: u64,
     /// Output queue stats.
     pub output_queue: OutputQueueStats,
-    /// Per-node snapshots in tree-walk order.
-    pub per_node: Vec<(NodeId, NodeStats)>,
 }
 
-/// Output queue pressure and drop accounting.
-///
-/// Bounded output queues report pressure through a bounded length plus a
-/// dropped-or-rejected count, never through unbounded queue growth.
+/// Output queue pressure and drop accounting. Bounded queues report
+/// pressure as length + drops, never as unbounded growth.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct OutputQueueStats {
-    /// Current number of queued outputs awaiting consumption.
+    /// Outputs currently queued.
     pub queued: usize,
-    /// Configured upper bound on the queue, if any.
+    /// Configured upper bound, if any.
     pub capacity: Option<usize>,
-    /// Number of outputs dropped or rejected due to capacity pressure.
+    /// Outputs dropped or rejected under pressure.
     pub dropped: u64,
 }

--- a/dispatcher/src/work.rs
+++ b/dispatcher/src/work.rs
@@ -13,57 +13,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Data types describing units of work as they flow between the runtime and
-//! [`crate::Scheduler`] nodes.
-//!
-//! Includes:
-//!
-//! - [`CostUnits`] and [`Readiness`] used to negotiate scheduling decisions,
-//! - [`WorkMeta`] attached to every [`crate::ScheduledWork`] item,
-//! - [`WorkCompletion`] and [`CompletionOutcome`] reported back after dispatch,
-//! - [`RoutingPath`] — the per-work breadcrumb stack that lets composable
-//!   branch schedulers forward completions to the originating child without
-//!   any per-branch side tables.
+//! Data types that flow between the runtime and [`crate::Scheduler`] nodes:
+//! readiness, cost, the layered meta model ([`WorkMeta`] + projection traits
+//! + wrappers), the structural [`RoutingPath`], and [`Completion`].
 
+use core::fmt::Debug;
 use core::time::Duration;
 use std::time::Instant;
-use core::fmt::Debug;
-use core::fmt::Display;
-use core::fmt::Formatter;
-use core::fmt::Result as FmtResult;
-
-use crate::WorkStats;
-
-/// Opaque identifier of a scheduler node in the dispatcher tree.
-///
-/// Allocated by the runtime on installation; replaced (not reused) when a
-/// node is removed and another is added.
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct NodeId(u64);
-
-impl NodeId {
-    /// Construct a `NodeId` from the runtime's monotonic allocation counter.
-    pub(crate) const fn from_seq(seq: u64) -> Self {
-        Self(seq)
-    }
-}
-
-impl Debug for NodeId {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        write!(f, "NodeId({})", self.0)
-    }
-}
-
-impl Display for NodeId {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        write!(f, "node:{}", self.0)
-    }
-}
 
 /// Cost units associated with a unit of work.
 ///
-/// `CostUnits` are concrete [`u64`] newtypes. They are not generic; the runtime
-/// uses them to weigh admission, fairness, and per-node/global capacity.
+/// A plain [`u64`] newtype. Cost-aware schedulers read it through the
+/// [`HasCost`] projection on whatever meta their tree carries.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct CostUnits(pub u64);
 
@@ -84,29 +45,23 @@ impl CostUnits {
     }
 }
 
-/// Readiness reported by a [`crate::Scheduler`] node.
+/// Readiness reported by [`crate::Scheduler::update_ready`].
 ///
-/// The runtime invokes [`crate::Scheduler::update_ready`] before selection. A
-/// node that returns `ready: false` is not asked for work in the current
-/// scan. `next_update_at` is an optional hint of when readiness should be
-/// re-evaluated; `next_cost` is an optional hint of the cost of the next work
-/// item (used for admission and fairness calculations).
-///
-/// Branch nodes aggregate child readiness: ready iff any child is ready,
-/// `next_update_at` is the minimum across children, `next_cost` reflects the
-/// branch policy's projected next pick.
+/// `ready: false` means "skip me this scan". `next_update_at` hints when
+/// to re-check; `next_cost` hints the cost of the projected next item
+/// (used for admission and fairness).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct Readiness {
     /// Whether the node currently has work that can be selected.
     pub ready: bool,
-    /// Optional time when readiness should next be re-evaluated.
+    /// Optional time at which readiness should be re-checked.
     pub next_update_at: Option<Instant>,
-    /// Optional cost of the next work item.
+    /// Optional cost of the next item.
     pub next_cost: Option<CostUnits>,
 }
 
 impl Readiness {
-    /// Construct a "ready now" readiness with the given cost hint.
+    /// "Ready now" with optional cost hint.
     #[must_use]
     pub const fn ready(cost: Option<CostUnits>) -> Self {
         Self {
@@ -116,7 +71,7 @@ impl Readiness {
         }
     }
 
-    /// Construct a "not ready" readiness with the given next-update hint.
+    /// "Not ready" with optional next-update hint.
     #[must_use]
     pub const fn not_ready(next_update_at: Option<Instant>) -> Self {
         Self {
@@ -127,150 +82,161 @@ impl Readiness {
     }
 }
 
-/// Per-work routing breadcrumb used by composable branch schedulers.
+/// LIFO stack of child indices that routes a completion back to its
+/// originating leaf.
 ///
-/// Acts as a LIFO stack of child indices recorded as the work travels *up*
-/// through the scheduler tree during [`crate::Scheduler::take_next`], and
-/// consumed in reverse as the completion travels *down* through the tree
-/// during [`crate::Scheduler::on_complete`].
-///
-/// Protocol:
-///
-/// 1. A leaf creates the work with an empty path and never inspects it again.
-/// 2. Each branch on `take_next`, after it has selected child `i` and
-///    received that child's `ScheduledWork`, calls
-///    [`RoutingPath::push`] with `i` on `work.meta.routing` before returning
-///    upward.
-/// 3. The runtime carries the path verbatim through dispatch and copies it
-///    onto the [`WorkCompletion`].
-/// 4. Each branch on `on_complete` pops its own tag with [`RoutingPath::pop`]
-///    and forwards the same `&mut WorkCompletion` to that child's
-///    `on_complete`. The leaf at the bottom finds the path empty.
-///
-/// The runtime itself never inspects the path — it is purely a node-to-node
-/// channel.
-///
-/// Internally backed by a [`Vec`] for the scaffold; later phases may swap to
-/// a small inline buffer (`smallvec`-style) without changing the API.
+/// Branches push their selected child index in `take_next` and pop it in
+/// `on_complete`; leaves see an empty path. The runtime forwards it
+/// verbatim and never inspects it. Backed by [`Vec`] today; later phases
+/// may swap in a small inline buffer without changing the API.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RoutingPath {
     inner: Vec<u32>,
 }
 
 impl RoutingPath {
-    /// Construct an empty routing path. Always the starting state at a leaf.
+    /// Empty path. The starting state at a leaf.
     #[must_use]
     pub const fn empty() -> Self {
         Self { inner: Vec::new() }
     }
 
-    /// Push a child index onto the path. Called by a branch after selecting
-    /// a child during [`crate::Scheduler::take_next`].
+    /// Push the selected child index. Called by a branch in `take_next`.
     pub fn push(&mut self, child_idx: u32) {
         self.inner.push(child_idx);
     }
 
-    /// Pop the most recent child index. Called by a branch at the start of
-    /// [`crate::Scheduler::on_complete`] to recover its own selection.
+    /// Pop the most recent child index. Called by a branch in `on_complete`.
     #[must_use]
     pub fn pop(&mut self) -> Option<u32> {
         self.inner.pop()
     }
 
-    /// Current depth of the path (number of branches that have stamped it).
+    /// Number of branches that have stamped the path.
     #[must_use]
     pub const fn depth(&self) -> usize {
         self.inner.len()
     }
 
-    /// `true` when the path is empty (a leaf has not been reached yet, or the
-    /// completion has been fully forwarded).
+    /// `true` once a leaf is reached (no more branches to forward through).
     #[must_use]
     pub const fn is_empty(&self) -> bool {
         self.inner.is_empty()
     }
 }
 
-/// Metadata attached to a unit of [`crate::ScheduledWork`].
+/// Marker bound for any work-meta type.
 ///
-/// `WorkMeta` is the scheduler-visible projection of a work item. It carries
-/// the cost and the routing breadcrumb stack; the actual work future lives
-/// alongside it inside [`crate::ScheduledWork`].
-#[derive(Debug, Clone)]
-pub struct WorkMeta {
-    /// Cost of this work item, used for admission and fairness.
-    pub cost: CostUnits,
-    /// Routing breadcrumb stack populated by branch schedulers as the work
-    /// travels up to the runtime. See [`RoutingPath`] for the protocol.
-    pub routing: RoutingPath,
+/// `WorkMeta` has no methods; it is a single-name alias for
+/// `Debug + Clone + Send + 'static`. The blanket impl below adopts every
+/// matching type, so users pick a meta (often `()`) without writing any
+/// impls. Policy data lives in *wrappers* that implement *projection
+/// traits* — [`WithCost`] adds [`HasCost`], [`WithPriority`] adds
+/// [`HasPriority`].
+pub trait WorkMeta: Debug + Clone + Send + 'static {}
+
+impl<T: Debug + Clone + Send + 'static> WorkMeta for T {}
+
+/// Projection exposing a [`CostUnits`] value from a meta type.
+pub trait HasCost {
+    /// Cost of the item this meta describes.
+    fn cost(&self) -> CostUnits;
 }
 
-impl WorkMeta {
-    /// Construct minimal work meta with the given cost and an empty routing
-    /// path. Leaves use this; branches mutate `routing` after the fact.
+/// Projection exposing a priority class from a meta type. Higher means
+/// higher priority; the numbering is up to the user.
+pub trait HasPriority {
+    /// Priority class for the item this meta describes.
+    fn priority(&self) -> u8;
+}
+
+/// Adds a [`CostUnits`] annotation on top of any meta `M`. Cost-aware
+/// branches use `WithCost<C::Meta>` as their own `Meta` and supply the
+/// cost in `take_next` from a per-child table.
+#[derive(Debug, Clone)]
+pub struct WithCost<M> {
+    /// Wrapped child meta, carried through unchanged.
+    pub inner: M,
+    /// Cost annotation added at this layer.
+    pub cost: CostUnits,
+}
+
+impl<M> WithCost<M> {
+    /// Wrap a meta with a cost annotation.
     #[must_use]
-    pub const fn with_cost(cost: CostUnits) -> Self {
-        Self {
-            cost,
-            routing: RoutingPath::empty(),
-        }
+    pub const fn new(inner: M, cost: CostUnits) -> Self {
+        Self { inner, cost }
     }
 }
 
-/// Outcome of a single work item, reported back through the scheduler tree.
+impl<M> HasCost for WithCost<M> {
+    fn cost(&self) -> CostUnits {
+        self.cost
+    }
+}
+
+impl<M: HasPriority> HasPriority for WithCost<M> {
+    fn priority(&self) -> u8 {
+        self.inner.priority()
+    }
+}
+
+/// Adds a priority annotation on top of any meta `M`. Priority-aware
+/// branches use `WithPriority<C::Meta>` as their own `Meta` and supply
+/// the priority in `take_next` from a per-child table.
+#[derive(Debug, Clone)]
+pub struct WithPriority<M> {
+    /// Wrapped child meta, carried through unchanged.
+    pub inner: M,
+    /// Priority annotation added at this layer.
+    pub priority: u8,
+}
+
+impl<M> WithPriority<M> {
+    /// Wrap a meta with a priority annotation.
+    #[must_use]
+    pub const fn new(inner: M, priority: u8) -> Self {
+        Self { inner, priority }
+    }
+}
+
+impl<M> HasPriority for WithPriority<M> {
+    fn priority(&self) -> u8 {
+        self.priority
+    }
+}
+
+impl<M: HasCost> HasCost for WithPriority<M> {
+    fn cost(&self) -> CostUnits {
+        self.inner.cost()
+    }
+}
+
+/// Success-or-failure outcome reported through the scheduler tree.
+/// Application events and errors flow separately through
+/// [`crate::RuntimeOutput::Work`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CompletionOutcome {
-    /// The work future returned `Ok`.
+    /// `Ok(_)` from the work payload.
     Succeeded,
-    /// The work future returned `Err`.
+    /// `Err(_)` from the work payload.
     Failed,
 }
 
-/// Completion summary delivered to [`crate::Scheduler::on_complete`].
+/// Completion delivered to [`crate::Scheduler::on_complete`], exactly once
+/// per dispatched item.
 ///
-/// Reported exactly once per dispatched work item. The runtime owns this
-/// struct; branches mutate `routing` in place as they pop their tag and
-/// forward to children, so the signature uses `&mut WorkCompletion`.
-///
-/// `node_id` is the id of the *root* node the work was dispatched under.
-/// Internal leaf identity (if any) is recovered by following `routing`.
+/// Branches mutate it in place: pop their tag from `routing`, read their
+/// layer off `meta`, then forward a `&mut Completion<C::Meta>` built from
+/// the unwrapped meta to the chosen child.
 #[derive(Debug, Clone)]
-pub struct WorkCompletion {
-    /// The root node the work was dispatched under.
-    pub node_id: NodeId,
-    /// Whether the work succeeded or failed.
+pub struct Completion<M: WorkMeta> {
+    /// Success or failure.
     pub outcome: CompletionOutcome,
-    /// Cost reported by the originating leaf at dispatch time.
-    pub cost: CostUnits,
     /// Wall-clock latency between dispatch and completion.
     pub latency: Duration,
-    /// Routing breadcrumb stack copied from the dispatched work. Branches
-    /// pop their own tag and forward to the indicated child.
+    /// Layered meta as observed at this point in the tree.
+    pub meta: M,
+    /// Routing breadcrumb copied from the dispatched item.
     pub routing: RoutingPath,
 }
-
-/// Successful work output: a vector of events with runtime-owned stats.
-///
-/// Multiple events from one work item preserve order. An empty event vector
-/// is allowed and still constitutes a successful output.
-pub struct WorkSuccess<Ev> {
-    /// Events produced by the work item, in order.
-    pub events: Vec<Ev>,
-    /// Runtime-owned statistics for this work item.
-    pub stats: WorkStats,
-    /// The root node the work was dispatched under.
-    pub node_id: NodeId,
-}
-
-/// Failed work output: the error value plus runtime-owned stats.
-pub struct WorkError<Err> {
-    /// The error returned by the work future.
-    pub error: Err,
-    /// Runtime-owned statistics for this work item.
-    pub stats: WorkStats,
-    /// The root node the work was dispatched under.
-    pub node_id: NodeId,
-}
-
-/// Result alias used inside [`RuntimeOutput::Work`].
-pub type WorkResult<Ev, Err> = Result<WorkSuccess<Ev>, WorkError<Err>>;


### PR DESCRIPTION
Streamlines work, reduces number of types. Makes Scheduler payload generic over T, adds mutability handles to Runtime