### PR TITLE
Session token create should not include auth credentials

### DIFF
--- a/bmc-http/build.rs
+++ b/bmc-http/build.rs
@@ -20,6 +20,7 @@ use std::error::Error as StdError;
 use std::path::PathBuf;
 
 const REDFISH_ERROR_SCHEMA: &str = "RedfishError_v1.xml";
+const REDFISH_MESSAGE_SCHEMA: &str = "Message_v1.xml";
 const REDFISH_SCHEMA_DIR: &str = "../redfish/schemas/redfish-csdl/csdl";
 
 fn main() -> Result<(), Box<dyn StdError>> {
@@ -31,12 +32,11 @@ fn main() -> Result<(), Box<dyn StdError>> {
     let out_dir = PathBuf::from(var("OUT_DIR")?);
     let output = out_dir.join("redfish.rs");
 
-    let root_csdls = vec![redfish_schema(REDFISH_ERROR_SCHEMA)];
+    let root_csdls = vec![redfish_schema(REDFISH_ERROR_SCHEMA), redfish_schema(REDFISH_MESSAGE_SCHEMA)];
 
     let resolve_csdls = vec![
         "Settings_v1.xml",
         "Resource_v1.xml",
-        "Message_v1.xml",
         "ResolutionStep_v1.xml",
         "ActionInfo_v1.xml",
     ]

--- a/bmc-http/src/lib.rs
+++ b/bmc-http/src/lib.rs
@@ -114,7 +114,6 @@ pub trait HttpClient: Send + Sync {
         &self,
         url: Url,
         body: &B,
-        credentials: &BmcCredentials,
         custom_headers: &HeaderMap,
     ) -> impl Future<Output = Result<SessionCreateResponse<T>, Self::Error>> + Send
     where
@@ -526,9 +525,8 @@ where
         v: &V,
     ) -> Result<SessionCreateResponse<R>, Self::Error> {
         let endpoint_url = self.redfish_endpoint.with_path(&id.to_string());
-        let credentials = self.read_credentials();
         self.client
-            .post_session(endpoint_url, v, credentials.as_ref(), &self.custom_headers)
+            .post_session(endpoint_url, v, &self.custom_headers)
             .await
     }
 

--- a/bmc-http/src/reqwest.rs
+++ b/bmc-http/src/reqwest.rs
@@ -19,15 +19,16 @@ use std::error::Error as StdErr;
 use std::fmt;
 use std::time::Duration;
 
+use crate::schema::redfish::message::Message;
+use crate::schema::redfish::redfish_error::RedfishError;
 use crate::BmcCredentials;
 use crate::CacheableError;
 use crate::HttpClient;
 use crate::MultipartUpdateRequest;
-use crate::schema::redfish::redfish_error::RedfishError;
 
 use futures_util::StreamExt as _;
-use http::HeaderMap;
 use http::header;
+use http::HeaderMap;
 use nv_redfish_core::AsyncTask;
 use nv_redfish_core::BoxTryStream;
 use nv_redfish_core::DataStream;
@@ -37,13 +38,13 @@ use nv_redfish_core::ODataId;
 use nv_redfish_core::OemMultipartPart;
 use nv_redfish_core::SessionCreateResponse;
 use nv_redfish_core::UploadReader;
-use reqwest::Client as ReqwestClient;
-use reqwest::Error as ReqwestError;
 use reqwest::multipart::Form;
 use reqwest::multipart::Part;
 use reqwest::redirect::Policy as RedirectPolicy;
-use serde::Serialize;
+use reqwest::Client as ReqwestClient;
+use reqwest::Error as ReqwestError;
 use serde::de::DeserializeOwned;
+use serde::Serialize;
 use tokio_util::compat::FuturesAsyncReadCompatExt as _;
 use tokio_util::io::ReaderStream;
 use url::Url;
@@ -443,9 +444,7 @@ impl Client {
                         // Non-empty 200/201 body matched the caller-selected type.
                         Ok(entity) => Ok(ModificationResponse::Entity(entity)),
                         Err(err) => {
-                            if expects_no_response_body::<T>()
-                                && is_redfish_success_response(&value)
-                            {
+                            if is_redfish_success_response(&value) {
                                 // No-response action returned a Redfish success envelope.
                                 Ok(ModificationResponse::Empty)
                             } else {
@@ -607,6 +606,17 @@ fn inject_etag(etag: &ODataETag, body: &mut serde_json::Value) {
 /// an error-shaped success body. Only that body should become Empty.
 #[inline]
 fn is_redfish_success_response(value: &serde_json::Value) -> bool {
+    #[derive(serde::Deserialize)]
+    struct ExtendedInfoEnvelope {
+        #[serde(rename = "@Message.ExtendedInfo")]
+        _extended_info: Vec<Message>,
+    }
+
+    // If we recieved extended info, this means we got a success response
+    if <ExtendedInfoEnvelope as serde::Deserialize>::deserialize(value).is_ok() {
+        return true;
+    }
+
     let Ok(response) = <RedfishError as serde::Deserialize>::deserialize(value) else {
         return false;
     };
@@ -615,17 +625,6 @@ fn is_redfish_success_response(value: &serde_json::Value) -> bool {
     let message = code.rsplit_once('.').map_or(code, |(_, message)| message);
 
     matches!(message, "Success" | "Created" | "NoOperation")
-}
-
-/// Distinguishes no-response callers like () from typed response callers.
-/// The same endpoint can be called with different R types, so only callers
-/// whose R can represent no body may map a success envelope to Empty.
-#[inline]
-fn expects_no_response_body<T>() -> bool
-where
-    T: DeserializeOwned,
-{
-    serde_json::from_value::<T>(serde_json::Value::Null).is_ok()
 }
 
 fn auth_headers(
@@ -688,14 +687,15 @@ impl HttpClient for Client {
         &self,
         url: Url,
         body: &B,
-        credentials: &BmcCredentials,
         custom_headers: &HeaderMap,
     ) -> Result<SessionCreateResponse<T>, Self::Error>
     where
         B: Serialize + Send + Sync,
         T: DeserializeOwned + Send + Sync,
     {
-        let response = auth_headers(self.client.post(url), credentials)
+        let response = self
+            .client
+            .post(url)
             .headers(custom_headers.clone())
             .json(body)
             .send()
@@ -891,13 +891,13 @@ mod tests {
     use super::*;
 
     use futures_util::io::Cursor;
+    use wiremock::matchers::header;
+    use wiremock::matchers::method;
+    use wiremock::matchers::path;
     use wiremock::Mock;
     use wiremock::MockServer;
     use wiremock::Request;
     use wiremock::ResponseTemplate;
-    use wiremock::matchers::header;
-    use wiremock::matchers::method;
-    use wiremock::matchers::path;
 
     #[derive(serde::Serialize)]
     struct MultipartParameters {
@@ -1040,10 +1040,11 @@ mod tests {
         let update_request = MultipartUpdateRequest {
             update_parameters: &params,
             update_stream,
-            oem_parts: vec![
-                OemMultipartPart::new("OemNvidia", Cursor::new(br#"{"Mode":"Rms"}"#.to_vec()))?
-                    .with_content_type("application/json"),
-            ],
+            oem_parts: vec![OemMultipartPart::new(
+                "OemNvidia",
+                Cursor::new(br#"{"Mode":"Rms"}"#.to_vec()),
+            )?
+            .with_content_type("application/json")],
             upload_timeout: Duration::from_secs(600),
         };
 

--- a/bmc-http/tests/reqwest_client_tests.rs
+++ b/bmc-http/tests/reqwest_client_tests.rs
@@ -228,7 +228,6 @@ mod reqwest_client_tests {
         Mock::given(method("POST"))
             .and(path(collection_path))
             .and(body_json(&create_request))
-            .and(header("authorization", "Basic cm9vdDpwYXNzd29yZA=="))
             .respond_with(
                 ResponseTemplate::new(201)
                     .insert_header("X-Auth-Token", "session-token-123")
@@ -297,7 +296,6 @@ mod reqwest_client_tests {
         Mock::given(method("POST"))
             .and(path(collection_path))
             .and(body_json(&create_request))
-            .and(header("authorization", "Basic cm9vdDpwYXNzd29yZA=="))
             .respond_with(
                 ResponseTemplate::new(201)
                     .insert_header("Location", session_path)
@@ -333,7 +331,6 @@ mod reqwest_client_tests {
         Mock::given(method("POST"))
             .and(path(collection_path))
             .and(body_json(&create_request))
-            .and(header("authorization", "Basic cm9vdDpwYXNzd29yZA=="))
             .respond_with(
                 ResponseTemplate::new(201)
                     .insert_header("X-Auth-Token", "session-token-123")
@@ -519,42 +516,6 @@ mod reqwest_client_tests {
 
         assert_eq!(action_response.result, "Reset initiated");
         assert!(action_response.success);
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_action_success_message_with_response_type_is_error()
-    -> Result<(), Box<dyn std::error::Error>> {
-        let mock_server = MockServer::start().await;
-        let action_path = "/redfish/v1/systems/1/Actions/ComputerSystem.Reset";
-
-        let action_request = ActionRequest {
-            parameter: "ForceRestart".to_string(),
-        };
-
-        let success_body = serde_json::json!({
-            "error": {
-                "code": "Base.1.8.Success",
-                "message": "Successfully Completed Request"
-            }
-        });
-
-        Mock::given(method("POST"))
-            .and(path(action_path))
-            .and(body_json(&action_request))
-            .and(header("authorization", "Basic cm9vdDpwYXNzd29yZA=="))
-            .respond_with(ResponseTemplate::new(200).set_body_json(&success_body))
-            .expect(1)
-            .mount(&mock_server)
-            .await;
-
-        let bmc = create_test_bmc(&mock_server);
-
-        let action = create_test_action(action_path);
-        let response = bmc.action(&action, &action_request).await;
-
-        assert!(matches!(response, Err(BmcError::JsonError(_))));
 
         Ok(())
     }


### PR DESCRIPTION
We included basic auth headers for session token create API call, which is rejected by some BMC. 

Also removes empty check for success and verifies for extended info on modify.