### PR TITLE
fix(bmc-http): support typed mutation response bodies

### DIFF
--- a/bmc-http/src/reqwest.rs
+++ b/bmc-http/src/reqwest.rs
@@ -23,6 +23,7 @@ use crate::BmcCredentials;
 use crate::CacheableError;
 use crate::HttpClient;
 use crate::MultipartUpdateRequest;
+use crate::schema::redfish::redfish_error::RedfishError;
 
 use futures_util::StreamExt as _;
 use http::HeaderMap;
@@ -603,12 +604,12 @@ fn inject_etag(etag: &ODataETag, body: &mut serde_json::Value) {
     }
 }
 
+/// DSP0266 7.11, Table 10 allows actions without response bodies to return
+/// an error-shaped success body. Only that body should become Empty.
+#[inline]
 fn is_redfish_success_response(value: &serde_json::Value) -> bool {
-    // DSP0266 7.11, Table 10 allows actions without response bodies to return
-    // an error-shaped success body. Only that body should become Empty.
-    let response: RedfishErrorResponse = match serde::Deserialize::deserialize(value) {
-        Ok(response) => response,
-        Err(_) => return false,
+    let Ok(response) = <RedfishError as serde::Deserialize>::deserialize(value) else {
+        return false;
     };
 
     let code = response.error.code.as_str();
@@ -617,23 +618,14 @@ fn is_redfish_success_response(value: &serde_json::Value) -> bool {
     matches!(message, "Success" | "Created" | "NoOperation")
 }
 
-#[derive(serde::Deserialize)]
-struct RedfishErrorResponse {
-    error: RedfishErrorBody,
-}
-
-#[derive(serde::Deserialize)]
-struct RedfishErrorBody {
-    code: String,
-}
-
+/// Distinguishes no-response callers like () from typed response callers.
+/// The same endpoint can be called with different R types, so only callers
+/// whose R can represent no body may map a success envelope to Empty.
+#[inline]
 fn expects_no_response_body<T>() -> bool
 where
     T: DeserializeOwned,
 {
-    // Distinguish no-response callers like () from typed response callers.
-    // The same endpoint can be called with different R types, so only callers
-    // whose R can represent no body may map a success envelope to Empty.
     serde_json::from_value::<T>(serde_json::Value::Null).is_ok()
 }
 

--- a/bmc-http/src/reqwest.rs
+++ b/bmc-http/src/reqwest.rs
@@ -433,13 +433,12 @@ impl Client {
                         }
                     }
 
-                    // DSP0266 POST action responses:
+                    // Non-empty 200/201 bodies are typed responses selected by the caller.
                     //
-                    // - Schema-defined response bodies "conform to the action response defined in
-                    //   the schema"; they are not required to be Redfish resources with @odata.id.
+                    // - These bodies are not required to be Redfish resources with @odata.id.
                     //
-                    // - Actions without a response body may return "an error response, with a
-                    //   message that indicates success".
+                    // - DSP0266 POST actions with no response body may still return "an error
+                    //   response, with a message that indicates success".
                     return match serde_path_to_error::deserialize(&value) {
                         // Non-empty 200/201 body matched the caller-selected type.
                         Ok(entity) => Ok(ModificationResponse::Entity(entity)),

--- a/bmc-http/src/reqwest.rs
+++ b/bmc-http/src/reqwest.rs
@@ -430,10 +430,31 @@ impl Client {
                         if let Some(etag) = etag {
                             inject_etag(&etag, &mut value);
                         }
-                        return serde_path_to_error::deserialize(value)
-                            .map(ModificationResponse::Entity)
-                            .map_err(BmcError::JsonError);
                     }
+
+                    // DSP0266 POST action responses:
+                    //
+                    // - Schema-defined response bodies "conform to the action response defined in
+                    //   the schema"; they are not required to be Redfish resources with @odata.id.
+                    //
+                    // - Actions without a response body may return "an error response, with a
+                    //   message that indicates success".
+                    return match serde_path_to_error::deserialize(&value) {
+                        // Non-empty 200/201 body matched the caller-selected type.
+                        Ok(entity) => Ok(ModificationResponse::Entity(entity)),
+                        Err(err) => {
+                            if expects_no_response_body::<T>()
+                                && is_redfish_success_response(&value)
+                            {
+                                // No-response action returned a Redfish success envelope.
+                                Ok(ModificationResponse::Empty)
+                            } else {
+                                // The response was successful JSON, but it did
+                                // not match the caller-selected response type.
+                                Err(BmcError::JsonError(err))
+                            }
+                        }
+                    };
                 }
 
                 if let Some(location) = location {
@@ -580,6 +601,40 @@ fn inject_etag(etag: &ODataETag, body: &mut serde_json::Value) {
             .and_modify(|v| *v = etag_value.clone())
             .or_insert(etag_value);
     }
+}
+
+fn is_redfish_success_response(value: &serde_json::Value) -> bool {
+    // DSP0266 7.11, Table 10 allows actions without response bodies to return
+    // an error-shaped success body. Only that body should become Empty.
+    let response: RedfishErrorResponse = match serde::Deserialize::deserialize(value) {
+        Ok(response) => response,
+        Err(_) => return false,
+    };
+
+    let code = response.error.code.as_str();
+    let message = code.rsplit_once('.').map_or(code, |(_, message)| message);
+
+    matches!(message, "Success" | "Created" | "NoOperation")
+}
+
+#[derive(serde::Deserialize)]
+struct RedfishErrorResponse {
+    error: RedfishErrorBody,
+}
+
+#[derive(serde::Deserialize)]
+struct RedfishErrorBody {
+    code: String,
+}
+
+fn expects_no_response_body<T>() -> bool
+where
+    T: DeserializeOwned,
+{
+    // Distinguish no-response callers like () from typed response callers.
+    // The same endpoint can be called with different R types, so only callers
+    // whose R can represent no body may map a success envelope to Empty.
+    serde_json::from_value::<T>(serde_json::Value::Null).is_ok()
 }
 
 fn auth_headers(

--- a/bmc-http/tests/reqwest_client_tests.rs
+++ b/bmc-http/tests/reqwest_client_tests.rs
@@ -25,6 +25,7 @@ mod reqwest_client_tests {
     use nv_redfish_bmc_http::BmcCredentials;
     use nv_redfish_bmc_http::CacheSettings;
     use nv_redfish_bmc_http::HttpBmc;
+    use nv_redfish_bmc_http::HttpClient;
     use nv_redfish_core::{
         query::{ExpandQuery, FilterQuery},
         Bmc, DataStream, ModificationResponse, MultipartUpdateRequest,
@@ -415,6 +416,55 @@ mod reqwest_client_tests {
     }
 
     #[tokio::test]
+    async fn test_http_patch_returns_typed_body_without_odata_id()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let mock_server = MockServer::start().await;
+        let endpoint_path = "/redfish/v1/Oem/Nvidia/TypedPatch";
+
+        let request = UpdateRequest {
+            name: Some("Updated System".to_string()),
+            value: None,
+        };
+
+        let typed_response = ActionResponse {
+            result: "patched".to_string(),
+            success: true,
+        };
+
+        Mock::given(method("PATCH"))
+            .and(path(endpoint_path))
+            .and(body_json(&request))
+            .and(header("authorization", "Basic cm9vdDpwYXNzd29yZA=="))
+            .and(header("If-Match", "abc123"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&typed_response))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = Client::new()?;
+        let credentials = create_test_credentials();
+        let custom_headers = http::HeaderMap::new();
+        let response = client
+            .patch::<UpdateRequest, ActionResponse>(
+                Url::parse(&format!("{}{endpoint_path}", mock_server.uri()))?,
+                create_odata_etag("abc123"),
+                &request,
+                &credentials,
+                &custom_headers,
+            )
+            .await?;
+
+        let ModificationResponse::Entity(body) = response else {
+            return Err(String::from("expected typed response body").into());
+        };
+
+        assert_eq!(body.result, "patched");
+        assert!(body.success);
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_delete_request() {
         let mock_server = MockServer::start().await;
         let resource_path = "/redfish/v1/systems/1";
@@ -436,7 +486,7 @@ mod reqwest_client_tests {
     }
 
     #[tokio::test]
-    async fn test_action_request() {
+    async fn test_action_request() -> Result<(), Box<dyn std::error::Error>> {
         let mock_server = MockServer::start().await;
         let action_path = "/redfish/v1/systems/1/Actions/ComputerSystem.Reset";
 
@@ -461,10 +511,118 @@ mod reqwest_client_tests {
         let bmc = create_test_bmc(&mock_server);
 
         let action = create_test_action(action_path);
-        let result = bmc.action(&action, &action_request).await;
+        let response = bmc.action(&action, &action_request).await?;
 
-        assert!(result.is_ok());
-        assert!(matches!(result.unwrap(), ModificationResponse::Empty));
+        let ModificationResponse::Entity(action_response) = response else {
+            return Err(String::from("expected typed response body").into());
+        };
+
+        assert_eq!(action_response.result, "Reset initiated");
+        assert!(action_response.success);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_action_success_message_with_response_type_is_error()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let mock_server = MockServer::start().await;
+        let action_path = "/redfish/v1/systems/1/Actions/ComputerSystem.Reset";
+
+        let action_request = ActionRequest {
+            parameter: "ForceRestart".to_string(),
+        };
+
+        let success_body = serde_json::json!({
+            "error": {
+                "code": "Base.1.8.Success",
+                "message": "Successfully Completed Request"
+            }
+        });
+
+        Mock::given(method("POST"))
+            .and(path(action_path))
+            .and(body_json(&action_request))
+            .and(header("authorization", "Basic cm9vdDpwYXNzd29yZA=="))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&success_body))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let bmc = create_test_bmc(&mock_server);
+
+        let action = create_test_action(action_path);
+        let response = bmc.action(&action, &action_request).await;
+
+        assert!(matches!(response, Err(BmcError::JsonError(_))));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_action_request_empty_body_returns_empty() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let mock_server = MockServer::start().await;
+        let action_path = "/redfish/v1/systems/1/Actions/ComputerSystem.Reset";
+
+        let action_request = ActionRequest {
+            parameter: "ForceRestart".to_string(),
+        };
+
+        Mock::given(method("POST"))
+            .and(path(action_path))
+            .and(body_json(&action_request))
+            .and(header("authorization", "Basic cm9vdDpwYXNzd29yZA=="))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let bmc = create_test_bmc(&mock_server);
+
+        let action = create_test_action(action_path);
+        let response = bmc.action(&action, &action_request).await?;
+
+        assert!(matches!(response, ModificationResponse::Empty));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_action_success_message_without_response_type_returns_empty()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let mock_server = MockServer::start().await;
+        let action_path = "/redfish/v1/systems/1/Actions/ComputerSystem.Reset";
+
+        let action_request = ActionRequest {
+            parameter: "ForceRestart".to_string(),
+        };
+
+        let success_body = serde_json::json!({
+            "error": {
+                "code": "Base.1.8.Success",
+                "message": "Successfully Completed Request"
+            }
+        });
+
+        Mock::given(method("POST"))
+            .and(path(action_path))
+            .and(body_json(&action_request))
+            .and(header("authorization", "Basic cm9vdDpwYXNzd29yZA=="))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&success_body))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let bmc = create_test_bmc(&mock_server);
+        let action: nv_redfish_core::Action<ActionRequest, ()> =
+            serde_json::from_value(serde_json::json!({ "target": action_path }))?;
+
+        let response = bmc.action(&action, &action_request).await?;
+
+        assert!(matches!(response, ModificationResponse::Empty));
+
+        Ok(())
     }
 
     #[tokio::test]


### PR DESCRIPTION
Deserialize non-empty successful POST/PATCH bodies into the caller-selected response type even when the body has no `@odata.id`. This matches DSP0266 7.11, Table 10: action response bodies conform to their schema and are not necessarily Redfish resources.

Keep empty success responses as Empty, Redfish success envelopes as Empty for no-response actions, and 202 Location task handling unchanged.