### PR TITLE
feat(redfish): add UpdateService upload APIs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
    "examples/event-stream-console",
    "examples/readme-minimal",
    "examples/session-token",
+   "examples/update-multipart",
    "dispatcher",
    "tests"
 ]
@@ -33,6 +34,8 @@ clap_derive = { version = "4.5" }
 sse-stream = { version = "0.2.1" }
 futures-util = { version = "0.3" }
 futures-core = { version = "0.3" }
+futures-io = { version = "0.3" }
+tokio-util = { version = "0.7" }
 http = {version = "1.3"}
 glob = { version = "0.3" }
 prettyplease = { version = "0.2" }

--- a/bmc-http/Cargo.toml
+++ b/bmc-http/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/nv-redfish-bmc-http"
 default = ["reqwest"]
 
 # HTTP client implementations with reqwest
-reqwest = ["dep:reqwest", "dep:serde_path_to_error", "dep:futures-util", "dep:sse-stream"]
+reqwest = ["dep:reqwest", "dep:serde_path_to_error", "dep:futures-util", "dep:sse-stream", "dep:tokio-util"]
 
 [dependencies]
 futures-core = { workspace = true }
@@ -23,6 +23,7 @@ nv-redfish-core = { workspace = true }
 http = { workspace = true }
 reqwest = { workspace = true, optional = true, features = [
     "json",
+    "multipart",
     "rustls-tls",
     "stream",
     "socks"
@@ -31,6 +32,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_path_to_error = { workspace = true, optional = true }
 sse-stream = { workspace = true, optional = true }
+tokio-util = { workspace = true, optional = true, features = ["compat", "io"] }
 url = { workspace = true }
 uuid = { workspace = true, features = ["serde"] }
 time = { workspace = true, features = ["serde", "formatting", "parsing"] }

--- a/bmc-http/src/lib.rs
+++ b/bmc-http/src/lib.rs
@@ -45,7 +45,14 @@ pub mod credentials;
 #[cfg(feature = "reqwest")]
 pub mod reqwest;
 
+use std::collections::HashMap;
+use std::error::Error as StdError;
+use std::future::Future;
+use std::sync::Arc;
+use std::sync::RwLock;
+
 use crate::cache::TypeErasedCarCache;
+
 use http::HeaderMap;
 use nv_redfish_core::query::ExpandQuery;
 use nv_redfish_core::Action;
@@ -58,16 +65,15 @@ use nv_redfish_core::ModificationResponse;
 use nv_redfish_core::ODataETag;
 use nv_redfish_core::ODataId;
 use nv_redfish_core::SessionCreateResponse;
+use nv_redfish_core::UploadReader;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use std::collections::HashMap;
-use std::error::Error as StdError;
-use std::future::Future;
-use std::sync::Arc;
-use std::sync::RwLock;
 use url::Url;
 
 #[doc(inline)]
 pub use credentials::BmcCredentials;
+
+#[doc(inline)]
+pub use nv_redfish_core::MultipartUpdateRequest;
 
 /// HTTP Client trait.
 ///
@@ -112,6 +118,22 @@ pub trait HttpClient: Send + Sync {
         B: Serialize + Send + Sync,
         T: DeserializeOwned + Send + Sync;
 
+    /// Performs an UpdateService multipart upload with credentials and headers.
+    ///
+    /// The request carries `UpdateParameters`, `UpdateFile`, and optional OEM
+    /// multipart parts.
+    fn post_multipart_update<U, V, T>(
+        &self,
+        url: Url,
+        request: MultipartUpdateRequest<'_, U, V>,
+        credentials: &BmcCredentials,
+        custom_headers: &HeaderMap,
+    ) -> impl Future<Output = Result<ModificationResponse<T>, Self::Error>> + Send
+    where
+        U: UploadReader,
+        T: DeserializeOwned + Send + Sync,
+        V: Serialize + Send + Sync;
+
     /// Perform an HTTP PATCH request.
     fn patch<B, T>(
         &self,
@@ -153,7 +175,6 @@ pub trait HttpClient: Send + Sync {
 /// # Type Parameters
 ///
 /// * `C` - The HTTP client implementation to use
-///
 pub struct HttpBmc<C: HttpClient> {
     client: C,
     redfish_endpoint: RedfishEndpoint,
@@ -552,6 +573,31 @@ where
             .post(
                 endpoint_url,
                 params,
+                credentials.as_ref(),
+                &self.custom_headers,
+            )
+            .await
+    }
+
+    async fn multipart_update<U, V, R>(
+        &self,
+        uri: &str,
+        request: MultipartUpdateRequest<'_, U, V>,
+    ) -> Result<ModificationResponse<R>, Self::Error>
+    where
+        U: UploadReader,
+        R: Send + Sync + for<'de> Deserialize<'de>,
+        V: Send + Sync + Serialize,
+    {
+        // MultipartHttpPushUri can be absolute or BMC-relative.
+        // Match existing URI handling before adding auth and headers.
+        let endpoint_url = Url::parse(uri).unwrap_or_else(|_| self.redfish_endpoint.with_path(uri));
+        let credentials = self.read_credentials();
+
+        self.client
+            .post_multipart_update(
+                endpoint_url,
+                request,
                 credentials.as_ref(),
                 &self.custom_headers,
             )

--- a/bmc-http/src/reqwest.rs
+++ b/bmc-http/src/reqwest.rs
@@ -15,26 +15,36 @@
 
 //! Implementation of [`HttpClient`] trait using reqwest crate.
 
+use std::error::Error as StdErr;
+use std::fmt;
+use std::time::Duration;
+
 use crate::BmcCredentials;
 use crate::CacheableError;
 use crate::HttpClient;
+use crate::MultipartUpdateRequest;
+
 use futures_util::StreamExt as _;
-use http::header;
 use http::HeaderMap;
+use http::header;
 use nv_redfish_core::AsyncTask;
 use nv_redfish_core::BoxTryStream;
+use nv_redfish_core::DataStream;
 use nv_redfish_core::ModificationResponse;
 use nv_redfish_core::ODataETag;
 use nv_redfish_core::ODataId;
+use nv_redfish_core::OemMultipartPart;
 use nv_redfish_core::SessionCreateResponse;
-use reqwest::redirect::Policy as RedirectPolicy;
+use nv_redfish_core::UploadReader;
 use reqwest::Client as ReqwestClient;
 use reqwest::Error as ReqwestError;
-use serde::de::DeserializeOwned;
+use reqwest::multipart::Form;
+use reqwest::multipart::Part;
+use reqwest::redirect::Policy as RedirectPolicy;
 use serde::Serialize;
-use std::error::Error as StdError;
-use std::fmt;
-use std::time::Duration;
+use serde::de::DeserializeOwned;
+use tokio_util::compat::FuturesAsyncReadCompatExt as _;
+use tokio_util::io::ReaderStream;
 use url::Url;
 
 /// Errors of reqwest implementation of the HTTP trait.
@@ -61,6 +71,10 @@ pub enum BmcError {
     CacheError(String),
     /// JSON deserialization error.
     DecodeError(serde_json::Error),
+    /// JSON serialization error.
+    EncodeError(serde_json::Error),
+    /// Invalid request error - data in the request didn't pass validation.
+    InvalidRequest(String),
 }
 
 impl From<reqwest::Error> for BmcError {
@@ -107,17 +121,19 @@ impl fmt::Display for BmcError {
             ),
             Self::SseStreamError(e) => write!(f, "SSE stream decode error: {e}"),
             Self::DecodeError(e) => write!(f, "JSON Decode error: {e}"),
+            Self::EncodeError(e) => write!(f, "JSON Encode error: {e}"),
+            Self::InvalidRequest(e) => write!(f, "Invalid request: {e}"),
         }
     }
 }
 
-impl StdError for BmcError {
-    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+impl StdErr for BmcError {
+    fn source(&self) -> Option<&(dyn StdErr + 'static)> {
         match self {
             Self::ReqwestError(e) => Some(e),
             Self::JsonError(e) => Some(e.inner()),
             Self::SseStreamError(e) => Some(e),
-            Self::DecodeError(e) => Some(e),
+            Self::DecodeError(e) | Self::EncodeError(e) => Some(e),
             _ => None,
         }
     }
@@ -264,7 +280,6 @@ impl ClientParams {
 /// This provides a concrete implementation of [`HttpClient`] using the popular
 /// reqwest HTTP client library. It supports all standard HTTP features including
 /// TLS, authentication, and connection pooling.
-///
 #[derive(Clone)]
 pub struct Client {
     client: ReqwestClient,
@@ -681,6 +696,57 @@ impl HttpClient for Client {
         self.handle_modification_response(response).await
     }
 
+    async fn post_multipart_update<U, V, T>(
+        &self,
+        url: Url,
+        update_request: MultipartUpdateRequest<'_, U, V>,
+        credentials: &BmcCredentials,
+        custom_headers: &HeaderMap,
+    ) -> Result<ModificationResponse<T>, Self::Error>
+    where
+        U: UploadReader,
+        T: DeserializeOwned + Send + Sync,
+        V: Serialize + Send + Sync,
+    {
+        let MultipartUpdateRequest {
+            update_parameters,
+            update_stream,
+            oem_parts,
+            upload_timeout,
+        } = update_request;
+
+        // First, check if all OEM parts have valid names.
+        for part in &oem_parts {
+            if !part.is_name_valid() {
+                return Err(BmcError::InvalidRequest(format!(
+                    "OEM part's name `{}` is invalid",
+                    part.name
+                )));
+            }
+        }
+
+        let stream_part = build_stream_part(update_stream, "application/octet-stream")?;
+        let update_parameters_part = build_update_parameters_part(update_parameters)?;
+
+        let mut form = Form::new()
+            .part("UpdateParameters", update_parameters_part)
+            .part("UpdateFile", stream_part);
+
+        for part in oem_parts {
+            let (name, part) = build_oem_part(part)?;
+            form = form.part(name, part);
+        }
+
+        let response = auth_headers(self.client.post(url), credentials)
+            .headers(custom_headers.clone())
+            .multipart(form)
+            .timeout(upload_timeout)
+            .send()
+            .await?;
+
+        self.handle_modification_response(response).await
+    }
+
     async fn sse<T: Send + Sized + for<'de> serde::Deserialize<'de>>(
         &self,
         url: Url,
@@ -720,9 +786,82 @@ impl HttpClient for Client {
     }
 }
 
+fn build_update_parameters_part<V>(update_parameters: &V) -> Result<Part, BmcError>
+where
+    V: Serialize + Send + Sync,
+{
+    Part::bytes(serde_json::to_vec(update_parameters).map_err(BmcError::EncodeError)?)
+        .mime_str("application/json")
+        .map_err(BmcError::ReqwestError)
+}
+
+fn build_stream_part<U>(stream: DataStream<U>, content_type: &'static str) -> Result<Part, BmcError>
+where
+    U: UploadReader,
+{
+    let DataStream {
+        name,
+        reader,
+        content_length,
+    } = stream;
+
+    let body = reqwest::Body::wrap_stream(ReaderStream::new(reader.compat()));
+    let part = match content_length {
+        Some(length) => Part::stream_with_length(body, length),
+        None => Part::stream(body),
+    };
+
+    part.file_name(name)
+        .mime_str(content_type)
+        .map_err(BmcError::ReqwestError)
+}
+
+fn build_oem_part(part: OemMultipartPart) -> Result<(String, Part), BmcError> {
+    let OemMultipartPart {
+        name,
+        reader,
+        content_type,
+        content_length,
+    } = part;
+
+    let body = reqwest::Body::wrap_stream(ReaderStream::new(reader.compat()));
+
+    let mut part = match content_length {
+        Some(length) => Part::stream_with_length(body, length),
+        None => Part::stream(body),
+    };
+
+    if let Some(content_type) = content_type {
+        part = part.mime_str(&content_type)?;
+    }
+
+    Ok((name, part))
+}
+
 #[cfg(test)]
 mod tests {
+    use std::error::Error as StdError;
+
     use super::*;
+
+    use futures_util::io::Cursor;
+    use wiremock::Mock;
+    use wiremock::MockServer;
+    use wiremock::Request;
+    use wiremock::ResponseTemplate;
+    use wiremock::matchers::header;
+    use wiremock::matchers::method;
+    use wiremock::matchers::path;
+
+    #[derive(serde::Serialize)]
+    struct MultipartParameters {
+        #[serde(rename = "ForceUpdate")]
+        force_update: bool,
+
+        #[serde(rename = "Targets")]
+        targets: Vec<String>,
+    }
+
     #[test]
     fn test_cacheable_error_trait() {
         let mock_response = reqwest::Response::from(
@@ -743,5 +882,166 @@ mod tests {
 
         let created_miss = BmcError::cache_miss();
         assert!(matches!(created_miss, BmcError::CacheMiss));
+    }
+
+    #[tokio::test]
+    async fn test_multipart_form_fails_oem_validation() -> Result<(), Box<dyn StdError>> {
+        let mock_server = MockServer::start().await;
+        let upload_path = "/redfish/v1/UpdateService/update-multipart";
+        let task_path = "/redfish/v1/TaskService/Tasks/42";
+
+        Mock::given(method("POST"))
+            .and(path(upload_path))
+            .and(header("authorization", "Basic cm9vdDpwYXNzd29yZA=="))
+            .and(header("X-Upload-Mode", "multipart"))
+            .and(|request: &Request| {
+                multipart_body_contains(request, "firmware.bin", "firmware-bytes")
+            })
+            .respond_with(
+                ResponseTemplate::new(202)
+                    .insert_header("Location", format!("https://bmc.example{task_path}"))
+                    .insert_header("Retry-After", "15"),
+            )
+            .expect(0)
+            .mount(&mock_server)
+            .await;
+
+        let params = MultipartParameters {
+            force_update: true,
+            targets: vec!["/redfish/v1/Systems/1".to_string()],
+        };
+
+        let mut custom_headers = HeaderMap::new();
+        custom_headers.insert("X-Upload-Mode", http::HeaderValue::from_static("multipart"));
+
+        let client = Client::new()?;
+        let credentials = BmcCredentials::new("root".to_string(), "password".to_string());
+
+        //
+        // Invalid OEM part.
+        //
+        let update_stream =
+            DataStream::new("firmware.bin", Cursor::new(b"firmware-bytes".to_vec()))
+                .with_content_length(14);
+
+        // Construction error - fails name validation.
+        let r = OemMultipartPart::new("oemNvidia", Cursor::new(br#"{"Mode":"Rms"}"#.to_vec()));
+        assert!(r.is_err());
+
+        let mut invalid_oem_part =
+            OemMultipartPart::new("OemNvidia", Cursor::new(br#"{"Mode":"Rms"}"#.to_vec()))?
+                .with_content_type("application/json");
+        invalid_oem_part.name = "oemNvidia".to_string();
+
+        let update_request = MultipartUpdateRequest {
+            update_parameters: &params,
+            update_stream,
+            oem_parts: vec![invalid_oem_part],
+            upload_timeout: Duration::from_secs(600),
+        };
+
+        let response = client
+            .post_multipart_update::<_, _, serde_json::Value>(
+                Url::parse(&format!("{}{upload_path}", mock_server.uri()))?,
+                update_request,
+                &credentials,
+                &custom_headers,
+            )
+            .await;
+
+        assert!(response.is_err());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_multipart_form_sends_parts_and_returns_task() -> Result<(), Box<dyn StdError>> {
+        let mock_server = MockServer::start().await;
+        let upload_path = "/redfish/v1/UpdateService/update-multipart";
+        let task_path = "/redfish/v1/TaskService/Tasks/42";
+
+        Mock::given(method("POST"))
+            .and(path(upload_path))
+            .and(header("authorization", "Basic cm9vdDpwYXNzd29yZA=="))
+            .and(header("X-Upload-Mode", "multipart"))
+            .and(|request: &Request| {
+                multipart_body_contains(request, "firmware.bin", "firmware-bytes")
+            })
+            .respond_with(
+                ResponseTemplate::new(202)
+                    .insert_header("Location", format!("https://bmc.example{task_path}"))
+                    .insert_header("Retry-After", "15"),
+            )
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let params = MultipartParameters {
+            force_update: true,
+            targets: vec!["/redfish/v1/Systems/1".to_string()],
+        };
+
+        let mut custom_headers = HeaderMap::new();
+        custom_headers.insert("X-Upload-Mode", http::HeaderValue::from_static("multipart"));
+
+        let client = Client::new()?;
+        let credentials = BmcCredentials::new("root".to_string(), "password".to_string());
+
+        let update_stream =
+            DataStream::new("firmware.bin", Cursor::new(b"firmware-bytes".to_vec()))
+                .with_content_length(14);
+
+        let update_request = MultipartUpdateRequest {
+            update_parameters: &params,
+            update_stream,
+            oem_parts: vec![
+                OemMultipartPart::new("OemNvidia", Cursor::new(br#"{"Mode":"Rms"}"#.to_vec()))?
+                    .with_content_type("application/json"),
+            ],
+            upload_timeout: Duration::from_secs(600),
+        };
+
+        let response = client
+            .post_multipart_update::<_, _, serde_json::Value>(
+                Url::parse(&format!("{}{upload_path}", mock_server.uri()))?,
+                update_request,
+                &credentials,
+                &custom_headers,
+            )
+            .await?;
+
+        let ModificationResponse::Task(task) = response else {
+            return Err(String::from("expected task response").into());
+        };
+
+        assert_eq!(task.id.to_string(), task_path);
+        assert_eq!(task.retry_after_secs, Some(15));
+
+        Ok(())
+    }
+
+    fn multipart_body_contains(request: &Request, file_name: &str, file_body: &str) -> bool {
+        let Some(content_type) = request
+            .headers
+            .get("content-type")
+            .and_then(|value| value.to_str().ok())
+        else {
+            return false;
+        };
+
+        let body = String::from_utf8_lossy(&request.body);
+
+        content_type.starts_with("multipart/form-data; boundary=")
+            && body.contains("name=\"UpdateParameters\"")
+            && body.contains("Content-Type: application/json")
+            && body.contains("\"ForceUpdate\":true")
+            && body.contains("\"Targets\":[\"/redfish/v1/Systems/1\"]")
+            && body.contains("name=\"UpdateFile\"")
+            && body.contains("Content-Type: application/octet-stream")
+            && body.contains(&format!("filename=\"{file_name}\""))
+            && body.contains("name=\"OemNvidia\"")
+            && !body.contains("name=\"OemNvidia\"; filename=")
+            && body.contains("{\"Mode\":\"Rms\"}")
+            && body.contains(file_body)
     }
 }

--- a/bmc-http/tests/reqwest_client_tests.rs
+++ b/bmc-http/tests/reqwest_client_tests.rs
@@ -17,18 +17,37 @@ mod common;
 
 #[cfg(feature = "reqwest")]
 mod reqwest_client_tests {
+    use std::time::Duration;
+
+    use futures_util::io::Cursor;
     use nv_redfish_bmc_http::reqwest::BmcError;
+    use nv_redfish_bmc_http::reqwest::Client;
     use nv_redfish_bmc_http::BmcCredentials;
+    use nv_redfish_bmc_http::CacheSettings;
+    use nv_redfish_bmc_http::HttpBmc;
     use nv_redfish_core::{
         query::{ExpandQuery, FilterQuery},
-        Bmc, ModificationResponse,
+        Bmc, DataStream, ModificationResponse, MultipartUpdateRequest,
     };
+    use serde::Serialize;
+    use url::Url;
     use wiremock::{
         matchers::{body_json, header, method, path, query_param},
         Mock, MockServer, ResponseTemplate,
     };
 
     use crate::common::test_utils::*;
+
+    struct FailingUpdateParameters;
+
+    impl Serialize for FailingUpdateParameters {
+        fn serialize<S>(&self, _: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            Err(serde::ser::Error::custom("serialize failed"))
+        }
+    }
 
     #[tokio::test]
     async fn test_get_request_success() {
@@ -231,6 +250,35 @@ mod reqwest_client_tests {
         assert_eq!(response.location.to_string(), session_path);
         assert_eq!(response.entity.name, names::TEST_SYSTEM);
         assert_eq!(response.entity.value, 999);
+    }
+
+    #[tokio::test]
+    async fn test_multipart_update_reports_encode_errors() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let bmc = HttpBmc::new(
+            Client::new()?,
+            Url::parse("http://127.0.0.1")?,
+            create_test_credentials(),
+            CacheSettings::default(),
+        );
+
+        let request = MultipartUpdateRequest {
+            update_parameters: &FailingUpdateParameters,
+            update_stream: DataStream::new("firmware.bin", Cursor::new(Vec::<u8>::new())),
+            oem_parts: Vec::new(),
+            upload_timeout: Duration::from_secs(600),
+        };
+
+        let result = bmc
+            .multipart_update::<_, _, TestResource>(
+                "/redfish/v1/UpdateService/update-multipart",
+                request,
+            )
+            .await;
+
+        assert!(matches!(result, Err(BmcError::EncodeError(_))));
+
+        Ok(())
     }
 
     #[tokio::test]

--- a/bmc-mock/src/expect.rs
+++ b/bmc-mock/src/expect.rs
@@ -15,11 +15,12 @@
 
 //! Expectations for Bmc Mock.
 
+use std::fmt::Display;
+
 use nv_redfish_core::action::ActionTarget;
 use nv_redfish_core::ODataId;
 use serde_json::from_str;
 use serde_json::Value as JsonValue;
-use std::fmt::Display;
 
 pub type Response<E> = Result<JsonValue, E>;
 
@@ -45,6 +46,13 @@ pub enum ExpectedRequest {
     Action {
         target: ActionTarget,
         request: JsonValue,
+    },
+    /// Expected multipart update.
+    MultipartUpdate {
+        uri: String,
+        request: JsonValue,
+        file_name: String,
+        oem_parts: Vec<String>,
     },
     /// Expected Delete.
     Delete { id: ODataId },
@@ -116,6 +124,45 @@ impl<E> Expect<E> {
             request: ExpectedRequest::Action {
                 target: ActionTarget::new(uri.to_string()),
                 request: from_str(&request.to_string()).expect("invalid json"),
+            },
+            response: Ok(from_str(&response.to_string()).expect("invalid json")),
+        }
+    }
+
+    pub fn multipart_update(
+        uri: impl Display,
+        request: impl Display,
+        file_name: impl Display,
+        response: impl Display,
+    ) -> Self {
+        Expect {
+            request: ExpectedRequest::MultipartUpdate {
+                uri: uri.to_string(),
+                request: from_str(&request.to_string()).expect("invalid json"),
+                file_name: file_name.to_string(),
+                oem_parts: Vec::new(),
+            },
+            response: Ok(from_str(&response.to_string()).expect("invalid json")),
+        }
+    }
+
+    pub fn multipart_update_with_oem_parts<I, P>(
+        uri: impl Display,
+        request: impl Display,
+        file_name: impl Display,
+        oem_parts: I,
+        response: impl Display,
+    ) -> Self
+    where
+        I: IntoIterator<Item = P>,
+        P: Display,
+    {
+        Expect {
+            request: ExpectedRequest::MultipartUpdate {
+                uri: uri.to_string(),
+                request: from_str(&request.to_string()).expect("invalid json"),
+                file_name: file_name.to_string(),
+                oem_parts: oem_parts.into_iter().map(|part| part.to_string()).collect(),
             },
             response: Ok(from_str(&response.to_string()).expect("invalid json")),
         }

--- a/bmc-mock/src/lib.rs
+++ b/bmc-mock/src/lib.rs
@@ -19,20 +19,6 @@ pub mod expect;
 pub use expect::Expect;
 pub use expect::ExpectedRequest;
 
-use nv_redfish_core::action::ActionTarget;
-use nv_redfish_core::query::ExpandQuery;
-use nv_redfish_core::ActionError;
-use nv_redfish_core::Bmc as NvRedfishBmc;
-use nv_redfish_core::EntityTypeRef;
-use nv_redfish_core::Expandable;
-use nv_redfish_core::ModificationResponse;
-use nv_redfish_core::ODataETag;
-use nv_redfish_core::ODataId;
-use nv_redfish_core::SessionCreateResponse;
-use serde::Serialize;
-use serde_json::from_value;
-use serde_json::to_value;
-use serde_json::Error as JsonError;
 use std::collections::VecDeque;
 use std::error::Error as StdError;
 use std::fmt::Display;
@@ -41,6 +27,23 @@ use std::fmt::Result as FmtResult;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::PoisonError;
+
+use nv_redfish_core::action::ActionTarget;
+use nv_redfish_core::query::ExpandQuery;
+use nv_redfish_core::ActionError;
+use nv_redfish_core::Bmc as NvRedfishBmc;
+use nv_redfish_core::EntityTypeRef;
+use nv_redfish_core::Expandable;
+use nv_redfish_core::ModificationResponse;
+use nv_redfish_core::MultipartUpdateRequest;
+use nv_redfish_core::ODataETag;
+use nv_redfish_core::ODataId;
+use nv_redfish_core::SessionCreateResponse;
+use nv_redfish_core::UploadReader;
+use serde::Serialize;
+use serde_json::from_value;
+use serde_json::to_value;
+use serde_json::Error as JsonError;
 
 #[derive(Debug)]
 pub enum Error {
@@ -56,6 +59,7 @@ pub enum Error {
     UnexpectedCreateSession(ODataId, String, ExpectedRequest),
     UnexpectedDelete(ODataId, ExpectedRequest),
     UnexpectedAction(ActionTarget, String, ExpectedRequest),
+    UnexpectedMultipartUpdate(String, String, String, ExpectedRequest),
     UnexpectedStream(String, ExpectedRequest),
 }
 
@@ -102,6 +106,12 @@ impl Display for Error {
                     "unexpected action: {id}; json: {json} expected: {expected:?}"
                 )
             }
+            Self::UnexpectedMultipartUpdate(uri, json, file, expected) => {
+                write!(
+                    f,
+                    "unexpected multipart update: {uri}; json: {json}; file: {file}; expected: {expected:?}"
+                )
+            }
             Self::UnexpectedStream(uri, expected) => {
                 write!(f, "unexpected stream: {uri}; expected: {expected:?}")
             }
@@ -117,9 +127,16 @@ impl Error {
     }
 }
 
-#[derive(Default)]
 pub struct Bmc<E> {
     expect: Mutex<VecDeque<Expect<E>>>,
+}
+
+impl<E> Default for Bmc<E> {
+    fn default() -> Self {
+        Self {
+            expect: Mutex::default(),
+        }
+    }
 }
 
 impl<E> Bmc<E> {
@@ -342,6 +359,64 @@ where
             _ => Err(Error::UnexpectedAction(
                 action.target.clone(),
                 in_request.to_string(),
+                expect.request,
+            )),
+        }
+    }
+
+    async fn multipart_update<U, V, R>(
+        &self,
+        in_uri: &str,
+        update_request: MultipartUpdateRequest<'_, U, V>,
+    ) -> Result<ModificationResponse<R>, Self::Error>
+    where
+        U: UploadReader,
+        R: Send + Sync + for<'de> serde::Deserialize<'de>,
+        V: Send + Sync + Serialize,
+    {
+        let expect = self
+            .expect
+            .lock()
+            .map_err(Error::mutex_lock)?
+            .pop_front()
+            .ok_or(Error::NothingIsExpected)?;
+
+        let MultipartUpdateRequest {
+            update_parameters,
+            update_stream,
+            oem_parts,
+            ..
+        } = update_request;
+        let in_request = to_value(update_parameters).expect("json serializable");
+        let file_name = update_stream.name;
+        let oem_parts = oem_parts
+            .into_iter()
+            .map(|part| part.name)
+            .collect::<Vec<_>>();
+
+        match expect {
+            Expect {
+                request:
+                    ExpectedRequest::MultipartUpdate {
+                        uri,
+                        request,
+                        file_name: expected_file_name,
+                        oem_parts: expected_parts,
+                    },
+                response,
+            } if uri == *in_uri
+                && request == in_request
+                && expected_file_name == file_name
+                && expected_parts == oem_parts =>
+            {
+                let response = response.map_err(|err| Error::ErrorResponse(Box::new(err)))?;
+                let result: R = from_value(response).map_err(Error::BadResponseJson)?;
+                Ok(ModificationResponse::Entity(result))
+            }
+            _ => Err(Error::UnexpectedMultipartUpdate(
+                in_uri.to_string(),
+                in_request.to_string(),
+                file_name,
                 expect.request,
             )),
         }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -12,6 +12,7 @@ documentation = "https://docs.rs/nv-redfish-core"
 
 [dependencies]
 futures-core = { workspace = true }
+futures-io = { workspace = true }
 serde = { workspace = true, features = ["alloc", "derive"] }
 serde_json = { workspace = true, features = [ "std" ] }
 uuid = { workspace = true, features = [ "serde" ] }

--- a/core/src/bmc.rs
+++ b/core/src/bmc.rs
@@ -66,6 +66,9 @@ use std::error::Error as StdError;
 use std::future::Future;
 use std::sync::Arc;
 
+use crate::MultipartUpdateRequest;
+use crate::UploadReader;
+
 /// BMC trait defines access to a Baseboard Management Controller using
 /// the Redfish protocol.
 pub trait Bmc: Send + Sync {
@@ -145,6 +148,17 @@ pub trait Bmc: Send + Sync {
         action: &Action<T, R>,
         params: &T,
     ) -> impl Future<Output = Result<ModificationResponse<R>, Self::Error>> + Send;
+
+    /// POST a Redfish `UpdateService` multipart upload using a named stream.
+    fn multipart_update<U, V, R>(
+        &self,
+        uri: &str,
+        request: MultipartUpdateRequest<'_, U, V>,
+    ) -> impl Future<Output = Result<ModificationResponse<R>, Self::Error>> + Send
+    where
+        U: UploadReader,
+        R: Send + Sync + for<'de> Deserialize<'de>,
+        V: Send + Sync + Serialize;
 
     /// Stream data for the URI.
     ///

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -84,6 +84,8 @@ pub mod nav_property;
 pub mod odata;
 /// Support of redfish queries
 pub mod query;
+/// Upload data types.
+pub mod upload;
 
 use crate::query::ExpandQuery;
 use futures_core::TryStream;
@@ -126,6 +128,18 @@ pub use query::FilterQuery;
 pub use query::ToFilterLiteral;
 #[doc(inline)]
 pub use serde_json::Value as AdditionalProperties;
+#[doc(inline)]
+pub use upload::DataStream;
+#[doc(inline)]
+pub use upload::MultipartUpdateRequest;
+#[doc(inline)]
+pub use upload::OemMultipartPart;
+#[doc(inline)]
+pub use upload::OemMultipartPartNameError;
+#[doc(inline)]
+pub use upload::OemMultipartPartReader;
+#[doc(inline)]
+pub use upload::UploadReader;
 #[doc(inline)]
 pub use uuid::Uuid as EdmGuid;
 

--- a/core/src/upload.rs
+++ b/core/src/upload.rs
@@ -1,0 +1,158 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use core::pin::Pin;
+use std::error::Error as StdError;
+use std::fmt;
+use std::time::Duration;
+
+use futures_io::AsyncRead;
+
+const OEM_PREFIX: &str = "Oem";
+
+/// Async reader accepted by upload methods.
+pub trait UploadReader: AsyncRead + Send + 'static {}
+
+impl<T> UploadReader for T where T: AsyncRead + Send + 'static {}
+
+/// Named data stream accepted by upload methods.
+pub struct DataStream<R> {
+    /// Multipart filename for this stream.
+    pub name: String,
+
+    /// Streamed upload data.
+    pub reader: R,
+
+    /// Known stream length, when available.
+    pub content_length: Option<u64>,
+}
+
+impl<R> DataStream<R> {
+    /// Create a named data stream without a known content length.
+    #[must_use]
+    pub fn new(name: impl Into<String>, reader: R) -> Self {
+        Self {
+            name: name.into(),
+            reader,
+            content_length: None,
+        }
+    }
+
+    /// Attach a known content length.
+    #[must_use]
+    pub const fn with_content_length(mut self, content_length: u64) -> Self {
+        self.content_length = Some(content_length);
+        self
+    }
+}
+
+/// Error returned when an OEM multipart part name is invalid.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OemMultipartPartNameError {
+    /// Invalid multipart part name.
+    pub name: String,
+}
+
+impl fmt::Display for OemMultipartPartNameError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "OEM multipart part name must start with Oem: {}",
+            self.name
+        )
+    }
+}
+
+impl StdError for OemMultipartPartNameError {}
+
+/// Reader type used for OEM multipart form parts.
+pub type OemMultipartPartReader = Pin<Box<dyn AsyncRead + Send + 'static>>;
+
+/// OEM multipart form part.
+pub struct OemMultipartPart {
+    /// Multipart part name.
+    pub name: String,
+
+    /// Streamed part data.
+    pub reader: OemMultipartPartReader,
+
+    /// Optional part content type.
+    pub content_type: Option<String>,
+
+    /// Known part length, when available.
+    pub content_length: Option<u64>,
+}
+
+impl OemMultipartPart {
+    /// Checks if the OEM part name is valid per the spec.
+    #[must_use]
+    pub fn is_name_valid(&self) -> bool {
+        self.name.starts_with(OEM_PREFIX)
+    }
+}
+
+impl OemMultipartPart {
+    /// Create an OEM multipart part.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `name` does not start with `Oem`.
+    pub fn new(
+        name: impl Into<String>,
+        reader: impl UploadReader,
+    ) -> Result<Self, OemMultipartPartNameError> {
+        let name = name.into();
+
+        if !name.starts_with(OEM_PREFIX) {
+            return Err(OemMultipartPartNameError { name });
+        }
+
+        Ok(Self {
+            name,
+            reader: Box::pin(reader),
+            content_type: None,
+            content_length: None,
+        })
+    }
+
+    /// Attach a content type.
+    #[must_use]
+    pub fn with_content_type(mut self, content_type: impl Into<String>) -> Self {
+        self.content_type = Some(content_type.into());
+        self
+    }
+
+    /// Attach a known content length.
+    #[must_use]
+    pub const fn with_content_length(mut self, content_length: u64) -> Self {
+        self.content_length = Some(content_length);
+        self
+    }
+}
+
+/// Multipart `UpdateService` upload request data.
+pub struct MultipartUpdateRequest<'a, U, V> {
+    /// Redfish `UpdateParameters` JSON part.
+    pub update_parameters: &'a V,
+
+    /// Named stream sent as the Redfish `UpdateFile` part.
+    pub update_stream: DataStream<U>,
+
+    /// Optional OEM-defined multipart parts.
+    pub oem_parts: Vec<OemMultipartPart>,
+
+    /// Timeout used only for this upload request.
+    pub upload_timeout: Duration,
+}

--- a/examples/explore-with-dummy-bmc/src/main.rs
+++ b/examples/explore-with-dummy-bmc/src/main.rs
@@ -20,8 +20,9 @@ use std::sync::Arc;
 use futures_util::StreamExt;
 use nv_redfish_core::query::ExpandQuery;
 use nv_redfish_core::{
-    Action, ActionError, Bmc, EntityTypeRef, Expandable, ModificationResponse, NavProperty,
-    ODataETag, ODataId, SessionCreateResponse, Updatable,
+    Action, ActionError, Bmc, EntityTypeRef, Expandable, ModificationResponse,
+    MultipartUpdateRequest, NavProperty, ODataETag, ODataId, SessionCreateResponse, Updatable,
+    UploadReader,
 };
 use redfish_oem_contoso::redfish::contoso_turboencabulator_service::{
     ContosoTurboencabulatorServiceUpdate, TurboencabulatorMode,
@@ -591,6 +592,19 @@ impl Bmc for MockBmc {
     ) -> Result<ModificationResponse<R>, Self::Error> {
         let result: R = serde_json::from_str("null").map_err(Error::ParseError)?;
         Ok(ModificationResponse::Entity(result))
+    }
+
+    async fn multipart_update<U, V, R>(
+        &self,
+        _uri: &str,
+        _request: MultipartUpdateRequest<'_, U, V>,
+    ) -> Result<ModificationResponse<R>, Self::Error>
+    where
+        U: UploadReader,
+        R: Send + Sync + for<'de> Deserialize<'de>,
+        V: Send + Sync + Serialize,
+    {
+        Err(Error::NotSupported)
     }
 
     async fn stream<T: Send + Sized + for<'de> Deserialize<'de> + 'static>(

--- a/examples/update-multipart/Cargo.toml
+++ b/examples/update-multipart/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "update-multipart"
+version.workspace = true
+license.workspace = true
+repository.workspace = true
+readme.workspace = true
+edition.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]
+clap = { workspace = true, features = ["derive"] }
+futures-util = { workspace = true, features = ["io"] }
+nv-redfish = { workspace = true, features = ["bmc-http", "update-service"] }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+url = { workspace = true }

--- a/examples/update-multipart/src/main.rs
+++ b/examples/update-multipart/src/main.rs
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error as StdError;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use clap::Parser;
+use futures_util::io::AllowStdIo;
+use nv_redfish::bmc_http::reqwest::Client;
+use nv_redfish::bmc_http::reqwest::ClientParams;
+use nv_redfish::bmc_http::BmcCredentials;
+use nv_redfish::bmc_http::CacheSettings;
+use nv_redfish::bmc_http::HttpBmc;
+use nv_redfish::core::DataStream;
+use nv_redfish::update_service::MultipartUpdateParameters;
+use nv_redfish::ServiceRoot;
+use url::Url;
+
+#[derive(Debug, Parser)]
+#[command()]
+struct Args {
+    #[arg(long)]
+    bmc: Url,
+
+    #[arg(long)]
+    username: String,
+
+    #[arg(long)]
+    password: String,
+
+    #[arg(long)]
+    file: PathBuf,
+
+    #[arg(long = "target")]
+    targets: Vec<String>,
+
+    #[arg(long, default_value_t = false)]
+    force_update: bool,
+
+    #[arg(long, default_value_t = false)]
+    insecure: bool,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn StdError>> {
+    let args = Args::parse();
+    let client = Client::with_params(ClientParams::new().accept_invalid_certs(args.insecure))?;
+    let bmc = Arc::new(HttpBmc::new(
+        client,
+        args.bmc,
+        BmcCredentials::new(args.username, args.password),
+        CacheSettings::default(),
+    ));
+
+    let root = ServiceRoot::new(Arc::clone(&bmc)).await?;
+    let update_service = root
+        .update_service()
+        .await?
+        .ok_or("BMC did not expose UpdateService")?;
+
+    let firmware = std::fs::File::open(&args.file)?;
+    let content_length = firmware.metadata()?.len();
+    let file_name = args
+        .file
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or("firmware path does not have a valid file name")?
+        .to_string();
+    let update_stream =
+        DataStream::new(file_name, AllowStdIo::new(firmware)).with_content_length(content_length);
+    let parameters = MultipartUpdateParameters::builder()
+        .with_force_update(args.force_update)
+        .with_targets(args.targets)
+        .build();
+
+    let response = update_service
+        .multipart_update_from_reader::<_, _, serde_json::Value>(
+            &parameters,
+            update_stream,
+            Duration::from_secs(1800),
+        )
+        .await?;
+
+    println!("{response:#?}");
+
+    Ok(())
+}

--- a/redfish/Cargo.toml
+++ b/redfish/Cargo.toml
@@ -121,3 +121,7 @@ tagged-types = { workspace = true }
 
 [build-dependencies]
 nv-redfish-csdl-compiler = { workspace = true }
+
+[dev-dependencies]
+nv-redfish-bmc-mock = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/redfish/src/error.rs
+++ b/redfish/src/error.rs
@@ -34,6 +34,9 @@ pub enum Error<B: Bmc> {
     /// Event service does not provide `ServerSentEventUri`
     #[cfg(feature = "event-service")]
     EventServiceServerSentEventUriNotAvailable,
+    /// Update service does not provide `MultipartHttpPushUri`
+    #[cfg(feature = "update-service")]
+    UpdateServiceMultipartHttpPushUriNotAvailable,
     /// Metric definitions are not available for telemetry service
     #[cfg(feature = "telemetry-service")]
     MetricDefinitionsNotAvailable,
@@ -60,6 +63,10 @@ impl<B: Bmc> Display for Error<B> {
             #[cfg(feature = "event-service")]
             Self::EventServiceServerSentEventUriNotAvailable => {
                 write!(f, "Event service does not provide ServerSentEventUri")
+            }
+            #[cfg(feature = "update-service")]
+            Self::UpdateServiceMultipartHttpPushUriNotAvailable => {
+                write!(f, "Update service does not provide MultipartHttpPushUri")
             }
             #[cfg(feature = "telemetry-service")]
             Self::MetricDefinitionsNotAvailable => {

--- a/redfish/src/update_service/mod.rs
+++ b/redfish/src/update_service/mod.rs
@@ -23,16 +23,16 @@ mod software_inventory;
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::core::NavProperty;
-use crate::patch_support::Payload;
-use crate::patch_support::ReadPatchFn;
-use crate::schema::update_service::UpdateService as UpdateServiceSchema;
-use crate::schema::update_service::UpdateServiceSimpleUpdateAction;
 use crate::Error;
 use crate::NvBmc;
 use crate::Resource;
 use crate::ResourceSchema;
 use crate::ServiceRoot;
+use crate::core::NavProperty;
+use crate::patch_support::Payload;
+use crate::patch_support::ReadPatchFn;
+use crate::schema::update_service::UpdateService as UpdateServiceSchema;
+use crate::schema::update_service::UpdateServiceSimpleUpdateAction;
 
 use nv_redfish_core::Bmc;
 use nv_redfish_core::DataStream;
@@ -344,199 +344,5 @@ fn add_default_update_service_name(v: JsonValue) -> JsonValue {
         JsonValue::Object(obj)
     } else {
         v
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use futures_util::io::Cursor;
-    use nv_redfish_bmc_mock::Bmc as MockBmc;
-    use nv_redfish_bmc_mock::Expect;
-    use nv_redfish_core::OemMultipartPart;
-    use serde_json::json;
-    use std::error::Error as StdError;
-    use std::io;
-
-    const UPDATE_SERVICE_URI: &str = "/redfish/v1/UpdateService";
-    const MULTIPART_URI: &str = "/redfish/v1/UpdateService/update-multipart";
-
-    type TestResult = Result<(), Box<dyn StdError>>;
-
-    #[tokio::test]
-    async fn uses_multipart_http_push_uri() -> TestResult {
-        let bmc = Arc::new(MockBmc::<io::Error>::default());
-        bmc.expect(Expect::get("/redfish/v1", service_root_json()));
-        bmc.expect(Expect::get(
-            UPDATE_SERVICE_URI,
-            update_service_json(Some(MULTIPART_URI)),
-        ));
-        bmc.expect(Expect::multipart_update(
-            MULTIPART_URI,
-            json!({
-                "ForceUpdate": true,
-                "Targets": ["/redfish/v1/Systems/1"]
-            }),
-            "firmware.bin",
-            json!({
-                "@odata.id": "/redfish/v1/TaskService/Tasks/42",
-                "Id": "42"
-            }),
-        ));
-
-        let root = ServiceRoot::new(Arc::clone(&bmc)).await?;
-        let update_service = root
-            .update_service()
-            .await?
-            .ok_or("expected update service")?;
-        let parameters = MultipartUpdateParameters::builder()
-            .with_force_update(true)
-            .with_targets(vec!["/redfish/v1/Systems/1".to_string()])
-            .build();
-
-        let response = update_service
-            .multipart_update_from_reader::<_, _, serde_json::Value>(
-                &parameters,
-                DataStream::new("firmware.bin", Cursor::new(b"firmware".to_vec()))
-                    .with_content_length(8),
-                Duration::from_secs(600),
-            )
-            .await?;
-
-        let ModificationResponse::Entity(body) = response else {
-            return Err(String::from("expected entity response").into());
-        };
-
-        assert_eq!(body["@odata.id"], "/redfish/v1/TaskService/Tasks/42");
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn uses_generated_update_parameters_with_oem_parts() -> TestResult {
-        let bmc = Arc::new(MockBmc::<io::Error>::default());
-        bmc.expect(Expect::get("/redfish/v1", service_root_json()));
-        bmc.expect(Expect::get(
-            UPDATE_SERVICE_URI,
-            update_service_json(Some(MULTIPART_URI)),
-        ));
-
-        let oem = crate::schema::resource::OemUpdate {
-            additional_properties: json!({
-                "Nvidia": {
-                    "Mode": "Rms"
-                }
-            }),
-        };
-        let parameters = MultipartUpdateParameters::builder()
-            .with_force_update(true)
-            .with_targets(vec!["/redfish/v1/Systems/1".to_string()])
-            .with_oem(oem)
-            .build();
-
-        let expected_parameters = serde_json::to_value(&parameters)?;
-
-        bmc.expect(Expect::multipart_update_with_oem_parts(
-            MULTIPART_URI,
-            expected_parameters,
-            "firmware.bin",
-            ["OemNvidia"],
-            json!({
-                "@odata.id": "/redfish/v1/TaskService/Tasks/77",
-                "Id": "77"
-            }),
-        ));
-
-        let root = ServiceRoot::new(Arc::clone(&bmc)).await?;
-        let update_service = root
-            .update_service()
-            .await?
-            .ok_or("expected update service")?;
-
-        let request = MultipartUpdateRequest {
-            update_parameters: &parameters,
-            update_stream: DataStream::new("firmware.bin", Cursor::new(b"firmware".to_vec())),
-            oem_parts: vec![OemMultipartPart::new(
-                "OemNvidia",
-                Cursor::new(br#"{"Mode":"Rms"}"#.to_vec()),
-            )?
-            .with_content_type("application/json")],
-            upload_timeout: Duration::from_secs(600),
-        };
-
-        let response = update_service
-            .multipart_update::<_, _, serde_json::Value>(request)
-            .await?;
-
-        let ModificationResponse::Entity(body) = response else {
-            return Err(String::from("expected entity response").into());
-        };
-
-        assert_eq!(body["@odata.id"], "/redfish/v1/TaskService/Tasks/77");
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn requires_multipart_http_push_uri() -> TestResult {
-        let bmc = Arc::new(MockBmc::<io::Error>::default());
-
-        bmc.expect(Expect::get("/redfish/v1", service_root_json()));
-
-        // Multipart uploads must use the service-provided endpoint, so a
-        // missing MultipartHttpPushUri should fail before any upload is sent.
-        bmc.expect(Expect::get(UPDATE_SERVICE_URI, update_service_json(None)));
-
-        let root = ServiceRoot::new(Arc::clone(&bmc)).await?;
-        let update_service = root
-            .update_service()
-            .await?
-            .ok_or("expected update service")?;
-
-        let result = update_service
-            .multipart_update_from_reader::<_, _, serde_json::Value>(
-                &MultipartUpdateParameters::default(),
-                DataStream::new("firmware.bin", Cursor::new(b"firmware".to_vec()))
-                    .with_content_length(8),
-                Duration::from_secs(600),
-            )
-            .await;
-
-        assert!(matches!(
-            result,
-            Err(Error::UpdateServiceMultipartHttpPushUriNotAvailable)
-        ));
-
-        Ok(())
-    }
-
-    fn service_root_json() -> serde_json::Value {
-        json!({
-            "@odata.id": "/redfish/v1",
-            "Id": "RootService",
-            "Name": "Root Service",
-            "Links": {
-                "Sessions": {
-                    "@odata.id": "/redfish/v1/SessionService/Sessions"
-                }
-            },
-            "UpdateService": {
-                "@odata.id": UPDATE_SERVICE_URI
-            }
-        })
-    }
-
-    fn update_service_json(multipart_uri: Option<&str>) -> serde_json::Value {
-        let mut body = json!({
-            "@odata.id": UPDATE_SERVICE_URI,
-            "Id": "UpdateService",
-            "Name": "Update Service"
-        });
-
-        if let Some(multipart_uri) = multipart_uri {
-            body["MultipartHttpPushUri"] = json!(multipart_uri);
-        }
-
-        body
     }
 }

--- a/redfish/src/update_service/mod.rs
+++ b/redfish/src/update_service/mod.rs
@@ -20,6 +20,9 @@
 
 mod software_inventory;
 
+use std::sync::Arc;
+use std::time::Duration;
+
 use crate::core::NavProperty;
 use crate::patch_support::Payload;
 use crate::patch_support::ReadPatchFn;
@@ -30,14 +33,19 @@ use crate::NvBmc;
 use crate::Resource;
 use crate::ResourceSchema;
 use crate::ServiceRoot;
+
 use nv_redfish_core::Bmc;
+use nv_redfish_core::DataStream;
 use nv_redfish_core::ModificationResponse;
+use nv_redfish_core::MultipartUpdateRequest;
+use nv_redfish_core::UploadReader;
 use serde_json::Value as JsonValue;
 use software_inventory::SoftwareInventoryCollection;
-use std::sync::Arc;
 
 #[doc(inline)]
 pub use crate::schema::update_service::TransferProtocolType;
+#[doc(inline)]
+pub use crate::schema::update_service::UpdateParametersUpdate as MultipartUpdateParameters;
 #[doc(inline)]
 pub use software_inventory::SoftwareInventory;
 #[doc(inline)]
@@ -173,8 +181,10 @@ impl<B: Bmc> UpdateService<B> {
     /// * `username` - Optional username for accessing the image URI
     /// * `password` - Optional password for accessing the image URI
     /// * `force_update` - Whether to bypass update policies (e.g., allow downgrade)
-    /// * `stage` - Whether to stage the image for later activation instead of immediate installation
-    /// * `local_image` - An indication of whether the service adds the image to the local image store
+    /// * `stage` - Whether to stage the image for later activation instead of immediate
+    ///   installation
+    /// * `local_image` - An indication of whether the service adds the image to the local image
+    ///   store
     /// * `exclude_targets` - An array of URIs that indicate where not to apply the update image
     ///
     /// # Errors
@@ -223,7 +233,8 @@ impl<B: Bmc> UpdateService<B> {
             .map_err(Error::Bmc)
     }
 
-    /// Start updates that have been previously invoked with an `OperationApplyTime` of `OnStartUpdateRequest`.
+    /// Start updates that have been previously invoked with an `OperationApplyTime` of
+    /// `OnStartUpdateRequest`.
     ///
     /// # Errors
     ///
@@ -242,6 +253,63 @@ impl<B: Bmc> UpdateService<B> {
 
         actions
             .start_update(self.bmc.as_ref())
+            .await
+            .map_err(Error::Bmc)
+    }
+
+    /// Upload a named stream using this service's `MultipartHttpPushUri`.
+    ///
+    /// Prefer the generated [`MultipartUpdateParameters`] type. A generic
+    /// payload is accepted for platform fields that are not generated.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `MultipartHttpPushUri` is absent or the upload fails.
+    pub async fn multipart_update_from_reader<U, V, R>(
+        &self,
+        update_parameters: &V,
+        update_stream: DataStream<U>,
+        upload_timeout: Duration,
+    ) -> Result<ModificationResponse<R>, Error<B>>
+    where
+        U: UploadReader,
+        V: Send + Sync + serde::Serialize,
+        R: Send + Sync + for<'de> serde::Deserialize<'de>,
+    {
+        self.multipart_update(MultipartUpdateRequest {
+            update_parameters,
+            update_stream,
+            oem_parts: Vec::new(),
+            upload_timeout,
+        })
+        .await
+    }
+
+    /// Perform a multipart upload using this service's `MultipartHttpPushUri`.
+    ///
+    /// Use this method when the request needs optional OEM multipart parts.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `MultipartHttpPushUri` is absent or the upload fails.
+    pub async fn multipart_update<U, V, R>(
+        &self,
+        request: MultipartUpdateRequest<'_, U, V>,
+    ) -> Result<ModificationResponse<R>, Error<B>>
+    where
+        U: UploadReader,
+        V: Send + Sync + serde::Serialize,
+        R: Send + Sync + for<'de> serde::Deserialize<'de>,
+    {
+        let multipart_uri = self
+            .data
+            .multipart_http_push_uri
+            .as_ref()
+            .ok_or(Error::UpdateServiceMultipartHttpPushUriNotAvailable)?;
+
+        self.bmc
+            .as_ref()
+            .multipart_update(multipart_uri, request)
             .await
             .map_err(Error::Bmc)
     }
@@ -276,5 +344,199 @@ fn add_default_update_service_name(v: JsonValue) -> JsonValue {
         JsonValue::Object(obj)
     } else {
         v
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures_util::io::Cursor;
+    use nv_redfish_bmc_mock::Bmc as MockBmc;
+    use nv_redfish_bmc_mock::Expect;
+    use nv_redfish_core::OemMultipartPart;
+    use serde_json::json;
+    use std::error::Error as StdError;
+    use std::io;
+
+    const UPDATE_SERVICE_URI: &str = "/redfish/v1/UpdateService";
+    const MULTIPART_URI: &str = "/redfish/v1/UpdateService/update-multipart";
+
+    type TestResult = Result<(), Box<dyn StdError>>;
+
+    #[tokio::test]
+    async fn uses_multipart_http_push_uri() -> TestResult {
+        let bmc = Arc::new(MockBmc::<io::Error>::default());
+        bmc.expect(Expect::get("/redfish/v1", service_root_json()));
+        bmc.expect(Expect::get(
+            UPDATE_SERVICE_URI,
+            update_service_json(Some(MULTIPART_URI)),
+        ));
+        bmc.expect(Expect::multipart_update(
+            MULTIPART_URI,
+            json!({
+                "ForceUpdate": true,
+                "Targets": ["/redfish/v1/Systems/1"]
+            }),
+            "firmware.bin",
+            json!({
+                "@odata.id": "/redfish/v1/TaskService/Tasks/42",
+                "Id": "42"
+            }),
+        ));
+
+        let root = ServiceRoot::new(Arc::clone(&bmc)).await?;
+        let update_service = root
+            .update_service()
+            .await?
+            .ok_or("expected update service")?;
+        let parameters = MultipartUpdateParameters::builder()
+            .with_force_update(true)
+            .with_targets(vec!["/redfish/v1/Systems/1".to_string()])
+            .build();
+
+        let response = update_service
+            .multipart_update_from_reader::<_, _, serde_json::Value>(
+                &parameters,
+                DataStream::new("firmware.bin", Cursor::new(b"firmware".to_vec()))
+                    .with_content_length(8),
+                Duration::from_secs(600),
+            )
+            .await?;
+
+        let ModificationResponse::Entity(body) = response else {
+            return Err(String::from("expected entity response").into());
+        };
+
+        assert_eq!(body["@odata.id"], "/redfish/v1/TaskService/Tasks/42");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn uses_generated_update_parameters_with_oem_parts() -> TestResult {
+        let bmc = Arc::new(MockBmc::<io::Error>::default());
+        bmc.expect(Expect::get("/redfish/v1", service_root_json()));
+        bmc.expect(Expect::get(
+            UPDATE_SERVICE_URI,
+            update_service_json(Some(MULTIPART_URI)),
+        ));
+
+        let oem = crate::schema::resource::OemUpdate {
+            additional_properties: json!({
+                "Nvidia": {
+                    "Mode": "Rms"
+                }
+            }),
+        };
+        let parameters = MultipartUpdateParameters::builder()
+            .with_force_update(true)
+            .with_targets(vec!["/redfish/v1/Systems/1".to_string()])
+            .with_oem(oem)
+            .build();
+
+        let expected_parameters = serde_json::to_value(&parameters)?;
+
+        bmc.expect(Expect::multipart_update_with_oem_parts(
+            MULTIPART_URI,
+            expected_parameters,
+            "firmware.bin",
+            ["OemNvidia"],
+            json!({
+                "@odata.id": "/redfish/v1/TaskService/Tasks/77",
+                "Id": "77"
+            }),
+        ));
+
+        let root = ServiceRoot::new(Arc::clone(&bmc)).await?;
+        let update_service = root
+            .update_service()
+            .await?
+            .ok_or("expected update service")?;
+
+        let request = MultipartUpdateRequest {
+            update_parameters: &parameters,
+            update_stream: DataStream::new("firmware.bin", Cursor::new(b"firmware".to_vec())),
+            oem_parts: vec![OemMultipartPart::new(
+                "OemNvidia",
+                Cursor::new(br#"{"Mode":"Rms"}"#.to_vec()),
+            )?
+            .with_content_type("application/json")],
+            upload_timeout: Duration::from_secs(600),
+        };
+
+        let response = update_service
+            .multipart_update::<_, _, serde_json::Value>(request)
+            .await?;
+
+        let ModificationResponse::Entity(body) = response else {
+            return Err(String::from("expected entity response").into());
+        };
+
+        assert_eq!(body["@odata.id"], "/redfish/v1/TaskService/Tasks/77");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn requires_multipart_http_push_uri() -> TestResult {
+        let bmc = Arc::new(MockBmc::<io::Error>::default());
+
+        bmc.expect(Expect::get("/redfish/v1", service_root_json()));
+
+        // Multipart uploads must use the service-provided endpoint, so a
+        // missing MultipartHttpPushUri should fail before any upload is sent.
+        bmc.expect(Expect::get(UPDATE_SERVICE_URI, update_service_json(None)));
+
+        let root = ServiceRoot::new(Arc::clone(&bmc)).await?;
+        let update_service = root
+            .update_service()
+            .await?
+            .ok_or("expected update service")?;
+
+        let result = update_service
+            .multipart_update_from_reader::<_, _, serde_json::Value>(
+                &MultipartUpdateParameters::default(),
+                DataStream::new("firmware.bin", Cursor::new(b"firmware".to_vec()))
+                    .with_content_length(8),
+                Duration::from_secs(600),
+            )
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(Error::UpdateServiceMultipartHttpPushUriNotAvailable)
+        ));
+
+        Ok(())
+    }
+
+    fn service_root_json() -> serde_json::Value {
+        json!({
+            "@odata.id": "/redfish/v1",
+            "Id": "RootService",
+            "Name": "Root Service",
+            "Links": {
+                "Sessions": {
+                    "@odata.id": "/redfish/v1/SessionService/Sessions"
+                }
+            },
+            "UpdateService": {
+                "@odata.id": UPDATE_SERVICE_URI
+            }
+        })
+    }
+
+    fn update_service_json(multipart_uri: Option<&str>) -> serde_json::Value {
+        let mut body = json!({
+            "@odata.id": UPDATE_SERVICE_URI,
+            "Id": "UpdateService",
+            "Name": "Update Service"
+        });
+
+        if let Some(multipart_uri) = multipart_uri {
+            body["MultipartHttpPushUri"] = json!(multipart_uri);
+        }
+
+        body
     }
 }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -37,6 +37,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 
 [dev-dependencies]
+futures-util = { workspace = true, features = ["io"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 trybuild = { workspace = true }
 

--- a/tests/tests/test-update-service.rs
+++ b/tests/tests/test-update-service.rs
@@ -15,23 +15,35 @@
 
 //! Integration tests of Update Service.
 
+use std::error::Error as StdError;
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures_util::io::Cursor;
+use nv_redfish::update_service::MultipartUpdateParameters;
 use nv_redfish::update_service::UpdateService;
+use nv_redfish::Error;
 use nv_redfish::ServiceRoot;
+use nv_redfish_core::DataStream;
 use nv_redfish_core::EntityTypeRef;
+use nv_redfish_core::ModificationResponse;
+use nv_redfish_core::MultipartUpdateRequest;
 use nv_redfish_core::ODataId;
+use nv_redfish_core::OemMultipartPart;
 use nv_redfish_tests::ami_viking_service_root;
 use nv_redfish_tests::Bmc;
 use nv_redfish_tests::Expect;
 use nv_redfish_tests::ODATA_ID;
 use nv_redfish_tests::ODATA_TYPE;
 use serde_json::json;
-use std::error::Error as StdError;
-use std::sync::Arc;
 use tokio::test;
 
 const UPDATE_SERVICE_DATA_TYPE: &str = "#UpdateService.v1_9_0.UpdateService";
 const SW_INVENTORIES_DATA_TYPE: &str = "#SoftwareInventoryCollection.SoftwareInventoryCollection";
 const SW_INVENTORY_DATA_TYPE: &str = "#SoftwareInventory.v1_4_0.SoftwareInventory";
+
+const UPDATE_SERVICE_URI: &str = "/redfish/v1/UpdateService";
+const MULTIPART_URI: &str = "/redfish/v1/UpdateService/update-multipart";
 
 #[test]
 async fn list_dell_fw_inventores() -> Result<(), Box<dyn StdError>> {
@@ -202,4 +214,184 @@ async fn get_update_service(
         }),
     ));
     Ok(service_root.update_service().await?.unwrap())
+}
+
+#[tokio::test]
+async fn uses_multipart_http_push_uri() -> Result<(), Box<dyn StdError>> {
+    let bmc = Arc::new(Bmc::default());
+
+    bmc.expect(Expect::get("/redfish/v1", service_root_json()));
+    bmc.expect(Expect::get(
+        UPDATE_SERVICE_URI,
+        update_service_json(Some(MULTIPART_URI)),
+    ));
+
+    bmc.expect(Expect::multipart_update(
+        MULTIPART_URI,
+        json!({
+            "ForceUpdate": true,
+            "Targets": ["/redfish/v1/Systems/1"]
+        }),
+        "firmware.bin",
+        json!({
+            "@odata.id": "/redfish/v1/TaskService/Tasks/42",
+            "Id": "42"
+        }),
+    ));
+
+    let root = ServiceRoot::new(Arc::clone(&bmc)).await?;
+    let update_service = root
+        .update_service()
+        .await?
+        .ok_or("expected update service")?;
+    let parameters = MultipartUpdateParameters::builder()
+        .with_force_update(true)
+        .with_targets(vec!["/redfish/v1/Systems/1".to_string()])
+        .build();
+
+    let response = update_service
+        .multipart_update_from_reader::<_, _, serde_json::Value>(
+            &parameters,
+            DataStream::new("firmware.bin", Cursor::new(b"firmware".to_vec()))
+                .with_content_length(8),
+            Duration::from_secs(600),
+        )
+        .await?;
+
+    let ModificationResponse::Entity(body) = response else {
+        return Err(String::from("expected entity response").into());
+    };
+
+    assert_eq!(body["@odata.id"], "/redfish/v1/TaskService/Tasks/42");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn uses_generated_update_parameters_with_oem_parts() -> Result<(), Box<dyn StdError>> {
+    let bmc = Arc::new(Bmc::default());
+
+    bmc.expect(Expect::get("/redfish/v1", service_root_json()));
+    bmc.expect(Expect::get(
+        UPDATE_SERVICE_URI,
+        update_service_json(Some(MULTIPART_URI)),
+    ));
+
+    let oem = nv_redfish::schema::resource::OemUpdate {
+        additional_properties: json!({
+            "Nvidia": {
+                "Mode": "Rms"
+            }
+        }),
+    };
+    let parameters = MultipartUpdateParameters::builder()
+        .with_force_update(true)
+        .with_targets(vec!["/redfish/v1/Systems/1".to_string()])
+        .with_oem(oem)
+        .build();
+
+    let expected_parameters = serde_json::to_value(&parameters)?;
+
+    bmc.expect(Expect::multipart_update_with_oem_parts(
+        MULTIPART_URI,
+        expected_parameters,
+        "firmware.bin",
+        ["OemNvidia"],
+        json!({
+            "@odata.id": "/redfish/v1/TaskService/Tasks/77",
+            "Id": "77"
+        }),
+    ));
+
+    let root = ServiceRoot::new(Arc::clone(&bmc)).await?;
+    let update_service = root
+        .update_service()
+        .await?
+        .ok_or("expected update service")?;
+
+    let request = MultipartUpdateRequest {
+        update_parameters: &parameters,
+        update_stream: DataStream::new("firmware.bin", Cursor::new(b"firmware".to_vec())),
+        oem_parts: vec![OemMultipartPart::new(
+            "OemNvidia",
+            Cursor::new(br#"{"Mode":"Rms"}"#.to_vec()),
+        )?
+        .with_content_type("application/json")],
+        upload_timeout: Duration::from_secs(600),
+    };
+
+    let response = update_service
+        .multipart_update::<_, _, serde_json::Value>(request)
+        .await?;
+
+    let ModificationResponse::Entity(body) = response else {
+        return Err(String::from("expected entity response").into());
+    };
+
+    assert_eq!(body["@odata.id"], "/redfish/v1/TaskService/Tasks/77");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn requires_multipart_http_push_uri() -> Result<(), Box<dyn StdError>> {
+    let bmc = Arc::new(Bmc::default());
+
+    bmc.expect(Expect::get("/redfish/v1", service_root_json()));
+
+    // Multipart uploads must use the service-provided endpoint, so a
+    // missing MultipartHttpPushUri should fail before any upload is sent.
+    bmc.expect(Expect::get(UPDATE_SERVICE_URI, update_service_json(None)));
+
+    let root = ServiceRoot::new(Arc::clone(&bmc)).await?;
+    let update_service = root
+        .update_service()
+        .await?
+        .ok_or("expected update service")?;
+
+    let result = update_service
+        .multipart_update_from_reader::<_, _, serde_json::Value>(
+            &MultipartUpdateParameters::default(),
+            DataStream::new("firmware.bin", Cursor::new(b"firmware".to_vec()))
+                .with_content_length(8),
+            Duration::from_secs(600),
+        )
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(Error::UpdateServiceMultipartHttpPushUriNotAvailable)
+    ));
+
+    Ok(())
+}
+
+fn service_root_json() -> serde_json::Value {
+    json!({
+        "@odata.id": "/redfish/v1",
+        "Id": "RootService",
+        "Name": "Root Service",
+        "Links": {
+            "Sessions": {
+                "@odata.id": "/redfish/v1/SessionService/Sessions"
+            }
+        },
+        "UpdateService": {
+            "@odata.id": UPDATE_SERVICE_URI
+        }
+    })
+}
+
+fn update_service_json(multipart_uri: Option<&str>) -> serde_json::Value {
+    let mut body = json!({
+        "@odata.id": UPDATE_SERVICE_URI,
+        "Id": "UpdateService",
+        "Name": "Update Service"
+    });
+
+    if let Some(multipart_uri) = multipart_uri {
+        body["MultipartHttpPushUri"] = json!(multipart_uri);
+    }
+
+    body
 }


### PR DESCRIPTION
## Description

Adds Redfish UpdateService multipart upload support.

- Extends the BMC and HTTP client traits with multipart UpdateService upload support.
- Streams UpdateFile from any async reader through a named DataStream.
- Uses the generated UpdateParametersUpdate schema type through the MultipartUpdateParameters alias for the normal high-level API.
- Uses the service-provided MultipartHttpPushUri from the UpdateService resource.
- [Spec](https://www.dmtf.org/sites/default/files/standards/documents/DSP0266_1.23.0.html#multipart-http-push-updates) conformant parts including optional OEM parts support.

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes

- [x] This PR contains breaking changes

Adds required methods to `Bmc` and `HttpClient`. Implementations must implement multipart update support.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

Multipart upload is reader/stream-based so callers can provide file-backed streams or other data sources.

Signed-off-by: Jay Zhu <jayzhu@nvidia.com>
