### PR TITLE
feat(upload): support legacy HttpPushUri uploads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,11 @@ define build-and-test
 	cargo build -p nv-redfish-tests --tests
 	cargo build -p nv-redfish-bmc-mock
 	cargo test $1 -- --no-capture
+	cargo build -p nv-redfish --features update-service-deprecated
+	cargo build -p nv-redfish --features bmc-http,update-service-deprecated
+	cargo test -p nv-redfish-bmc-http --test reqwest_client_tests --features reqwest,update-service-deprecated
+	cargo test -p nv-redfish-tests --test test-update-service --features update-service-deprecated
+	cargo build -p update-multipart --features update-service-deprecated
 	cargo clippy $1
 	cargo build  $1
 	cargo build -p nv-redfish --features computer-systems,bios,boot-options,storages,memory,processors

--- a/bmc-http/Cargo.toml
+++ b/bmc-http/Cargo.toml
@@ -15,6 +15,7 @@ default = ["reqwest"]
 
 # HTTP client implementations with reqwest
 reqwest = ["dep:reqwest", "dep:serde_path_to_error", "dep:futures-util", "dep:sse-stream", "dep:tokio-util"]
+update-service-deprecated = ["nv-redfish-core/update-service-deprecated"]
 
 [dependencies]
 futures-core = { workspace = true }

--- a/bmc-http/src/lib.rs
+++ b/bmc-http/src/lib.rs
@@ -78,6 +78,9 @@ pub use credentials::BmcCredentials;
 #[cfg(feature = "update-service-deprecated")]
 #[doc(inline)]
 pub use nv_redfish_core::HttpPushUriUpdateRequest;
+#[cfg(feature = "update-service-deprecated")]
+#[doc(inline)]
+pub use nv_redfish_core::UploadStream;
 
 #[doc(inline)]
 pub use nv_redfish_core::MultipartUpdateRequest;
@@ -140,7 +143,12 @@ pub trait HttpClient: Send + Sync {
         T: DeserializeOwned + Send + Sync,
         V: Serialize + Send + Sync;
 
-    /// Performs an `UpdateService` raw `HttpPushUri` upload with credentials and headers.
+    /// Performs a deprecated `UpdateService` raw `HttpPushUri` upload with
+    /// credentials and headers.
+    ///
+    /// This supports the deprecated `HttpPushUri` update path that exists in
+    /// the Redfish spec. Prefer multipart update for BMCs that support
+    /// `MultipartHttpPushUri`.
     #[cfg(feature = "update-service-deprecated")]
     fn post_http_push_uri_update<U, T>(
         &self,

--- a/bmc-http/src/lib.rs
+++ b/bmc-http/src/lib.rs
@@ -75,6 +75,10 @@ use url::Url;
 #[doc(inline)]
 pub use credentials::BmcCredentials;
 
+#[cfg(feature = "update-service-deprecated")]
+#[doc(inline)]
+pub use nv_redfish_core::HttpPushUriUpdateRequest;
+
 #[doc(inline)]
 pub use nv_redfish_core::MultipartUpdateRequest;
 
@@ -135,6 +139,19 @@ pub trait HttpClient: Send + Sync {
         U: UploadReader,
         T: DeserializeOwned + Send + Sync,
         V: Serialize + Send + Sync;
+
+    /// Performs an `UpdateService` raw `HttpPushUri` upload with credentials and headers.
+    #[cfg(feature = "update-service-deprecated")]
+    fn post_http_push_uri_update<U, T>(
+        &self,
+        url: Url,
+        request: HttpPushUriUpdateRequest<U>,
+        credentials: &BmcCredentials,
+        custom_headers: &HeaderMap,
+    ) -> impl Future<Output = Result<ModificationResponse<T>, Self::Error>> + Send
+    where
+        U: UploadReader,
+        T: DeserializeOwned + Send + Sync;
 
     /// Perform an HTTP PATCH request.
     fn patch<B, T>(
@@ -597,6 +614,31 @@ where
 
         self.client
             .post_multipart_update(
+                endpoint_url,
+                request,
+                credentials.as_ref(),
+                &self.custom_headers,
+            )
+            .await
+    }
+
+    #[cfg(feature = "update-service-deprecated")]
+    async fn http_push_uri_update<U, R>(
+        &self,
+        uri: &str,
+        request: HttpPushUriUpdateRequest<U>,
+    ) -> Result<ModificationResponse<R>, Self::Error>
+    where
+        U: UploadReader,
+        R: Send + Sync + for<'de> Deserialize<'de>,
+    {
+        // HttpPushUri can be absolute or BMC-relative.
+        // Match existing multipart URI handling before adding auth and headers.
+        let endpoint_url = Url::parse(uri).unwrap_or_else(|_| self.redfish_endpoint.with_path(uri));
+        let credentials = self.read_credentials();
+
+        self.client
+            .post_http_push_uri_update(
                 endpoint_url,
                 request,
                 credentials.as_ref(),

--- a/bmc-http/src/reqwest.rs
+++ b/bmc-http/src/reqwest.rs
@@ -24,6 +24,8 @@ use crate::schema::redfish::redfish_error::RedfishError;
 use crate::BmcCredentials;
 use crate::CacheableError;
 use crate::HttpClient;
+#[cfg(feature = "update-service-deprecated")]
+use crate::HttpPushUriUpdateRequest;
 use crate::MultipartUpdateRequest;
 
 use futures_util::StreamExt as _;
@@ -794,6 +796,45 @@ impl HttpClient for Client {
             .send()
             .await?;
 
+        self.handle_modification_response(response).await
+    }
+
+    #[cfg(feature = "update-service-deprecated")]
+    async fn post_http_push_uri_update<U, T>(
+        &self,
+        url: Url,
+        update_request: HttpPushUriUpdateRequest<U>,
+        credentials: &BmcCredentials,
+        custom_headers: &HeaderMap,
+    ) -> Result<ModificationResponse<T>, Self::Error>
+    where
+        U: UploadReader,
+        T: DeserializeOwned + Send + Sync,
+    {
+        let HttpPushUriUpdateRequest {
+            update_stream,
+            upload_timeout,
+        } = update_request;
+
+        let DataStream {
+            reader,
+            content_length,
+            ..
+        } = update_stream;
+
+        let body = reqwest::Body::wrap_stream(ReaderStream::new(reader.compat()));
+
+        let mut request = auth_headers(self.client.post(url), credentials)
+            .headers(custom_headers.clone())
+            .header(header::CONTENT_TYPE, "application/octet-stream")
+            .body(body)
+            .timeout(upload_timeout);
+
+        if let Some(content_length) = content_length {
+            request = request.header(header::CONTENT_LENGTH, content_length.to_string());
+        }
+
+        let response = request.send().await?;
         self.handle_modification_response(response).await
     }
 

--- a/bmc-http/src/reqwest.rs
+++ b/bmc-http/src/reqwest.rs
@@ -40,6 +40,8 @@ use nv_redfish_core::ODataId;
 use nv_redfish_core::OemMultipartPart;
 use nv_redfish_core::SessionCreateResponse;
 use nv_redfish_core::UploadReader;
+#[cfg(feature = "update-service-deprecated")]
+use nv_redfish_core::UploadStream;
 use reqwest::multipart::Form;
 use reqwest::multipart::Part;
 use reqwest::redirect::Policy as RedirectPolicy;
@@ -816,10 +818,9 @@ impl HttpClient for Client {
             upload_timeout,
         } = update_request;
 
-        let DataStream {
+        let UploadStream {
             reader,
             content_length,
-            ..
         } = update_stream;
 
         let body = reqwest::Body::wrap_stream(ReaderStream::new(reader.compat()));

--- a/bmc-http/tests/reqwest_client_tests.rs
+++ b/bmc-http/tests/reqwest_client_tests.rs
@@ -34,6 +34,8 @@ mod reqwest_client_tests {
     };
     #[cfg(feature = "update-service-deprecated")]
     use nv_redfish_core::HttpPushUriUpdateRequest;
+    #[cfg(feature = "update-service-deprecated")]
+    use nv_redfish_core::UploadStream;
     use serde::Serialize;
     use url::Url;
     use wiremock::{
@@ -315,7 +317,7 @@ mod reqwest_client_tests {
 
         let bmc = create_test_bmc_with_custom_headers(&mock_server, custom_headers);
         let request = HttpPushUriUpdateRequest {
-            update_stream: DataStream::new("firmware.bin", Cursor::new(b"firmware-bytes".to_vec()))
+            update_stream: UploadStream::new(Cursor::new(b"firmware-bytes".to_vec()))
                 .with_content_length(14),
             upload_timeout: Duration::from_secs(600),
         };
@@ -356,7 +358,7 @@ mod reqwest_client_tests {
             BmcCredentials::token("session-token".to_string()),
         );
         let request = HttpPushUriUpdateRequest {
-            update_stream: DataStream::new("firmware.bin", Cursor::new(b"firmware-bytes".to_vec())),
+            update_stream: UploadStream::new(Cursor::new(b"firmware-bytes".to_vec())),
             upload_timeout: Duration::from_secs(600),
         };
         let upload_url = format!("{}{upload_path}", mock_server.uri());
@@ -385,7 +387,7 @@ mod reqwest_client_tests {
 
         let bmc = create_test_bmc(&mock_server);
         let request = HttpPushUriUpdateRequest {
-            update_stream: DataStream::new("firmware.bin", Cursor::new(b"firmware-bytes".to_vec()))
+            update_stream: UploadStream::new(Cursor::new(b"firmware-bytes".to_vec()))
                 .with_content_length(14),
             upload_timeout: Duration::from_secs(600),
         };
@@ -444,7 +446,7 @@ mod reqwest_client_tests {
             CacheSettings::default(),
         );
         let request = HttpPushUriUpdateRequest {
-            update_stream: DataStream::new("firmware.bin", Cursor::new(b"firmware-bytes".to_vec())),
+            update_stream: UploadStream::new(Cursor::new(b"firmware-bytes".to_vec())),
             upload_timeout: Duration::from_secs(2),
         };
 

--- a/bmc-http/tests/reqwest_client_tests.rs
+++ b/bmc-http/tests/reqwest_client_tests.rs
@@ -22,6 +22,8 @@ mod reqwest_client_tests {
     use futures_util::io::Cursor;
     use nv_redfish_bmc_http::reqwest::BmcError;
     use nv_redfish_bmc_http::reqwest::Client;
+    #[cfg(feature = "update-service-deprecated")]
+    use nv_redfish_bmc_http::reqwest::ClientParams;
     use nv_redfish_bmc_http::BmcCredentials;
     use nv_redfish_bmc_http::CacheSettings;
     use nv_redfish_bmc_http::HttpBmc;
@@ -30,12 +32,16 @@ mod reqwest_client_tests {
         query::{ExpandQuery, FilterQuery},
         Bmc, DataStream, ModificationResponse, MultipartUpdateRequest,
     };
+    #[cfg(feature = "update-service-deprecated")]
+    use nv_redfish_core::HttpPushUriUpdateRequest;
     use serde::Serialize;
     use url::Url;
     use wiremock::{
         matchers::{body_json, header, method, path, query_param},
         Mock, MockServer, ResponseTemplate,
     };
+    #[cfg(feature = "update-service-deprecated")]
+    use wiremock::Request;
 
     use crate::common::test_utils::*;
 
@@ -277,6 +283,184 @@ mod reqwest_client_tests {
             .await;
 
         assert!(matches!(result, Err(BmcError::EncodeError(_))));
+
+        Ok(())
+    }
+
+    #[cfg(feature = "update-service-deprecated")]
+    #[tokio::test]
+    async fn http_push_uri_relative_task() -> Result<(), Box<dyn std::error::Error>> {
+        let mock_server = MockServer::start().await;
+        let upload_path = "/redfish/v1/UpdateService/update";
+        let task_path = "/redfish/v1/TaskService/Tasks/42";
+
+        Mock::given(method("POST"))
+            .and(path(upload_path))
+            .and(header("authorization", "Basic cm9vdDpwYXNzd29yZA=="))
+            .and(header("X-Upload-Mode", "raw"))
+            .and(header("content-type", "application/octet-stream"))
+            .and(header("content-length", "14"))
+            .and(|request: &Request| request.body == b"firmware-bytes")
+            .respond_with(
+                ResponseTemplate::new(202)
+                    .insert_header("Location", format!("https://bmc.example{task_path}"))
+                    .insert_header("Retry-After", "15"),
+            )
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let mut custom_headers = http::HeaderMap::new();
+        custom_headers.insert("X-Upload-Mode", http::HeaderValue::from_static("raw"));
+
+        let bmc = create_test_bmc_with_custom_headers(&mock_server, custom_headers);
+        let request = HttpPushUriUpdateRequest {
+            update_stream: DataStream::new("firmware.bin", Cursor::new(b"firmware-bytes".to_vec()))
+                .with_content_length(14),
+            upload_timeout: Duration::from_secs(600),
+        };
+
+        let response = bmc
+            .http_push_uri_update::<_, TestResource>(upload_path, request)
+            .await?;
+
+        let ModificationResponse::Task(task) = response else {
+            return Err(String::from("expected task response").into());
+        };
+
+        assert_eq!(task.location.0.to_string(), task_path);
+        assert_eq!(task.retry_after, Some(Duration::from_secs(15)));
+
+        Ok(())
+    }
+
+    #[cfg(feature = "update-service-deprecated")]
+    #[tokio::test]
+    async fn http_push_uri_absolute_token_empty() -> Result<(), Box<dyn std::error::Error>> {
+        let mock_server = MockServer::start().await;
+        let upload_path = "/redfish/v1/UpdateService/update";
+
+        Mock::given(method("POST"))
+            .and(path(upload_path))
+            .and(header("X-Auth-Token", "session-token"))
+            .and(header("content-type", "application/octet-stream"))
+            .and(|request: &Request| !request.headers.contains_key("content-length"))
+            .and(|request: &Request| request.body == b"firmware-bytes")
+            .respond_with(ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let bmc = create_test_bmc_with_credentials(
+            &mock_server,
+            BmcCredentials::token("session-token".to_string()),
+        );
+        let request = HttpPushUriUpdateRequest {
+            update_stream: DataStream::new("firmware.bin", Cursor::new(b"firmware-bytes".to_vec())),
+            upload_timeout: Duration::from_secs(600),
+        };
+        let upload_url = format!("{}{upload_path}", mock_server.uri());
+
+        let response = bmc
+            .http_push_uri_update::<_, ()>(&upload_url, request)
+            .await?;
+
+        assert!(matches!(response, ModificationResponse::Empty));
+
+        Ok(())
+    }
+
+    #[cfg(feature = "update-service-deprecated")]
+    #[tokio::test]
+    async fn http_push_uri_error_response() -> Result<(), Box<dyn std::error::Error>> {
+        let mock_server = MockServer::start().await;
+        let upload_path = "/redfish/v1/UpdateService/update";
+
+        Mock::given(method("POST"))
+            .and(path(upload_path))
+            .respond_with(ResponseTemplate::new(500).set_body_string("upload failed"))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let bmc = create_test_bmc(&mock_server);
+        let request = HttpPushUriUpdateRequest {
+            update_stream: DataStream::new("firmware.bin", Cursor::new(b"firmware-bytes".to_vec()))
+                .with_content_length(14),
+            upload_timeout: Duration::from_secs(600),
+        };
+
+        let result = bmc
+            .http_push_uri_update::<_, ()>(upload_path, request)
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(BmcError::InvalidResponse { status, .. }) if status.as_u16() == 500
+        ));
+
+        Ok(())
+    }
+
+    #[cfg(feature = "update-service-deprecated")]
+    #[tokio::test]
+    async fn http_push_uri_timeout_scoped() -> Result<(), Box<dyn std::error::Error>> {
+        let mock_server = MockServer::start().await;
+        let upload_path = "/redfish/v1/UpdateService/update";
+        let resource_path = paths::SYSTEMS_1;
+        let delayed_response = Duration::from_millis(200);
+
+        Mock::given(method("POST"))
+            .and(path(upload_path))
+            .and(header("authorization", "Basic cm9vdDpwYXNzd29yZA=="))
+            .and(|request: &Request| request.body == b"firmware-bytes")
+            .respond_with(ResponseTemplate::new(204).set_delay(delayed_response))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path(resource_path))
+            .and(header("authorization", "Basic cm9vdDpwYXNzd29yZA=="))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_delay(delayed_response)
+                    .set_body_json(create_test_resource(
+                        resource_path,
+                        None,
+                        names::TEST_SYSTEM,
+                        42,
+                    )),
+            )
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = Client::with_params(ClientParams::new().timeout(Duration::from_millis(50)))?;
+        let bmc = HttpBmc::new(
+            client,
+            Url::parse(&mock_server.uri())?,
+            create_test_credentials(),
+            CacheSettings::default(),
+        );
+        let request = HttpPushUriUpdateRequest {
+            update_stream: DataStream::new("firmware.bin", Cursor::new(b"firmware-bytes".to_vec())),
+            upload_timeout: Duration::from_secs(2),
+        };
+
+        let upload = bmc
+            .http_push_uri_update::<_, ()>(upload_path, request)
+            .await?;
+
+        assert!(matches!(upload, ModificationResponse::Empty));
+
+        let resource_id = create_odata_id(resource_path);
+        let get_result = bmc.get::<TestResource>(&resource_id).await;
+        let Err(BmcError::ReqwestError(err)) = get_result else {
+            return Err(String::from("expected default GET timeout").into());
+        };
+
+        assert!(err.is_timeout());
 
         Ok(())
     }

--- a/bmc-mock/Cargo.toml
+++ b/bmc-mock/Cargo.toml
@@ -10,6 +10,10 @@ keywords.workspace = true
 categories.workspace = true
 documentation = "https://docs.rs/nv-redfish-bmc-mock"
 
+[features]
+default = []
+update-service-deprecated = ["nv-redfish-core/update-service-deprecated"]
+
 [dependencies]
 nv-redfish-core = { workspace = true }
 futures-core = { workspace = true }

--- a/bmc-mock/src/expect.rs
+++ b/bmc-mock/src/expect.rs
@@ -54,6 +54,8 @@ pub enum ExpectedRequest {
         file_name: String,
         oem_parts: Vec<String>,
     },
+    /// Expected raw HttpPushUri update.
+    HttpPushUriUpdate { uri: String, file_name: String },
     /// Expected Delete.
     Delete { id: ODataId },
     /// Expected Stream.
@@ -163,6 +165,20 @@ impl<E> Expect<E> {
                 request: from_str(&request.to_string()).expect("invalid json"),
                 file_name: file_name.to_string(),
                 oem_parts: oem_parts.into_iter().map(|part| part.to_string()).collect(),
+            },
+            response: Ok(from_str(&response.to_string()).expect("invalid json")),
+        }
+    }
+
+    pub fn http_push_uri_update(
+        uri: impl Display,
+        file_name: impl Display,
+        response: impl Display,
+    ) -> Self {
+        Expect {
+            request: ExpectedRequest::HttpPushUriUpdate {
+                uri: uri.to_string(),
+                file_name: file_name.to_string(),
             },
             response: Ok(from_str(&response.to_string()).expect("invalid json")),
         }

--- a/bmc-mock/src/expect.rs
+++ b/bmc-mock/src/expect.rs
@@ -55,7 +55,8 @@ pub enum ExpectedRequest {
         oem_parts: Vec<String>,
     },
     /// Expected raw HttpPushUri update.
-    HttpPushUriUpdate { uri: String, file_name: String },
+    #[cfg(feature = "update-service-deprecated")]
+    HttpPushUriUpdate { uri: String },
     /// Expected Delete.
     Delete { id: ODataId },
     /// Expected Stream.
@@ -170,15 +171,11 @@ impl<E> Expect<E> {
         }
     }
 
-    pub fn http_push_uri_update(
-        uri: impl Display,
-        file_name: impl Display,
-        response: impl Display,
-    ) -> Self {
+    #[cfg(feature = "update-service-deprecated")]
+    pub fn http_push_uri_update(uri: impl Display, response: impl Display) -> Self {
         Expect {
             request: ExpectedRequest::HttpPushUriUpdate {
                 uri: uri.to_string(),
-                file_name: file_name.to_string(),
             },
             response: Ok(from_str(&response.to_string()).expect("invalid json")),
         }

--- a/bmc-mock/src/lib.rs
+++ b/bmc-mock/src/lib.rs
@@ -34,6 +34,8 @@ use nv_redfish_core::ActionError;
 use nv_redfish_core::Bmc as NvRedfishBmc;
 use nv_redfish_core::EntityTypeRef;
 use nv_redfish_core::Expandable;
+#[cfg(feature = "update-service-deprecated")]
+use nv_redfish_core::HttpPushUriUpdateRequest;
 use nv_redfish_core::ModificationResponse;
 use nv_redfish_core::MultipartUpdateRequest;
 use nv_redfish_core::ODataETag;
@@ -60,6 +62,7 @@ pub enum Error {
     UnexpectedDelete(ODataId, ExpectedRequest),
     UnexpectedAction(ActionTarget, String, ExpectedRequest),
     UnexpectedMultipartUpdate(String, String, String, ExpectedRequest),
+    UnexpectedHttpPushUriUpdate(String, String, ExpectedRequest),
     UnexpectedStream(String, ExpectedRequest),
 }
 
@@ -110,6 +113,12 @@ impl Display for Error {
                 write!(
                     f,
                     "unexpected multipart update: {uri}; json: {json}; file: {file}; expected: {expected:?}"
+                )
+            }
+            Self::UnexpectedHttpPushUriUpdate(uri, file, expected) => {
+                write!(
+                    f,
+                    "unexpected HttpPushUri update: {uri}; file: {file}; expected: {expected:?}"
                 )
             }
             Self::UnexpectedStream(uri, expected) => {
@@ -416,6 +425,46 @@ where
             _ => Err(Error::UnexpectedMultipartUpdate(
                 in_uri.to_string(),
                 in_request.to_string(),
+                file_name,
+                expect.request,
+            )),
+        }
+    }
+
+    #[cfg(feature = "update-service-deprecated")]
+    async fn http_push_uri_update<U, R>(
+        &self,
+        in_uri: &str,
+        update_request: HttpPushUriUpdateRequest<U>,
+    ) -> Result<ModificationResponse<R>, Self::Error>
+    where
+        U: UploadReader,
+        R: Send + Sync + for<'de> serde::Deserialize<'de>,
+    {
+        let expect = self
+            .expect
+            .lock()
+            .map_err(Error::mutex_lock)?
+            .pop_front()
+            .ok_or(Error::NothingIsExpected)?;
+
+        let file_name = update_request.update_stream.name;
+
+        match expect {
+            Expect {
+                request:
+                    ExpectedRequest::HttpPushUriUpdate {
+                        uri,
+                        file_name: expected_file_name,
+                    },
+                response,
+            } if uri == *in_uri && expected_file_name == file_name => {
+                let response = response.map_err(|err| Error::ErrorResponse(Box::new(err)))?;
+                let result: R = from_value(response).map_err(Error::BadResponseJson)?;
+                Ok(ModificationResponse::Entity(result))
+            }
+            _ => Err(Error::UnexpectedHttpPushUriUpdate(
+                in_uri.to_string(),
                 file_name,
                 expect.request,
             )),

--- a/bmc-mock/src/lib.rs
+++ b/bmc-mock/src/lib.rs
@@ -62,7 +62,8 @@ pub enum Error {
     UnexpectedDelete(ODataId, ExpectedRequest),
     UnexpectedAction(ActionTarget, String, ExpectedRequest),
     UnexpectedMultipartUpdate(String, String, String, ExpectedRequest),
-    UnexpectedHttpPushUriUpdate(String, String, ExpectedRequest),
+    #[cfg(feature = "update-service-deprecated")]
+    UnexpectedHttpPushUriUpdate(String, ExpectedRequest),
     UnexpectedStream(String, ExpectedRequest),
 }
 
@@ -115,10 +116,11 @@ impl Display for Error {
                     "unexpected multipart update: {uri}; json: {json}; file: {file}; expected: {expected:?}"
                 )
             }
-            Self::UnexpectedHttpPushUriUpdate(uri, file, expected) => {
+            #[cfg(feature = "update-service-deprecated")]
+            Self::UnexpectedHttpPushUriUpdate(uri, expected) => {
                 write!(
                     f,
-                    "unexpected HttpPushUri update: {uri}; file: {file}; expected: {expected:?}"
+                    "unexpected HttpPushUri update: {uri}; expected: {expected:?}"
                 )
             }
             Self::UnexpectedStream(uri, expected) => {
@@ -435,7 +437,7 @@ where
     async fn http_push_uri_update<U, R>(
         &self,
         in_uri: &str,
-        update_request: HttpPushUriUpdateRequest<U>,
+        _update_request: HttpPushUriUpdateRequest<U>,
     ) -> Result<ModificationResponse<R>, Self::Error>
     where
         U: UploadReader,
@@ -448,24 +450,17 @@ where
             .pop_front()
             .ok_or(Error::NothingIsExpected)?;
 
-        let file_name = update_request.update_stream.name;
-
         match expect {
             Expect {
-                request:
-                    ExpectedRequest::HttpPushUriUpdate {
-                        uri,
-                        file_name: expected_file_name,
-                    },
+                request: ExpectedRequest::HttpPushUriUpdate { uri },
                 response,
-            } if uri == *in_uri && expected_file_name == file_name => {
+            } if uri == *in_uri => {
                 let response = response.map_err(|err| Error::ErrorResponse(Box::new(err)))?;
                 let result: R = from_value(response).map_err(Error::BadResponseJson)?;
                 Ok(ModificationResponse::Entity(result))
             }
             _ => Err(Error::UnexpectedHttpPushUriUpdate(
                 in_uri.to_string(),
-                file_name,
                 expect.request,
             )),
         }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,6 +10,10 @@ keywords.workspace = true
 categories.workspace = true
 documentation = "https://docs.rs/nv-redfish-core"
 
+[features]
+default = []
+update-service-deprecated = []
+
 [dependencies]
 futures-core = { workspace = true }
 futures-io = { workspace = true }

--- a/core/src/bmc.rs
+++ b/core/src/bmc.rs
@@ -58,6 +58,8 @@ use crate::BoxTryStream;
 use crate::EntityTypeRef;
 use crate::Expandable;
 use crate::FilterQuery;
+#[cfg(feature = "update-service-deprecated")]
+use crate::HttpPushUriUpdateRequest;
 use crate::ModificationResponse;
 use crate::ODataETag;
 use crate::ODataId;
@@ -159,6 +161,17 @@ pub trait Bmc: Send + Sync {
         U: UploadReader,
         R: Send + Sync + for<'de> Deserialize<'de>,
         V: Send + Sync + Serialize;
+
+    /// POST a raw binary stream to a Redfish `UpdateService` `HttpPushUri`.
+    #[cfg(feature = "update-service-deprecated")]
+    fn http_push_uri_update<U, R>(
+        &self,
+        uri: &str,
+        request: HttpPushUriUpdateRequest<U>,
+    ) -> impl Future<Output = Result<ModificationResponse<R>, Self::Error>> + Send
+    where
+        U: UploadReader,
+        R: Send + Sync + for<'de> Deserialize<'de>;
 
     /// Stream data for the URI.
     ///

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -131,6 +131,8 @@ pub use serde_json::Value as AdditionalProperties;
 #[doc(inline)]
 pub use upload::DataStream;
 #[doc(inline)]
+pub use upload::HttpPushUriUpdateRequest;
+#[doc(inline)]
 pub use upload::MultipartUpdateRequest;
 #[doc(inline)]
 pub use upload::OemMultipartPart;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -130,6 +130,7 @@ pub use query::ToFilterLiteral;
 pub use serde_json::Value as AdditionalProperties;
 #[doc(inline)]
 pub use upload::DataStream;
+#[cfg(feature = "update-service-deprecated")]
 #[doc(inline)]
 pub use upload::HttpPushUriUpdateRequest;
 #[doc(inline)]
@@ -142,6 +143,9 @@ pub use upload::OemMultipartPartNameError;
 pub use upload::OemMultipartPartReader;
 #[doc(inline)]
 pub use upload::UploadReader;
+#[cfg(feature = "update-service-deprecated")]
+#[doc(inline)]
+pub use upload::UploadStream;
 #[doc(inline)]
 pub use uuid::Uuid as EdmGuid;
 

--- a/core/src/upload.rs
+++ b/core/src/upload.rs
@@ -27,12 +27,9 @@ pub trait UploadReader: AsyncRead + Send + 'static {}
 
 impl<T> UploadReader for T where T: AsyncRead + Send + 'static {}
 
-/// Named data stream accepted by upload methods.
+/// Named data stream accepted by multipart upload methods.
 pub struct DataStream<R> {
-    /// Name associated with this stream.
-    ///
-    /// Multipart uploads send this as the firmware filename. Raw binary uploads
-    /// keep it for caller-visible context and do not send it as a filename.
+    /// Multipart filename for this stream.
     pub name: String,
 
     /// Streamed upload data.
@@ -48,6 +45,35 @@ impl<R> DataStream<R> {
     pub fn new(name: impl Into<String>, reader: R) -> Self {
         Self {
             name: name.into(),
+            reader,
+            content_length: None,
+        }
+    }
+
+    /// Attach a known content length.
+    #[must_use]
+    pub const fn with_content_length(mut self, content_length: u64) -> Self {
+        self.content_length = Some(content_length);
+        self
+    }
+}
+
+/// Streamed body accepted by deprecated raw upload methods.
+#[cfg(feature = "update-service-deprecated")]
+pub struct UploadStream<R> {
+    /// Streamed upload data.
+    pub reader: R,
+
+    /// Known stream length, when available.
+    pub content_length: Option<u64>,
+}
+
+#[cfg(feature = "update-service-deprecated")]
+impl<R> UploadStream<R> {
+    /// Create a streamed upload body without a known content length.
+    #[must_use]
+    pub const fn new(reader: R) -> Self {
+        Self {
             reader,
             content_length: None,
         }
@@ -161,9 +187,10 @@ pub struct MultipartUpdateRequest<'a, U, V> {
 }
 
 /// `UpdateService` raw `HttpPushUri` upload request data.
+#[cfg(feature = "update-service-deprecated")]
 pub struct HttpPushUriUpdateRequest<U> {
     /// Streamed update image data.
-    pub update_stream: DataStream<U>,
+    pub update_stream: UploadStream<U>,
 
     /// Timeout used only for this upload request.
     pub upload_timeout: Duration,

--- a/core/src/upload.rs
+++ b/core/src/upload.rs
@@ -29,7 +29,10 @@ impl<T> UploadReader for T where T: AsyncRead + Send + 'static {}
 
 /// Named data stream accepted by upload methods.
 pub struct DataStream<R> {
-    /// Multipart filename for this stream.
+    /// Name associated with this stream.
+    ///
+    /// Multipart uploads send this as the firmware filename. Raw binary uploads
+    /// keep it for caller-visible context and do not send it as a filename.
     pub name: String,
 
     /// Streamed upload data.
@@ -152,6 +155,15 @@ pub struct MultipartUpdateRequest<'a, U, V> {
 
     /// Optional OEM-defined multipart parts.
     pub oem_parts: Vec<OemMultipartPart>,
+
+    /// Timeout used only for this upload request.
+    pub upload_timeout: Duration,
+}
+
+/// `UpdateService` raw `HttpPushUri` upload request data.
+pub struct HttpPushUriUpdateRequest<U> {
+    /// Streamed update image data.
+    pub update_stream: DataStream<U>,
 
     /// Timeout used only for this upload request.
     pub upload_timeout: Duration,

--- a/examples/explore-with-dummy-bmc/Cargo.toml
+++ b/examples/explore-with-dummy-bmc/Cargo.toml
@@ -8,6 +8,10 @@ edition.workspace = true
 keywords.workspace = true
 categories.workspace = true
 
+[features]
+default = []
+update-service-deprecated = ["nv-redfish-core/update-service-deprecated"]
+
 [dependencies]
 tokio = { workspace = true, features = ["full"] }
 serde = { workspace = true, features = ["derive"] }

--- a/examples/explore-with-dummy-bmc/src/main.rs
+++ b/examples/explore-with-dummy-bmc/src/main.rs
@@ -19,6 +19,8 @@ use std::sync::Arc;
 
 use futures_util::StreamExt;
 use nv_redfish_core::query::ExpandQuery;
+#[cfg(feature = "update-service-deprecated")]
+use nv_redfish_core::HttpPushUriUpdateRequest;
 use nv_redfish_core::{
     Action, ActionError, Bmc, EntityTypeRef, Expandable, ModificationResponse,
     MultipartUpdateRequest, NavProperty, ODataETag, ODataId, SessionCreateResponse, Updatable,
@@ -603,6 +605,19 @@ impl Bmc for MockBmc {
         U: UploadReader,
         R: Send + Sync + for<'de> Deserialize<'de>,
         V: Send + Sync + Serialize,
+    {
+        Err(Error::NotSupported)
+    }
+
+    #[cfg(feature = "update-service-deprecated")]
+    async fn http_push_uri_update<U, R>(
+        &self,
+        _uri: &str,
+        _request: HttpPushUriUpdateRequest<U>,
+    ) -> Result<ModificationResponse<R>, Self::Error>
+    where
+        U: UploadReader,
+        R: Send + Sync + for<'de> Deserialize<'de>,
     {
         Err(Error::NotSupported)
     }

--- a/examples/update-multipart/Cargo.toml
+++ b/examples/update-multipart/Cargo.toml
@@ -8,6 +8,10 @@ edition.workspace = true
 keywords.workspace = true
 categories.workspace = true
 
+[features]
+default = []
+update-service-deprecated = ["nv-redfish/update-service-deprecated"]
+
 [dependencies]
 clap = { workspace = true, features = ["derive"] }
 futures-util = { workspace = true, features = ["io"] }

--- a/examples/update-multipart/src/main.rs
+++ b/examples/update-multipart/src/main.rs
@@ -26,6 +26,8 @@ use nv_redfish::bmc_http::BmcCredentials;
 use nv_redfish::bmc_http::CacheSettings;
 use nv_redfish::bmc_http::HttpBmc;
 use nv_redfish::core::DataStream;
+#[cfg(feature = "update-service-deprecated")]
+use nv_redfish::core::UploadStream;
 use nv_redfish::update_service::MultipartUpdateParameters;
 use nv_redfish::ServiceRoot;
 use url::Url;
@@ -78,17 +80,11 @@ async fn main() -> Result<(), Box<dyn StdError>> {
 
     let firmware = std::fs::File::open(&args.file)?;
     let content_length = firmware.metadata()?.len();
-    let file_name = args
-        .file
-        .file_name()
-        .and_then(|name| name.to_str())
-        .ok_or("firmware path does not have a valid file name")?
-        .to_string();
-    let update_stream =
-        DataStream::new(file_name, AllowStdIo::new(firmware)).with_content_length(content_length);
 
     #[cfg(feature = "update-service-deprecated")]
     if args.http_push_uri {
+        let update_stream =
+            UploadStream::new(AllowStdIo::new(firmware)).with_content_length(content_length);
         let response = update_service
             .http_push_uri_update_from_reader::<_, serde_json::Value>(
                 update_stream,
@@ -100,6 +96,15 @@ async fn main() -> Result<(), Box<dyn StdError>> {
 
         return Ok(());
     }
+
+    let file_name = args
+        .file
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or("firmware path does not have a valid file name")?
+        .to_string();
+    let update_stream =
+        DataStream::new(file_name, AllowStdIo::new(firmware)).with_content_length(content_length);
 
     let parameters = MultipartUpdateParameters::builder()
         .with_force_update(args.force_update)

--- a/examples/update-multipart/src/main.rs
+++ b/examples/update-multipart/src/main.rs
@@ -51,6 +51,10 @@ struct Args {
     #[arg(long, default_value_t = false)]
     force_update: bool,
 
+    #[cfg(feature = "update-service-deprecated")]
+    #[arg(long, default_value_t = false)]
+    http_push_uri: bool,
+
     #[arg(long, default_value_t = false)]
     insecure: bool,
 }
@@ -82,6 +86,21 @@ async fn main() -> Result<(), Box<dyn StdError>> {
         .to_string();
     let update_stream =
         DataStream::new(file_name, AllowStdIo::new(firmware)).with_content_length(content_length);
+
+    #[cfg(feature = "update-service-deprecated")]
+    if args.http_push_uri {
+        let response = update_service
+            .http_push_uri_update_from_reader::<_, serde_json::Value>(
+                update_stream,
+                Duration::from_secs(1800),
+            )
+            .await?;
+
+        println!("{response:#?}");
+
+        return Ok(());
+    }
+
     let parameters = MultipartUpdateParameters::builder()
         .with_force_update(args.force_update)
         .with_targets(args.targets)

--- a/redfish/Cargo.toml
+++ b/redfish/Cargo.toml
@@ -83,6 +83,11 @@ storages = []
 task-service = ["impl-entity-link"]
 thermal = []  # Support of legacy ThermalSubsystem
 update-service = ["patch-payload-get", "patch-collection"]
+update-service-deprecated = [
+    "update-service",
+    "nv-redfish-core/update-service-deprecated",
+    "nv-redfish-bmc-http?/update-service-deprecated",
+]
 
 # OEM features support
 oem = []

--- a/redfish/src/error.rs
+++ b/redfish/src/error.rs
@@ -37,6 +37,9 @@ pub enum Error<B: Bmc> {
     /// Update service does not provide `MultipartHttpPushUri`
     #[cfg(feature = "update-service")]
     UpdateServiceMultipartHttpPushUriNotAvailable,
+    /// Update service does not provide `HttpPushUri`
+    #[cfg(feature = "update-service-deprecated")]
+    UpdateServiceHttpPushUriNotAvailable,
     /// Task service does not provide a Tasks collection.
     #[cfg(feature = "task-service")]
     TaskServiceTasksUnavailable,
@@ -78,6 +81,10 @@ impl<B: Bmc> Display for Error<B> {
             #[cfg(feature = "update-service")]
             Self::UpdateServiceMultipartHttpPushUriNotAvailable => {
                 write!(f, "Update service does not provide MultipartHttpPushUri")
+            }
+            #[cfg(feature = "update-service-deprecated")]
+            Self::UpdateServiceHttpPushUriNotAvailable => {
+                write!(f, "Update service does not provide HttpPushUri")
             }
             #[cfg(feature = "task-service")]
             Self::TaskServiceTasksUnavailable => {

--- a/redfish/src/update_service/mod.rs
+++ b/redfish/src/update_service/mod.rs
@@ -36,6 +36,10 @@ use crate::schema::update_service::UpdateServiceSimpleUpdateAction;
 
 use nv_redfish_core::Bmc;
 use nv_redfish_core::DataStream;
+#[cfg(feature = "update-service-deprecated")]
+use nv_redfish_core::EntityTypeRef;
+#[cfg(feature = "update-service-deprecated")]
+use nv_redfish_core::HttpPushUriUpdateRequest;
 use nv_redfish_core::ModificationResponse;
 use nv_redfish_core::MultipartUpdateRequest;
 use nv_redfish_core::UploadReader;
@@ -46,6 +50,9 @@ use software_inventory::SoftwareInventoryCollection;
 pub use crate::schema::update_service::TransferProtocolType;
 #[doc(inline)]
 pub use crate::schema::update_service::UpdateParametersUpdate as MultipartUpdateParameters;
+#[cfg(feature = "update-service-deprecated")]
+#[doc(inline)]
+pub use crate::schema::update_service::UpdateServiceUpdate;
 #[doc(inline)]
 pub use software_inventory::SoftwareInventory;
 #[doc(inline)]
@@ -253,6 +260,97 @@ impl<B: Bmc> UpdateService<B> {
 
         actions
             .start_update(self.bmc.as_ref())
+            .await
+            .map_err(Error::Bmc)
+    }
+
+    /// Update this service with deprecated generated `UpdateServiceUpdate` fields.
+    ///
+    /// Use this for standard `HttpPushUriOptions`, `HttpPushUriTargets`, and
+    /// related busy flags before or after an `HttpPushUri` upload.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the update request fails.
+    #[cfg(feature = "update-service-deprecated")]
+    pub async fn update(
+        &self,
+        update: &UpdateServiceUpdate,
+    ) -> Result<ModificationResponse<Self>, Error<B>> {
+        let response = self
+            .bmc
+            .as_ref()
+            .update::<_, NavProperty<UpdateServiceSchema>>(
+                self.data.odata_id(),
+                self.data.etag(),
+                update,
+            )
+            .await
+            .map_err(Error::Bmc)?;
+
+        match response {
+            ModificationResponse::Entity(nav) => {
+                let data = nav.get(self.bmc.as_ref()).await.map_err(Error::Bmc)?;
+
+                Ok(ModificationResponse::Entity(Self {
+                    bmc: self.bmc.clone(),
+                    data,
+                    fw_inventory_read_patch_fn: self.fw_inventory_read_patch_fn.clone(),
+                }))
+            }
+            ModificationResponse::Task(task) => Ok(ModificationResponse::Task(task)),
+            ModificationResponse::Empty => Ok(ModificationResponse::Empty),
+        }
+    }
+
+    /// Upload a raw binary stream using this service's deprecated `HttpPushUri`.
+    ///
+    /// The stream is sent as `application/octet-stream` without multipart
+    /// `UpdateParameters`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `HttpPushUri` is absent or the upload fails.
+    #[cfg(feature = "update-service-deprecated")]
+    pub async fn http_push_uri_update_from_reader<U, R>(
+        &self,
+        update_stream: DataStream<U>,
+        upload_timeout: Duration,
+    ) -> Result<ModificationResponse<R>, Error<B>>
+    where
+        U: UploadReader,
+        R: Send + Sync + for<'de> serde::Deserialize<'de>,
+    {
+        self.http_push_uri_update(HttpPushUriUpdateRequest {
+            update_stream,
+            upload_timeout,
+        })
+        .await
+    }
+
+    /// Perform a raw binary upload using this service's deprecated `HttpPushUri`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `HttpPushUri` is absent or the upload fails.
+    #[cfg(feature = "update-service-deprecated")]
+    pub async fn http_push_uri_update<U, R>(
+        &self,
+        request: HttpPushUriUpdateRequest<U>,
+    ) -> Result<ModificationResponse<R>, Error<B>>
+    where
+        U: UploadReader,
+        R: Send + Sync + for<'de> serde::Deserialize<'de>,
+    {
+        let http_push_uri = self
+            .data
+            .http_push_uri
+            .as_ref()
+            .ok_or(Error::UpdateServiceHttpPushUriNotAvailable)?;
+
+        self.bmc
+            .as_ref()
+            .http_push_uri_update(http_push_uri, request)
             .await
             .map_err(Error::Bmc)
     }

--- a/redfish/src/update_service/mod.rs
+++ b/redfish/src/update_service/mod.rs
@@ -43,6 +43,8 @@ use nv_redfish_core::HttpPushUriUpdateRequest;
 use nv_redfish_core::ModificationResponse;
 use nv_redfish_core::MultipartUpdateRequest;
 use nv_redfish_core::UploadReader;
+#[cfg(feature = "update-service-deprecated")]
+use nv_redfish_core::UploadStream;
 use serde_json::Value as JsonValue;
 use software_inventory::SoftwareInventoryCollection;
 
@@ -314,7 +316,7 @@ impl<B: Bmc> UpdateService<B> {
     #[cfg(feature = "update-service-deprecated")]
     pub async fn http_push_uri_update_from_reader<U, R>(
         &self,
-        update_stream: DataStream<U>,
+        update_stream: UploadStream<U>,
         upload_timeout: Duration,
     ) -> Result<ModificationResponse<R>, Error<B>>
     where

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -11,6 +11,13 @@ categories.workspace = true
 [lib]
 path = "src/lib.rs"
 
+[features]
+default = []
+update-service-deprecated = [
+    "nv-redfish/update-service-deprecated",
+    "nv-redfish-bmc-mock/update-service-deprecated",
+]
+
 [dependencies]
 nv-redfish-core = { workspace = true }
 nv-redfish-bmc-mock = { workspace = true }

--- a/tests/tests/test-update-service.rs
+++ b/tests/tests/test-update-service.rs
@@ -20,8 +20,12 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use futures_util::io::Cursor;
+#[cfg(feature = "update-service-deprecated")]
+use nv_redfish::schema::update_service::HttpPushUriOptionsUpdate;
 use nv_redfish::update_service::MultipartUpdateParameters;
 use nv_redfish::update_service::UpdateService;
+#[cfg(feature = "update-service-deprecated")]
+use nv_redfish::update_service::UpdateServiceUpdate;
 use nv_redfish::Error;
 use nv_redfish::ServiceRoot;
 use nv_redfish_core::DataStream;
@@ -43,7 +47,16 @@ const SW_INVENTORIES_DATA_TYPE: &str = "#SoftwareInventoryCollection.SoftwareInv
 const SW_INVENTORY_DATA_TYPE: &str = "#SoftwareInventory.v1_4_0.SoftwareInventory";
 
 const UPDATE_SERVICE_URI: &str = "/redfish/v1/UpdateService";
+#[cfg(feature = "update-service-deprecated")]
+const HTTP_PUSH_URI: &str = "/redfish/v1/UpdateService/update";
 const MULTIPART_URI: &str = "/redfish/v1/UpdateService/update-multipart";
+
+#[cfg(feature = "update-service-deprecated")]
+#[derive(serde::Deserialize)]
+struct UploadResponse {
+    #[serde(rename = "Result")]
+    result: String,
+}
 
 #[test]
 async fn list_dell_fw_inventores() -> Result<(), Box<dyn StdError>> {
@@ -267,6 +280,100 @@ async fn uses_multipart_http_push_uri() -> Result<(), Box<dyn StdError>> {
     Ok(())
 }
 
+#[cfg(feature = "update-service-deprecated")]
+#[tokio::test]
+async fn uses_http_push_uri_without_update_parameters() -> Result<(), Box<dyn StdError>> {
+    let bmc = Arc::new(Bmc::default());
+
+    bmc.expect(Expect::get("/redfish/v1", service_root_json()));
+    bmc.expect(Expect::get(
+        UPDATE_SERVICE_URI,
+        update_service_json_with_uris(None, Some(HTTP_PUSH_URI)),
+    ));
+
+    bmc.expect(Expect::http_push_uri_update(
+        HTTP_PUSH_URI,
+        "firmware.bin",
+        json!({
+            "Result": "accepted"
+        }),
+    ));
+
+    let root = ServiceRoot::new(Arc::clone(&bmc)).await?;
+    let update_service = root
+        .update_service()
+        .await?
+        .ok_or("expected update service")?;
+
+    let response = update_service
+        .http_push_uri_update_from_reader::<_, UploadResponse>(
+            DataStream::new("firmware.bin", Cursor::new(b"firmware".to_vec()))
+                .with_content_length(8),
+            Duration::from_secs(600),
+        )
+        .await?;
+
+    let ModificationResponse::Entity(body) = response else {
+        return Err(String::from("expected entity response").into());
+    };
+
+    assert_eq!(body.result, "accepted");
+
+    Ok(())
+}
+
+#[cfg(feature = "update-service-deprecated")]
+#[tokio::test]
+async fn patches_http_push_uri_options_and_targets() -> Result<(), Box<dyn StdError>> {
+    let bmc = Arc::new(Bmc::default());
+
+    bmc.expect(Expect::get("/redfish/v1", service_root_json()));
+    bmc.expect(Expect::get(
+        UPDATE_SERVICE_URI,
+        update_service_json_with_uris(None, Some(HTTP_PUSH_URI)),
+    ));
+
+    let update = UpdateServiceUpdate::builder()
+        .with_http_push_uri_targets(vec!["/redfish/v1/Systems/1".to_string()])
+        .with_http_push_uri_targets_busy(true)
+        .with_http_push_uri_options(
+            HttpPushUriOptionsUpdate::builder()
+                .with_force_update(true)
+                .build(),
+        )
+        .with_http_push_uri_options_busy(true)
+        .build();
+
+    bmc.expect(Expect::update(
+        UPDATE_SERVICE_URI,
+        json!({
+            "HttpPushUriTargets": ["/redfish/v1/Systems/1"],
+            "HttpPushUriTargetsBusy": true,
+            "HttpPushUriOptions": {
+                "ForceUpdate": true
+            },
+            "HttpPushUriOptionsBusy": true
+        }),
+        update_service_json_with_uris(None, Some(HTTP_PUSH_URI)),
+    ));
+
+    let root = ServiceRoot::new(Arc::clone(&bmc)).await?;
+    let update_service = root
+        .update_service()
+        .await?
+        .ok_or("expected update service")?;
+
+    let response = update_service.update(&update).await?;
+
+    let ModificationResponse::Entity(updated) = response else {
+        return Err(String::from("expected entity response").into());
+    };
+
+    assert_eq!(updated.raw().http_push_uri.as_deref(), Some(HTTP_PUSH_URI));
+
+    Ok(())
+}
+
 #[tokio::test]
 async fn uses_generated_update_parameters_with_oem_parts() -> Result<(), Box<dyn StdError>> {
     let bmc = Arc::new(Bmc::default());
@@ -366,6 +473,39 @@ async fn requires_multipart_http_push_uri() -> Result<(), Box<dyn StdError>> {
     Ok(())
 }
 
+#[cfg(feature = "update-service-deprecated")]
+#[tokio::test]
+async fn requires_http_push_uri() -> Result<(), Box<dyn StdError>> {
+    let bmc = Arc::new(Bmc::default());
+
+    bmc.expect(Expect::get("/redfish/v1", service_root_json()));
+
+    // Raw uploads must use the service-provided endpoint, so a missing
+    // HttpPushUri should fail before any upload is sent.
+    bmc.expect(Expect::get(UPDATE_SERVICE_URI, update_service_json(None)));
+
+    let root = ServiceRoot::new(Arc::clone(&bmc)).await?;
+    let update_service = root
+        .update_service()
+        .await?
+        .ok_or("expected update service")?;
+
+    let result = update_service
+        .http_push_uri_update_from_reader::<_, UploadResponse>(
+            DataStream::new("firmware.bin", Cursor::new(b"firmware".to_vec()))
+                .with_content_length(8),
+            Duration::from_secs(600),
+        )
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(Error::UpdateServiceHttpPushUriNotAvailable)
+    ));
+
+    Ok(())
+}
+
 fn service_root_json() -> serde_json::Value {
     json!({
         "@odata.id": "/redfish/v1",
@@ -383,6 +523,13 @@ fn service_root_json() -> serde_json::Value {
 }
 
 fn update_service_json(multipart_uri: Option<&str>) -> serde_json::Value {
+    update_service_json_with_uris(multipart_uri, None)
+}
+
+fn update_service_json_with_uris(
+    multipart_uri: Option<&str>,
+    http_push_uri: Option<&str>,
+) -> serde_json::Value {
     let mut body = json!({
         "@odata.id": UPDATE_SERVICE_URI,
         "Id": "UpdateService",
@@ -391,6 +538,10 @@ fn update_service_json(multipart_uri: Option<&str>) -> serde_json::Value {
 
     if let Some(multipart_uri) = multipart_uri {
         body["MultipartHttpPushUri"] = json!(multipart_uri);
+    }
+
+    if let Some(http_push_uri) = http_push_uri {
+        body["HttpPushUri"] = json!(http_push_uri);
     }
 
     body

--- a/tests/tests/test-update-service.rs
+++ b/tests/tests/test-update-service.rs
@@ -34,6 +34,8 @@ use nv_redfish_core::ModificationResponse;
 use nv_redfish_core::MultipartUpdateRequest;
 use nv_redfish_core::ODataId;
 use nv_redfish_core::OemMultipartPart;
+#[cfg(feature = "update-service-deprecated")]
+use nv_redfish_core::UploadStream;
 use nv_redfish_tests::ami_viking_service_root;
 use nv_redfish_tests::Bmc;
 use nv_redfish_tests::Expect;
@@ -293,7 +295,6 @@ async fn uses_http_push_uri_without_update_parameters() -> Result<(), Box<dyn St
 
     bmc.expect(Expect::http_push_uri_update(
         HTTP_PUSH_URI,
-        "firmware.bin",
         json!({
             "Result": "accepted"
         }),
@@ -307,8 +308,7 @@ async fn uses_http_push_uri_without_update_parameters() -> Result<(), Box<dyn St
 
     let response = update_service
         .http_push_uri_update_from_reader::<_, UploadResponse>(
-            DataStream::new("firmware.bin", Cursor::new(b"firmware".to_vec()))
-                .with_content_length(8),
+            UploadStream::new(Cursor::new(b"firmware".to_vec())).with_content_length(8),
             Duration::from_secs(600),
         )
         .await?;
@@ -492,8 +492,7 @@ async fn requires_http_push_uri() -> Result<(), Box<dyn StdError>> {
 
     let result = update_service
         .http_push_uri_update_from_reader::<_, UploadResponse>(
-            DataStream::new("firmware.bin", Cursor::new(b"firmware".to_vec()))
-                .with_content_length(8),
+            UploadStream::new(Cursor::new(b"firmware".to_vec())).with_content_length(8),
             Duration::from_secs(600),
         )
         .await;


### PR DESCRIPTION
Added opt-in support for `UpdateService.HttpPushUri`, the older Redfish firmware upload path.

`HttpPushUri` is deprecated in favor of `MultipartHttpPushUri`, and multipart should stay the preferred path. But some existing RMS firmware update flows still use the raw binary upload endpoint.

This addition is put behind `update-service-deprecated` feature which lets callers only get this API when they explicitly opt in. Same pattern could be used for managing future spec deprecations.

Spec references:
- DMTF marks `HttpPushUri`, targets, options, and busy flags deprecated in `UpdateService` v1.15.0 in favor of `MultipartHttpPushUri`.
- DSP0266 defines the multipart push path and common mutation/task response behavior.