### PR TITLE
csdl-compiler: support complation of complex types by root patterns

### DIFF
--- a/csdl-compiler/src/compiler/mod.rs
+++ b/csdl-compiler/src/compiler/mod.rs
@@ -307,9 +307,32 @@ impl SchemaBundle {
                     .collect::<Vec<_>>()
             }))
             .collect::<Result<Vec<_>, _>>()?;
+
+        let complex_types = self
+            .edmx_docs
+            .iter()
+            .take(self.root_set_threshold.unwrap_or(self.edmx_docs.len()))
+            .flat_map(|edmx| {
+                edmx.data_services.schemas.iter().flat_map(|s| {
+                    s.types.values().filter_map(move |t| {
+                        if let Type::ComplexType(t) = t {
+                            let name = QualifiedName::new(&s.namespace, t.name.inner());
+                            if root_patterns.matches(&name) {
+                                Some(name)
+                            } else {
+                                None
+                            }
+                        } else {
+                            None
+                        }
+                    })
+                })
+            })
+            .collect();
+
         Ok(RootSet {
             entity_types,
-            complex_types: Vec::new(),
+            complex_types,
         })
     }
 

--- a/redfish/features.toml
+++ b/redfish/features.toml
@@ -157,6 +157,9 @@ patterns = [
     "SoftwareInventory.*",
     "SoftwareInventoryCollection.*",
 ]
+root_patterns = [
+    "UpdateService.*.UpdateParameters"
+]
 
 [[features]]
 name = "event-service"

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -40,7 +40,9 @@ fn main() -> Result<(), Error> {
         output: base_output,
         csdls: base_csdls,
         entity_type_patterns: vec![],
-        include_root_patterns: vec![],
+        include_root_patterns: vec!["ServiceRoot.*.RootSetOnlyComplexType"
+            .parse()
+            .expect("valid root-set complex type pattern")],
         rigid_array_patterns: vec!["ServiceRoot.*.ServiceRoot/RigidArrayValues"
             .parse()
             .expect("valid rigid array pattern")],

--- a/tests/schemas/base/schema.xml
+++ b/tests/schemas/base/schema.xml
@@ -123,6 +123,12 @@
         <Property Name="Level2" Type="ServiceRoot.v1_0_0.ComplexTypeLevel2" Nullable="false"/>
       </ComplexType>
 
+      <ComplexType Name="RootSetOnlyComplexType">
+        <Property Name="Value" Type="Edm.String" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+        </Property>
+      </ComplexType>
+
       <ComplexType Name="ComplexTypeLevel2">
         <Property Name="Required" Type="Edm.String" Nullable="false">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>

--- a/tests/tests/tests-base-operations.rs
+++ b/tests/tests/tests-base-operations.rs
@@ -26,6 +26,7 @@ use nv_redfish_tests::base::get_service_root;
 use nv_redfish_tests::base::nav_service_root;
 use nv_redfish_tests::base::redfish::service_root::ActionType;
 use nv_redfish_tests::base::redfish::service_root::ReadOnlyComplexTypeUpdate;
+use nv_redfish_tests::base::redfish::service_root::RootSetOnlyComplexType;
 use nv_redfish_tests::base::redfish::service_root::ServiceRootUpdate;
 use nv_redfish_tests::base::redfish::service_root::TestCollectionMemberCreate;
 use nv_redfish_tests::json_merge;
@@ -886,4 +887,15 @@ async fn enum_unknown_value_falls_back_to_unsupported_value() {
     let serialized =
         serde_json::to_value(ActionType::UnsupportedValue).expect("fallback must serialize");
     assert_eq!(serialized, json!("UnsupportedValue"));
+}
+
+// Check that standalone complex types matched by root set patterns are generated.
+#[test]
+async fn root_set_complex_type_is_generated_test() {
+    let value: RootSetOnlyComplexType = serde_json::from_value(json!({
+        "Value": "root-set complex",
+    }))
+    .expect("root-set complex type must deserialize");
+
+    assert_eq!(value.value, Some("root-set complex".into()));
 }


### PR DESCRIPTION
Add compilation of CSDL complex types not referenced from the type tree that are matched by root pattern. This compilation is needed to support of compilation `UpdateParameters` type defined by UpdateService schema.