### PR TITLE
feat(bmc-http): generate Redfish error struct at build time

### DIFF
--- a/bmc-http/Cargo.toml
+++ b/bmc-http/Cargo.toml
@@ -38,7 +38,6 @@ uuid = { workspace = true, features = ["serde"] }
 time = { workspace = true, features = ["serde", "formatting", "parsing"] }
 
 [build-dependencies]
-glob = { workspace = true }
 nv-redfish-csdl-compiler = { workspace = true }
 
 [dev-dependencies]

--- a/bmc-http/Cargo.toml
+++ b/bmc-http/Cargo.toml
@@ -28,7 +28,7 @@ reqwest = { workspace = true, optional = true, features = [
     "stream",
     "socks"
 ] }
-serde = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_path_to_error = { workspace = true, optional = true }
 sse-stream = { workspace = true, optional = true }
@@ -36,6 +36,10 @@ tokio-util = { workspace = true, optional = true, features = ["compat", "io"] }
 url = { workspace = true }
 uuid = { workspace = true, features = ["serde"] }
 time = { workspace = true, features = ["serde", "formatting", "parsing"] }
+
+[build-dependencies]
+glob = { workspace = true }
+nv-redfish-csdl-compiler = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt"] }

--- a/bmc-http/build.rs
+++ b/bmc-http/build.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights
+// reserved. SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,12 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use glob::glob;
 use nv_redfish_csdl_compiler::commands::Commands;
 use nv_redfish_csdl_compiler::commands::process_command;
 use std::env::var;
 use std::error::Error as StdError;
-use std::ffi::OsStr;
 use std::path::PathBuf;
 
 const REDFISH_ERROR_SCHEMA: &str = "RedfishError_v1.xml";
@@ -32,14 +30,19 @@ fn main() -> Result<(), Box<dyn StdError>> {
 
     let out_dir = PathBuf::from(var("OUT_DIR")?);
     let output = out_dir.join("redfish.rs");
-    let redfish_error_schema_name = Some(OsStr::new(REDFISH_ERROR_SCHEMA));
 
     let root_csdls = vec![redfish_schema(REDFISH_ERROR_SCHEMA)];
-    let resolve_csdls = glob(&redfish_schema("*.xml"))?
-        .filter_map(Result::ok)
-        .filter(|path| path.file_name() != redfish_error_schema_name)
-        .map(|path| path.display().to_string())
-        .collect::<Vec<_>>();
+
+    let resolve_csdls = vec![
+        "Settings_v1.xml",
+        "Resource_v1.xml",
+        "Message_v1.xml",
+        "ResolutionStep_v1.xml",
+        "ActionInfo_v1.xml",
+    ]
+    .into_iter()
+    .map(|s| format!("{REDFISH_SCHEMA_DIR}/{s}"))
+    .collect::<Vec<_>>();
 
     for f in root_csdls.iter().chain(resolve_csdls.iter()) {
         println!("cargo:rerun-if-changed={f}");

--- a/bmc-http/build.rs
+++ b/bmc-http/build.rs
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use glob::glob;
+use nv_redfish_csdl_compiler::commands::Commands;
+use nv_redfish_csdl_compiler::commands::process_command;
+use std::env::var;
+use std::error::Error as StdError;
+use std::ffi::OsStr;
+use std::path::PathBuf;
+
+const REDFISH_ERROR_SCHEMA: &str = "RedfishError_v1.xml";
+const REDFISH_SCHEMA_DIR: &str = "../redfish/schemas/redfish-csdl/csdl";
+
+fn main() -> Result<(), Box<dyn StdError>> {
+    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_REQWEST");
+    if var("CARGO_FEATURE_REQWEST").is_err() {
+        return Ok(());
+    }
+
+    let out_dir = PathBuf::from(var("OUT_DIR")?);
+    let output = out_dir.join("redfish.rs");
+    let redfish_error_schema_name = Some(OsStr::new(REDFISH_ERROR_SCHEMA));
+
+    let root_csdls = vec![redfish_schema(REDFISH_ERROR_SCHEMA)];
+    let resolve_csdls = glob(&redfish_schema("*.xml"))?
+        .filter_map(Result::ok)
+        .filter(|path| path.file_name() != redfish_error_schema_name)
+        .map(|path| path.display().to_string())
+        .collect::<Vec<_>>();
+
+    for f in root_csdls.iter().chain(resolve_csdls.iter()) {
+        println!("cargo:rerun-if-changed={f}");
+    }
+
+    process_command(&Commands::CompileOem {
+        output,
+        root_csdls,
+        resolve_csdls,
+        entity_type_patterns: Vec::new(),
+        rigid_array_patterns: Vec::new(),
+    })?;
+
+    Ok(())
+}
+
+fn redfish_schema(file: &str) -> String {
+    format!("{REDFISH_SCHEMA_DIR}/{file}")
+}

--- a/bmc-http/build.rs
+++ b/bmc-http/build.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights
-// reserved. SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bmc-http/src/lib.rs
+++ b/bmc-http/src/lib.rs
@@ -43,6 +43,9 @@ pub mod cache;
 pub mod credentials;
 
 #[cfg(feature = "reqwest")]
+mod schema;
+
+#[cfg(feature = "reqwest")]
 pub mod reqwest;
 
 use std::collections::HashMap;

--- a/bmc-http/src/schema.rs
+++ b/bmc-http/src/schema.rs
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[allow(clippy::absolute_paths)]
+#[allow(clippy::doc_markdown)]
+#[allow(clippy::missing_const_for_fn)]
+#[allow(clippy::option_option)]
+#[allow(clippy::struct_field_names)]
+#[allow(clippy::too_long_first_doc_paragraph)]
+#[allow(dead_code)]
+#[allow(missing_docs)]
+pub mod redfish {
+    include!(concat!(env!("OUT_DIR"), "/redfish.rs"));
+}


### PR DESCRIPTION
The `bmc-http` can use Redfish error in its response deserialization.

Generated code:

```rust
///Generated schema of RedfishError namespace
#[allow(unused_imports)]
pub mod redfish_error {
    use super::super::redfish as redfish;
    use serde::{Serialize, Deserialize};
    use redfish::{
        NavProperty, ODataId, ODataETag, de_optional_nullable, de_required_nullable,
    };
    use redfish::ActionError as _;
    /// The error payload from a Redfish service.
    ///
    /// The Redfish Specification-described type shall contain an error payload from a Redfish service.
    #[derive(Deserialize, Debug)]
    pub struct RedfishError {
        /// The properties that describe an error from a Redfish service.
        ///
        /// This property, as described by the Redfish Specification, shall contain properties that describe an
        /// error from a Redfish service.
        #[serde(rename = "error")]
        pub error: redfish::redfish_error::RedfishErrorContents,
    }
    ///SAFETY: All generated data types are Send
    unsafe impl Send for RedfishError {}
    ///SAFETY: All generated data types are Sync
    unsafe impl Sync for RedfishError {}
    /// The properties that describe an error from a Redfish service.
    ///
    /// The Redfish Specification-described type shall contain properties that describe an error from a
    /// Redfish service.
    #[derive(Deserialize, Debug)]
    pub struct RedfishErrorContents {
        /// A string indicating a specific `MessageId` from a message registry.
        ///
        /// This property shall contain a string indicating a specific `MessageId` from a message registry.
        #[serde(rename = "code")]
        pub code: redfish::edm::String,
        /// A human-readable error message corresponding to the message in a message registry.
        ///
        /// This property shall contain a human-readable error message corresponding to the message in a
        /// message registry.
        #[serde(rename = "message")]
        pub message: redfish::edm::String,
    }
    ///SAFETY: All generated data types are Send
    unsafe impl Send for RedfishErrorContents {}
    ///SAFETY: All generated data types are Sync
    unsafe impl Sync for RedfishErrorContents {}
}
```