### PR TITLE
feat(power-equipment): add standard PowerShelves support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ all-std-features = accounts \
                    memory \
                    network-adapters \
                    power \
+                   power-equipment \
                    power-supplies \
                    processors \
                    secure-boot \

--- a/redfish/Cargo.toml
+++ b/redfish/Cargo.toml
@@ -41,6 +41,7 @@ std-redfish = [
     "network-adapters",
     "network-device-functions",
     "power",
+    "power-equipment",
     "power-supplies",
     "pcie-devices",
     "processors",
@@ -73,6 +74,7 @@ managers = ["impl-nv-bmc-expand", "patch-collection"]
 memory = []
 pcie-devices = ["resource-status"]
 power = [] # Support of legacy PowerSubsystem
+power-equipment = ["impl-nv-bmc-expand"]
 power-supplies = []
 processors = ["pcie-devices"]
 resource-status = []

--- a/redfish/features.toml
+++ b/redfish/features.toml
@@ -312,6 +312,21 @@ patterns = [
 ]
 
 [[features]]
+name = "power-equipment"
+csdl_files = [
+    "PowerEquipment_v1.xml",
+    "PowerDistribution_v1.xml",
+    "PowerDistributionCollection_v1.xml",
+    "Redundancy_v1.xml",
+]
+patterns = [
+    "PowerEquipment.*",
+    "PowerDistribution.*",
+    "PowerDistributionCollection.*",
+    "Redundancy.*",
+]
+
+[[features]]
 name = "power-supplies"
 csdl_files = [
     "PowerSupply_v1.xml",

--- a/redfish/src/bmc_quirks.rs
+++ b/redfish/src/bmc_quirks.rs
@@ -101,6 +101,7 @@ impl BmcQuirks {
         feature = "chassis",
         feature = "computer-systems",
         feature = "managers",
+        feature = "power-equipment",
         feature = "update-service",
     ))]
     pub(crate) const fn bug_missing_root_nav_properties(&self) -> bool {

--- a/redfish/src/bmc_quirks.rs
+++ b/redfish/src/bmc_quirks.rs
@@ -101,7 +101,6 @@ impl BmcQuirks {
         feature = "chassis",
         feature = "computer-systems",
         feature = "managers",
-        feature = "power-equipment",
         feature = "update-service",
     ))]
     pub(crate) const fn bug_missing_root_nav_properties(&self) -> bool {

--- a/redfish/src/lib.rs
+++ b/redfish/src/lib.rs
@@ -123,6 +123,9 @@ pub mod network_device_function;
 /// `PCIe` devices.
 #[cfg(feature = "pcie-devices")]
 pub mod pcie_device;
+/// Power equipment.
+#[cfg(feature = "power-equipment")]
+pub mod power_equipment;
 /// Metrics and sensor abstraction.
 #[cfg(feature = "sensors")]
 pub mod sensor;

--- a/redfish/src/power_equipment.rs
+++ b/redfish/src/power_equipment.rs
@@ -1,0 +1,170 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Power equipment entities and collections.
+//!
+//! This module provides typed access to Redfish `PowerEquipment` and the
+//! power shelf resources exposed through its `PowerShelves` collection.
+
+use crate::core::NavProperty;
+use crate::schema::power_distribution::PowerDistribution as PowerDistributionSchema;
+use crate::schema::power_distribution_collection::PowerDistributionCollection as PowerDistributionCollectionSchema;
+use crate::schema::power_equipment::PowerEquipment as PowerEquipmentSchema;
+use crate::Error;
+use crate::NvBmc;
+use crate::Resource;
+use crate::ResourceSchema;
+use crate::ServiceRoot;
+use nv_redfish_core::Bmc;
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+#[doc(inline)]
+pub use crate::schema::power_distribution::PowerEquipmentType;
+
+/// Power equipment service.
+///
+/// Provides access to root-level power distribution equipment collections.
+pub struct PowerEquipment<B: Bmc> {
+    bmc: NvBmc<B>,
+    data: Arc<PowerEquipmentSchema>,
+}
+
+impl<B: Bmc> PowerEquipment<B> {
+    /// Create a new power equipment handle.
+    pub(crate) async fn new(
+        bmc: &NvBmc<B>,
+        root: &ServiceRoot<B>,
+    ) -> Result<Option<Self>, Error<B>> {
+        let data = if let Some(nav) = &root.root.power_equipment {
+            nav.get(bmc.as_ref()).await.map_err(Error::Bmc)?
+        } else if bmc.quirks.bug_missing_root_nav_properties() {
+            NavProperty::new_reference(format!("{}/PowerEquipment", root.odata_id()).into())
+                .get(bmc.as_ref())
+                .await
+                .map_err(Error::Bmc)?
+        } else {
+            return Ok(None);
+        };
+        Ok(Some(Self {
+            bmc: bmc.clone(),
+            data,
+        }))
+    }
+
+    /// Get the raw schema data for this power equipment service.
+    ///
+    /// Returns an `Arc` to the underlying schema, allowing cheap cloning
+    /// and sharing of the data.
+    #[must_use]
+    pub fn raw(&self) -> Arc<PowerEquipmentSchema> {
+        self.data.clone()
+    }
+
+    /// Get the power shelf collection.
+    ///
+    /// Returns `Ok(None)` when the service does not expose `PowerShelves`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if retrieving the power shelf collection fails.
+    pub async fn power_shelves(&self) -> Result<Option<PowerShelfCollection<B>>, Error<B>> {
+        let Some(collection_ref) = &self.data.power_shelves else {
+            return Ok(None);
+        };
+
+        PowerShelfCollection::new(&self.bmc, collection_ref)
+            .await
+            .map(Some)
+    }
+}
+
+impl<B: Bmc> Resource for PowerEquipment<B> {
+    fn resource_ref(&self) -> &ResourceSchema {
+        &self.data.as_ref().base
+    }
+}
+
+/// Power shelf collection.
+///
+/// Provides functions to access `PowerShelves` members.
+pub struct PowerShelfCollection<B: Bmc> {
+    bmc: NvBmc<B>,
+    collection: Arc<PowerDistributionCollectionSchema>,
+}
+
+impl<B: Bmc> PowerShelfCollection<B> {
+    async fn new(
+        bmc: &NvBmc<B>,
+        nav: &NavProperty<PowerDistributionCollectionSchema>,
+    ) -> Result<Self, Error<B>> {
+        let collection = bmc.expand_property(nav).await?;
+        Ok(Self {
+            bmc: bmc.clone(),
+            collection,
+        })
+    }
+
+    /// List all power shelves available in this collection.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if fetching power shelf data fails.
+    pub async fn members(&self) -> Result<Vec<PowerShelf<B>>, Error<B>> {
+        let mut members = Vec::with_capacity(self.collection.members.len());
+        for member in &self.collection.members {
+            members.push(PowerShelf::new(&self.bmc, member).await?);
+        }
+
+        Ok(members)
+    }
+}
+
+/// Power shelf.
+///
+/// A power shelf is represented by the Redfish `PowerDistribution` schema with
+/// `EquipmentType` set to `PowerShelf`.
+pub struct PowerShelf<B: Bmc> {
+    data: Arc<PowerDistributionSchema>,
+    _marker: PhantomData<B>,
+}
+
+impl<B: Bmc> PowerShelf<B> {
+    async fn new(
+        bmc: &NvBmc<B>,
+        nav: &NavProperty<PowerDistributionSchema>,
+    ) -> Result<Self, Error<B>> {
+        let data = nav.get(bmc.as_ref()).await.map_err(Error::Bmc)?;
+        Ok(Self {
+            data,
+            _marker: PhantomData,
+        })
+    }
+
+    /// Get the raw `PowerDistribution` schema data for this power shelf.
+    ///
+    /// Returns an `Arc` to the underlying schema, allowing cheap cloning
+    /// and sharing of the data.
+    #[must_use]
+    pub fn raw(&self) -> Arc<PowerDistributionSchema> {
+        self.data.clone()
+    }
+}
+
+impl<B: Bmc> Resource for PowerShelf<B> {
+    fn resource_ref(&self) -> &ResourceSchema {
+        &self.data.as_ref().base
+    }
+}

--- a/redfish/src/power_equipment.rs
+++ b/redfish/src/power_equipment.rs
@@ -48,16 +48,12 @@ impl<B: Bmc> PowerEquipment<B> {
         bmc: &NvBmc<B>,
         root: &ServiceRoot<B>,
     ) -> Result<Option<Self>, Error<B>> {
-        let data = if let Some(nav) = &root.root.power_equipment {
-            nav.get(bmc.as_ref()).await.map_err(Error::Bmc)?
-        } else if bmc.quirks.bug_missing_root_nav_properties() {
-            NavProperty::new_reference(format!("{}/PowerEquipment", root.odata_id()).into())
-                .get(bmc.as_ref())
-                .await
-                .map_err(Error::Bmc)?
-        } else {
+        let Some(nav) = &root.root.power_equipment else {
             return Ok(None);
         };
+
+        let data = nav.get(bmc.as_ref()).await.map_err(Error::Bmc)?;
+
         Ok(Some(Self {
             bmc: bmc.clone(),
             data,

--- a/redfish/src/service_root.rs
+++ b/redfish/src/service_root.rs
@@ -42,6 +42,8 @@ use crate::event_service::EventService;
 use crate::manager::ManagerCollection;
 #[cfg(feature = "oem-hpe")]
 use crate::oem::hpe::HpeiLoServiceExt;
+#[cfg(feature = "power-equipment")]
+use crate::power_equipment::PowerEquipment;
 #[cfg(feature = "session-service")]
 use crate::session_service::SessionService;
 #[cfg(feature = "task-service")]
@@ -302,6 +304,18 @@ impl<B: Bmc> ServiceRoot<B> {
     #[cfg(feature = "managers")]
     pub async fn managers(&self) -> Result<Option<ManagerCollection<B>>, Error<B>> {
         ManagerCollection::new(&self.bmc, self).await
+    }
+
+    /// Get power equipment in BMC
+    ///
+    /// Returns `Ok(None)` when the BMC does not expose PowerEquipment.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if retrieving power equipment data fails.
+    #[cfg(feature = "power-equipment")]
+    pub async fn power_equipment(&self) -> Result<Option<PowerEquipment<B>>, Error<B>> {
+        PowerEquipment::new(&self.bmc, self).await
     }
 
     /// Get HPE OEM extension in service root

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -37,6 +37,7 @@ nv-redfish = { workspace = true, features = [
     "oem-nvidia-baseboard",
     "oem-supermicro",
     "oem-liteon",
+    "power-equipment",
     "power-supplies",
     "sensors",
     "session-service",

--- a/tests/tests/test-power-equipment.rs
+++ b/tests/tests/test-power-equipment.rs
@@ -1,0 +1,220 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Integration tests for standard PowerEquipment and PowerShelves.
+
+use nv_redfish::power_equipment::PowerEquipmentType;
+use nv_redfish::Resource as _;
+use nv_redfish::ServiceRoot;
+use nv_redfish_core::ODataId;
+use nv_redfish_tests::json_merge;
+use nv_redfish_tests::Bmc;
+use nv_redfish_tests::Expect;
+use nv_redfish_tests::ODATA_ID;
+use nv_redfish_tests::ODATA_TYPE;
+use serde_json::json;
+use serde_json::Value;
+use std::error::Error as StdError;
+use std::io::Error as IoError;
+use std::io::ErrorKind;
+use std::sync::Arc;
+use tokio::test;
+
+const ROOT_DATA_TYPE: &str = "#ServiceRoot.v1_13_0.ServiceRoot";
+const POWER_EQUIPMENT_DATA_TYPE: &str = "#PowerEquipment.v1_2_3.PowerEquipment";
+const POWER_DISTRIBUTION_COLLECTION_DATA_TYPE: &str =
+    "#PowerDistributionCollection.PowerDistributionCollection";
+const POWER_SHELF_DATA_TYPE: &str = "#PowerDistribution.v1_6_0.PowerDistribution";
+
+#[test]
+async fn power_equipment_lists_power_shelves() -> Result<(), Box<dyn StdError>> {
+    let bmc = Arc::new(Bmc::default());
+    let ids = ids();
+    bmc.expect(Expect::get(
+        &ids.root_id,
+        root_payload(
+            &ids,
+            json!({
+                "PowerEquipment": {
+                    ODATA_ID: &ids.power_equipment_id,
+                },
+            }),
+        ),
+    ));
+    let service_root = ServiceRoot::new(bmc.clone()).await?;
+
+    bmc.expect(Expect::get(
+        &ids.power_equipment_id,
+        power_equipment_payload(
+            &ids,
+            json!({
+                "PowerShelves": {
+                    ODATA_ID: &ids.power_shelves_id,
+                },
+            }),
+        ),
+    ));
+    let power_equipment = service_root
+        .power_equipment()
+        .await?
+        .ok_or_else(|| missing("missing PowerEquipment"))?;
+    assert_eq!(
+        power_equipment.odata_id().to_string(),
+        ids.power_equipment_id
+    );
+
+    bmc.expect(Expect::expand(
+        &ids.power_shelves_id,
+        json!({
+            ODATA_ID: &ids.power_shelves_id,
+            ODATA_TYPE: POWER_DISTRIBUTION_COLLECTION_DATA_TYPE,
+            "Name": "Power Shelves",
+            "Members": [{
+                ODATA_ID: &ids.power_shelf_id,
+            }],
+        }),
+    ));
+    let collection = power_equipment
+        .power_shelves()
+        .await?
+        .ok_or_else(|| missing("missing PowerShelves"))?;
+
+    bmc.expect(Expect::get(
+        &ids.power_shelf_id,
+        json!({
+            ODATA_ID: &ids.power_shelf_id,
+            ODATA_TYPE: POWER_SHELF_DATA_TYPE,
+            "Id": "1",
+            "Name": "Power Shelf 1",
+            "EquipmentType": "PowerShelf",
+            "Manufacturer": "NVIDIA",
+            "Model": "NV-PowerShelf-1",
+            "SerialNumber": "PS-12345",
+            "PartNumber": "900-12345-0000-000",
+        }),
+    ));
+    let shelves = collection.members().await?;
+    assert_eq!(shelves.len(), 1);
+    let shelf = shelves
+        .first()
+        .ok_or_else(|| missing("missing power shelf member"))?;
+    let raw = shelf.raw();
+    assert_eq!(shelf.odata_id().to_string(), ids.power_shelf_id);
+    assert_eq!(raw.equipment_type, PowerEquipmentType::PowerShelf);
+    assert_eq!(raw.manufacturer, Some(Some("NVIDIA".into())));
+    assert_eq!(raw.model, Some(Some("NV-PowerShelf-1".into())));
+    assert_eq!(raw.serial_number, Some(Some("PS-12345".into())));
+    assert_eq!(raw.part_number, Some(Some("900-12345-0000-000".into())));
+
+    Ok(())
+}
+
+#[test]
+async fn missing_power_equipment_link_returns_none() -> Result<(), Box<dyn StdError>> {
+    let bmc = Arc::new(Bmc::default());
+    let ids = ids();
+    bmc.expect(Expect::get(&ids.root_id, root_payload(&ids, json!({}))));
+    let service_root = ServiceRoot::new(bmc).await?;
+
+    assert!(service_root.power_equipment().await?.is_none());
+
+    Ok(())
+}
+
+#[test]
+async fn missing_power_shelves_link_returns_none() -> Result<(), Box<dyn StdError>> {
+    let bmc = Arc::new(Bmc::default());
+    let ids = ids();
+    bmc.expect(Expect::get(
+        &ids.root_id,
+        root_payload(
+            &ids,
+            json!({
+                "PowerEquipment": {
+                    ODATA_ID: &ids.power_equipment_id,
+                },
+            }),
+        ),
+    ));
+    let service_root = ServiceRoot::new(bmc.clone()).await?;
+
+    bmc.expect(Expect::get(
+        &ids.power_equipment_id,
+        power_equipment_payload(&ids, json!({})),
+    ));
+    let power_equipment = service_root
+        .power_equipment()
+        .await?
+        .ok_or_else(|| missing("missing PowerEquipment"))?;
+
+    assert!(power_equipment.power_shelves().await?.is_none());
+
+    Ok(())
+}
+
+struct Ids {
+    root_id: ODataId,
+    power_equipment_id: String,
+    power_shelves_id: String,
+    power_shelf_id: String,
+}
+
+fn ids() -> Ids {
+    let root_id = ODataId::service_root();
+    let power_equipment_id = format!("{root_id}/PowerEquipment");
+    let power_shelves_id = format!("{power_equipment_id}/PowerShelves");
+    let power_shelf_id = format!("{power_shelves_id}/1");
+    Ids {
+        root_id,
+        power_equipment_id,
+        power_shelves_id,
+        power_shelf_id,
+    }
+}
+
+fn root_payload(ids: &Ids, fields: Value) -> Value {
+    let base = json!({
+        ODATA_ID: &ids.root_id,
+        ODATA_TYPE: ROOT_DATA_TYPE,
+        "Id": "RootService",
+        "Name": "Root Service",
+        "RedfishVersion": "1.13.0",
+        "ProtocolFeaturesSupported": {
+            "ExpandQuery": {
+                "NoLinks": true,
+            },
+        },
+        "Links": {
+            "Sessions": {
+                ODATA_ID: format!("{}/SessionService/Sessions", ids.root_id),
+            },
+        },
+    });
+    json_merge([&base, &fields])
+}
+
+fn power_equipment_payload(ids: &Ids, fields: Value) -> Value {
+    let base = json!({
+        ODATA_ID: &ids.power_equipment_id,
+        ODATA_TYPE: POWER_EQUIPMENT_DATA_TYPE,
+        "Id": "PowerEquipment",
+        "Name": "Power Equipment",
+    });
+    json_merge([&base, &fields])
+}
+
+fn missing(message: &'static str) -> IoError {
+    IoError::new(ErrorKind::NotFound, message)
+}


### PR DESCRIPTION
Add typed `PowerEquipment` and `PowerDistribution` wrappers for discovering `/redfish/v1/PowerEquipment/PowerShelves` and reading PowerShelf members. This enables callers such as RMS GB300 Delta powershelf power control to discover PowerShelf resources through the standard Redfish surface.