### PR TITLE
feat(bmc-http)!: resolve action targets as URI references

### DIFF
--- a/bmc-http/src/lib.rs
+++ b/bmc-http/src/lib.rs
@@ -408,11 +408,11 @@ impl RedfishEndpoint {
     fn with_uri_reference(&self, uri: UriReference<'_>) -> Url {
         let UriReference(uri) = uri;
 
-        let Ok(url) = self.base_url.join(uri) else {
+        let Ok(resolved) = self.base_url.join(uri) else {
             return self.with_path(uri);
         };
 
-        url
+        resolved
     }
 
     /// Convert a path to a full Redfish endpoint URL with query parameters

--- a/bmc-http/src/lib.rs
+++ b/bmc-http/src/lib.rs
@@ -199,6 +199,13 @@ pub trait HttpClient: Send + Sync {
 /// to provide a complete Redfish client implementation. It implements the [`Bmc`] trait
 /// to provide standardized access to Redfish services.
 ///
+/// For Redfish URI-reference fields, such as action targets and update or
+/// stream URIs, this implementation resolves the URI reference and sends the
+/// request with the configured credentials and custom headers. It does not
+/// enforce same-origin policy for absolute URI references. Callers that need
+/// destination-host restrictions or credential/header forwarding controls
+/// should enforce them through a shared outbound URI policy.
+///
 /// # Type Parameters
 ///
 /// * `C` - The HTTP client implementation to use
@@ -346,6 +353,15 @@ pub struct RedfishEndpoint {
     base_url: Url,
 }
 
+/// Service-provided URI reference that must be resolved as a URI reference.
+///
+/// Constructing this marker is the internal opt-in for Redfish fields whose
+/// schemas allow URI references. Keep ordinary `ODataId` paths on
+/// [`RedfishEndpoint::with_path`] so they remain scoped to the configured BMC
+/// endpoint.
+#[derive(Clone, Copy)]
+struct UriReference<'a>(&'a str);
+
 impl RedfishEndpoint {
     /// Create a new `RedfishEndpoint` from a base URL
     #[must_use]
@@ -358,6 +374,44 @@ impl RedfishEndpoint {
     pub fn with_path(&self, path: &str) -> Url {
         let mut url = self.base_url.clone();
         url.set_path(path);
+        url
+    }
+
+    /// Resolve a Redfish-reported URI reference against this BMC endpoint.
+    ///
+    /// Callers must explicitly wrap service-provided values in
+    /// [`UriReference`] before using this method. Use it only for schema fields
+    /// that allow URI references, such as action targets,
+    /// `MultipartHttpPushUri`, `HttpPushUri`, and event stream URIs. Absolute
+    /// URIs are preserved, network-path references inherit the base scheme, and
+    /// path or relative references are resolved against the configured base
+    /// URL. If URL reference resolution rejects the value, fall back to path
+    /// replacement to preserve the historical BMC-relative handling.
+    ///
+    /// With base URL `https://bmc.example`:
+    /// - `https://other.example/redfish/v1/Actions/Reset` stays on
+    ///   `https://other.example`.
+    /// - `//other.example/redfish/v1/EventService/SSE` resolves to
+    ///   `https://other.example/redfish/v1/EventService/SSE`.
+    /// - `/redfish/v1/Systems/1/Actions/ComputerSystem.Reset` resolves to
+    ///   `https://bmc.example/redfish/v1/Systems/1/Actions/ComputerSystem.Reset`.
+    /// - `redfish/v1/UpdateService/upload` resolves relative to the base URL.
+    ///
+    /// Relative values without a leading slash use standard URI-reference
+    /// resolution. If the configured base URL includes a path component, that
+    /// can differ from direct path replacement.
+    ///
+    /// This method only performs URI-reference resolution. It does not decide
+    /// whether cross-host absolute URIs are allowed or whether credentials and
+    /// custom headers should be forwarded. Enforce those requirements as a
+    /// shared outbound URI policy before issuing requests.
+    fn with_uri_reference(&self, uri: UriReference<'_>) -> Url {
+        let UriReference(uri) = uri;
+
+        let Ok(url) = self.base_url.join(uri) else {
+            return self.with_path(uri);
+        };
+
         url
     }
 
@@ -593,7 +647,11 @@ where
         action: &Action<T, R>,
         params: &T,
     ) -> Result<ModificationResponse<R>, Self::Error> {
-        let endpoint_url = self.redfish_endpoint.with_path(&action.target.to_string());
+        let action_target = action.target.to_string();
+        let endpoint_url = self
+            .redfish_endpoint
+            .with_uri_reference(UriReference(&action_target));
+
         let credentials = self.read_credentials();
         self.client
             .post(
@@ -617,7 +675,7 @@ where
     {
         // MultipartHttpPushUri can be absolute or BMC-relative.
         // Match existing URI handling before adding auth and headers.
-        let endpoint_url = Url::parse(uri).unwrap_or_else(|_| self.redfish_endpoint.with_path(uri));
+        let endpoint_url = self.redfish_endpoint.with_uri_reference(UriReference(uri));
         let credentials = self.read_credentials();
 
         self.client
@@ -642,7 +700,7 @@ where
     {
         // HttpPushUri can be absolute or BMC-relative.
         // Match existing multipart URI handling before adding auth and headers.
-        let endpoint_url = Url::parse(uri).unwrap_or_else(|_| self.redfish_endpoint.with_path(uri));
+        let endpoint_url = self.redfish_endpoint.with_uri_reference(UriReference(uri));
         let credentials = self.read_credentials();
 
         self.client
@@ -671,10 +729,63 @@ where
         &self,
         uri: &str,
     ) -> Result<BoxTryStream<T, Self::Error>, Self::Error> {
-        let endpoint_url = Url::parse(uri).unwrap_or_else(|_| self.redfish_endpoint.with_path(uri));
+        let endpoint_url = self.redfish_endpoint.with_uri_reference(UriReference(uri));
         let credentials = self.read_credentials();
         self.client
             .sse(endpoint_url, credentials.as_ref(), &self.custom_headers)
             .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uri_reference_resolution_matches_documented_examples(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let endpoint = RedfishEndpoint::new(Url::parse("https://bmc.example")?);
+        let cases = [
+            (
+                "https://other.example/redfish/v1/Actions/Reset",
+                "https://other.example/redfish/v1/Actions/Reset",
+            ),
+            (
+                "//other.example/redfish/v1/EventService/SSE",
+                "https://other.example/redfish/v1/EventService/SSE",
+            ),
+            (
+                "/redfish/v1/Systems/1/Actions/ComputerSystem.Reset",
+                "https://bmc.example/redfish/v1/Systems/1/Actions/ComputerSystem.Reset",
+            ),
+            (
+                "redfish/v1/UpdateService/upload",
+                "https://bmc.example/redfish/v1/UpdateService/upload",
+            ),
+        ];
+
+        for (uri, expected) in cases {
+            assert_eq!(
+                endpoint.with_uri_reference(UriReference(uri)).as_str(),
+                expected,
+                "{uri}"
+            );
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn uri_reference_relative_path_follows_base_path() -> Result<(), Box<dyn std::error::Error>> {
+        let endpoint = RedfishEndpoint::new(Url::parse("https://bmc.example/proxy/")?);
+
+        let resolved = endpoint.with_uri_reference(UriReference("redfish/v1/UpdateService/upload"));
+
+        assert_eq!(
+            resolved.as_str(),
+            "https://bmc.example/proxy/redfish/v1/UpdateService/upload"
+        );
+
+        Ok(())
     }
 }

--- a/bmc-http/src/lib.rs
+++ b/bmc-http/src/lib.rs
@@ -50,6 +50,7 @@ pub mod reqwest;
 
 use std::collections::HashMap;
 use std::error::Error as StdError;
+use std::fmt;
 use std::future::Future;
 use std::sync::Arc;
 use std::sync::RwLock;
@@ -200,11 +201,11 @@ pub trait HttpClient: Send + Sync {
 /// to provide standardized access to Redfish services.
 ///
 /// For Redfish URI-reference fields, such as action targets and update or
-/// stream URIs, this implementation resolves the URI reference and sends the
-/// request with the configured credentials and custom headers. It does not
-/// enforce same-origin policy for absolute URI references. Callers that need
-/// destination-host restrictions or credential/header forwarding controls
-/// should enforce them through a shared outbound URI policy.
+/// stream URIs, this implementation resolves the URI reference against the
+/// configured BMC endpoint. It sends configured credentials and custom headers
+/// only when the resolved URL has the same parsed origin as the BMC endpoint.
+/// Cross-origin values are rejected before transport so callers can inspect and
+/// handle those targets explicitly.
 ///
 /// # Type Parameters
 ///
@@ -362,6 +363,21 @@ pub struct RedfishEndpoint {
 #[derive(Clone, Copy)]
 struct UriReference<'a>(&'a str);
 
+/// Error for a service URI reference rejected before transport.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RejectedUriReferenceError {
+    /// Reason the service URI reference was rejected.
+    pub reason: String,
+}
+
+impl StdError for RejectedUriReferenceError {}
+
+impl fmt::Display for RejectedUriReferenceError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.reason.fmt(f)
+    }
+}
+
 impl RedfishEndpoint {
     /// Create a new `RedfishEndpoint` from a base URL
     #[must_use]
@@ -377,42 +393,58 @@ impl RedfishEndpoint {
         url
     }
 
-    /// Resolve a Redfish-reported URI reference against this BMC endpoint.
+    /// Resolve a URI reference and verify that it stays on the BMC origin.
     ///
     /// Callers must explicitly wrap service-provided values in
     /// [`UriReference`] before using this method. Use it only for schema fields
     /// that allow URI references, such as action targets,
-    /// `MultipartHttpPushUri`, `HttpPushUri`, and event stream URIs. Absolute
-    /// URIs are preserved, network-path references inherit the base scheme, and
-    /// path or relative references are resolved against the configured base
-    /// URL. If URL reference resolution rejects the value, fall back to path
-    /// replacement to preserve the historical BMC-relative handling.
+    /// `MultipartHttpPushUri`, `HttpPushUri`, and event stream URIs. Same-origin
+    /// is checked with parsed URL origins: scheme, host, and effective port. It
+    /// is not a string prefix check, so prefix lookalikes such as
+    /// `https://bmc.example.evil/...` are rejected.
     ///
     /// With base URL `https://bmc.example`:
-    /// - `https://other.example/redfish/v1/Actions/Reset` stays on
-    ///   `https://other.example`.
-    /// - `//other.example/redfish/v1/EventService/SSE` resolves to
-    ///   `https://other.example/redfish/v1/EventService/SSE`.
+    /// - `https://bmc.example/redfish/v1/Actions/Reset` is accepted.
+    /// - `//bmc.example/redfish/v1/EventService/SSE` resolves to
+    ///   `https://bmc.example/redfish/v1/EventService/SSE`.
     /// - `/redfish/v1/Systems/1/Actions/ComputerSystem.Reset` resolves to
     ///   `https://bmc.example/redfish/v1/Systems/1/Actions/ComputerSystem.Reset`.
     /// - `redfish/v1/UpdateService/upload` resolves relative to the base URL.
+    /// - `https://bmc.example.evil/redfish/v1/Actions/Reset` is rejected.
+    /// - `//host:99999/path` is rejected because the authority is malformed.
     ///
     /// Relative values without a leading slash use standard URI-reference
     /// resolution. If the configured base URL includes a path component, that
-    /// can differ from direct path replacement.
-    ///
-    /// This method only performs URI-reference resolution. It does not decide
-    /// whether cross-host absolute URIs are allowed or whether credentials and
-    /// custom headers should be forwarded. Enforce those requirements as a
-    /// shared outbound URI policy before issuing requests.
-    fn with_uri_reference(&self, uri: UriReference<'_>) -> Url {
+    /// can differ from direct path replacement. Values rejected by
+    /// URI-reference resolution are rejected before transport.
+    fn with_same_origin_uri_reference(
+        &self,
+        uri: UriReference<'_>,
+    ) -> Result<Url, RejectedUriReferenceError> {
         let UriReference(uri) = uri;
 
-        let Ok(resolved) = self.base_url.join(uri) else {
-            return self.with_path(uri);
-        };
+        let resolved = self
+            .base_url
+            .join(uri)
+            .map_err(|source| RejectedUriReferenceError {
+                reason: format!(
+                    "service URI reference `{}` could not be resolved against \
+                     BMC endpoint `{}`: {source}",
+                    uri, self.base_url
+                ),
+            })?;
 
-        resolved
+        if resolved.origin() != self.base_url.origin() {
+            return Err(RejectedUriReferenceError {
+                reason: format!(
+                    "service URI reference `{}` resolved to `{resolved}`, \
+                     which is not same-origin with BMC endpoint `{}`",
+                    uri, self.base_url
+                ),
+            });
+        }
+
+        Ok(resolved)
     }
 
     /// Convert a path to a full Redfish endpoint URL with query parameters
@@ -470,9 +502,15 @@ pub trait CacheableError {
     fn cache_error(reason: String) -> Self;
 }
 
+/// Trait for errors that can represent request failures raised before transport.
+pub trait RequestError {
+    /// Create an error from a rejected service URI reference.
+    fn rejected_uri_reference(error: RejectedUriReferenceError) -> Self;
+}
+
 impl<C: HttpClient> HttpBmc<C>
 where
-    C::Error: CacheableError + StdError + Send + Sync,
+    C::Error: CacheableError + RequestError + StdError + Send + Sync,
 {
     #[allow(clippy::panic)] // See set_credentials Panic doc.
     fn read_credentials(&self) -> Arc<BmcCredentials> {
@@ -559,7 +597,7 @@ where
 
 impl<C: HttpClient> Bmc for HttpBmc<C>
 where
-    C::Error: CacheableError + StdError + Send + Sync,
+    C::Error: CacheableError + RequestError + StdError + Send + Sync,
 {
     type Error = C::Error;
 
@@ -647,10 +685,10 @@ where
         action: &Action<T, R>,
         params: &T,
     ) -> Result<ModificationResponse<R>, Self::Error> {
-        let action_target = action.target.to_string();
         let endpoint_url = self
             .redfish_endpoint
-            .with_uri_reference(UriReference(&action_target));
+            .with_same_origin_uri_reference(UriReference(action.target.as_str()))
+            .map_err(C::Error::rejected_uri_reference)?;
 
         let credentials = self.read_credentials();
         self.client
@@ -673,9 +711,11 @@ where
         R: Send + Sync + for<'de> Deserialize<'de>,
         V: Send + Sync + Serialize,
     {
-        // MultipartHttpPushUri can be absolute or BMC-relative.
-        // Match existing URI handling before adding auth and headers.
-        let endpoint_url = self.redfish_endpoint.with_uri_reference(UriReference(uri));
+        let endpoint_url = self
+            .redfish_endpoint
+            .with_same_origin_uri_reference(UriReference(uri))
+            .map_err(C::Error::rejected_uri_reference)?;
+
         let credentials = self.read_credentials();
 
         self.client
@@ -698,9 +738,11 @@ where
         U: UploadReader,
         R: Send + Sync + for<'de> Deserialize<'de>,
     {
-        // HttpPushUri can be absolute or BMC-relative.
-        // Match existing multipart URI handling before adding auth and headers.
-        let endpoint_url = self.redfish_endpoint.with_uri_reference(UriReference(uri));
+        let endpoint_url = self
+            .redfish_endpoint
+            .with_same_origin_uri_reference(UriReference(uri))
+            .map_err(C::Error::rejected_uri_reference)?;
+
         let credentials = self.read_credentials();
 
         self.client
@@ -729,7 +771,11 @@ where
         &self,
         uri: &str,
     ) -> Result<BoxTryStream<T, Self::Error>, Self::Error> {
-        let endpoint_url = self.redfish_endpoint.with_uri_reference(UriReference(uri));
+        let endpoint_url = self
+            .redfish_endpoint
+            .with_same_origin_uri_reference(UriReference(uri))
+            .map_err(C::Error::rejected_uri_reference)?;
+
         let credentials = self.read_credentials();
         self.client
             .sse(endpoint_url, credentials.as_ref(), &self.custom_headers)
@@ -740,19 +786,20 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::error::Error;
 
     #[test]
-    fn uri_reference_resolution_matches_documented_examples(
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    fn same_origin_uri_reference_matches_documented_examples() -> Result<(), Box<dyn Error>> {
         let endpoint = RedfishEndpoint::new(Url::parse("https://bmc.example")?);
+
         let cases = [
             (
-                "https://other.example/redfish/v1/Actions/Reset",
-                "https://other.example/redfish/v1/Actions/Reset",
+                "https://bmc.example/redfish/v1/Actions/Reset",
+                "https://bmc.example/redfish/v1/Actions/Reset",
             ),
             (
-                "//other.example/redfish/v1/EventService/SSE",
-                "https://other.example/redfish/v1/EventService/SSE",
+                "//bmc.example/redfish/v1/EventService/SSE",
+                "https://bmc.example/redfish/v1/EventService/SSE",
             ),
             (
                 "/redfish/v1/Systems/1/Actions/ComputerSystem.Reset",
@@ -766,7 +813,9 @@ mod tests {
 
         for (uri, expected) in cases {
             assert_eq!(
-                endpoint.with_uri_reference(UriReference(uri)).as_str(),
+                endpoint
+                    .with_same_origin_uri_reference(UriReference(uri))?
+                    .as_str(),
                 expected,
                 "{uri}"
             );
@@ -776,15 +825,46 @@ mod tests {
     }
 
     #[test]
-    fn uri_reference_relative_path_follows_base_path() -> Result<(), Box<dyn std::error::Error>> {
+    fn uri_reference_relative_path_follows_base_path() -> Result<(), Box<dyn Error>> {
         let endpoint = RedfishEndpoint::new(Url::parse("https://bmc.example/proxy/")?);
 
-        let resolved = endpoint.with_uri_reference(UriReference("redfish/v1/UpdateService/upload"));
+        let resolved = endpoint
+            .with_same_origin_uri_reference(UriReference("redfish/v1/UpdateService/upload"))?;
 
         assert_eq!(
             resolved.as_str(),
             "https://bmc.example/proxy/redfish/v1/UpdateService/upload"
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_prefix_lookalike_uri_reference() -> Result<(), Box<dyn Error>> {
+        let endpoint = RedfishEndpoint::new(Url::parse("https://bmc.example")?);
+
+        let result = endpoint.with_same_origin_uri_reference(UriReference(
+            "https://bmc.example.evil/redfish/v1/Actions/Reset",
+        ));
+
+        let error = result.expect_err("expected cross-origin URI reference error");
+
+        assert!(error.reason.contains("not same-origin"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_malformed_authority_uri_reference() -> Result<(), Box<dyn Error>> {
+        let endpoint = RedfishEndpoint::new(Url::parse("https://bmc.example")?);
+
+        for uri in ["//[:::1]/path", "//host:99999/path"] {
+            let result = endpoint.with_same_origin_uri_reference(UriReference(uri));
+
+            let error = result.expect_err("expected malformed URI reference error");
+
+            assert!(error.reason.contains("could not be resolved"));
+        }
 
         Ok(())
     }

--- a/bmc-http/src/reqwest.rs
+++ b/bmc-http/src/reqwest.rs
@@ -28,6 +28,8 @@ use crate::HttpClient;
 #[cfg(feature = "update-service-deprecated")]
 use crate::HttpPushUriUpdateRequest;
 use crate::MultipartUpdateRequest;
+use crate::RejectedUriReferenceError;
+use crate::RequestError;
 
 use futures_util::StreamExt as _;
 use http::header;
@@ -81,7 +83,7 @@ pub enum BmcError {
     DecodeError(serde_json::Error),
     /// JSON serialization error.
     EncodeError(serde_json::Error),
-    /// Invalid request error - data in the request didn't pass validation.
+    /// Request rejected before transport.
     InvalidRequest(String),
 }
 
@@ -105,6 +107,12 @@ impl CacheableError for BmcError {
 
     fn cache_error(reason: String) -> Self {
         Self::CacheError(reason)
+    }
+}
+
+impl RequestError for BmcError {
+    fn rejected_uri_reference(error: RejectedUriReferenceError) -> Self {
+        Self::InvalidRequest(error.reason)
     }
 }
 

--- a/bmc-http/tests/event_stream_tests.rs
+++ b/bmc-http/tests/event_stream_tests.rs
@@ -19,6 +19,7 @@ mod common;
 mod tests {
     use crate::common::test_utils::*;
     use futures_util::StreamExt;
+    use nv_redfish_bmc_http::reqwest::BmcError;
     use nv_redfish_core::Bmc;
     use serde::Deserialize;
     use serde_json::Value as JsonValue;
@@ -149,5 +150,17 @@ mod tests {
         );
 
         assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_event_stream_rejects_cross_origin_uri() {
+        let mock_server = MockServer::start().await;
+        let bmc = create_test_bmc(&mock_server);
+
+        let result = bmc
+            .stream::<JsonValue>("https://bmc.example.evil/redfish/v1/EventService/SSE")
+            .await;
+
+        assert!(matches!(result, Err(BmcError::InvalidRequest(_))));
     }
 }

--- a/bmc-http/tests/reqwest_client_tests.rs
+++ b/bmc-http/tests/reqwest_client_tests.rs
@@ -338,6 +338,30 @@ mod reqwest_client_tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn multipart_update_rejects_cross_origin_uri() -> Result<(), Box<dyn std::error::Error>> {
+        let mock_server = MockServer::start().await;
+        let bmc = create_test_bmc(&mock_server);
+
+        let request = MultipartUpdateRequest {
+            update_parameters: &(),
+            update_stream: DataStream::new("firmware.bin", Cursor::new(Vec::<u8>::new())),
+            oem_parts: Vec::new(),
+            upload_timeout: Duration::from_secs(600),
+        };
+
+        let result = bmc
+            .multipart_update::<_, _, TestResource>(
+                "https://bmc.example.evil/redfish/v1/UpdateService/upload",
+                request,
+            )
+            .await;
+
+        assert!(matches!(result, Err(BmcError::InvalidRequest(_))));
+
+        Ok(())
+    }
+
     #[cfg(feature = "update-service-deprecated")]
     #[tokio::test]
     async fn http_push_uri_relative_task() -> Result<(), Box<dyn std::error::Error>> {
@@ -417,6 +441,29 @@ mod reqwest_client_tests {
             .await?;
 
         assert!(matches!(response, ModificationResponse::Empty));
+
+        Ok(())
+    }
+
+    #[cfg(feature = "update-service-deprecated")]
+    #[tokio::test]
+    async fn http_push_uri_rejects_cross_origin_uri() -> Result<(), Box<dyn std::error::Error>> {
+        let mock_server = MockServer::start().await;
+        let bmc = create_test_bmc(&mock_server);
+
+        let request = HttpPushUriUpdateRequest {
+            update_stream: UploadStream::new(Cursor::new(b"firmware-bytes".to_vec())),
+            upload_timeout: Duration::from_secs(600),
+        };
+
+        let result = bmc
+            .http_push_uri_update::<_, ()>(
+                "https://bmc.example.evil/redfish/v1/UpdateService/update",
+                request,
+            )
+            .await;
+
+        assert!(matches!(result, Err(BmcError::InvalidRequest(_))));
 
         Ok(())
     }
@@ -506,8 +553,12 @@ mod reqwest_client_tests {
         assert!(matches!(upload, ModificationResponse::Empty));
 
         let resource_id = create_odata_id(resource_path);
-        let get_result = bmc.get::<TestResource>(&resource_id).await;
-        let Err(BmcError::ReqwestError(err)) = get_result else {
+        let error = bmc
+            .get::<TestResource>(&resource_id)
+            .await
+            .expect_err("expected default GET timeout");
+
+        let BmcError::ReqwestError(err) = error else {
             return Err(String::from("expected default GET timeout").into());
         };
 
@@ -790,6 +841,31 @@ mod reqwest_client_tests {
 
         assert_eq!(action_response.result, "Reset initiated");
         assert!(action_response.success);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_action_request_rejects_cross_origin_absolute_target(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mock_server = MockServer::start().await;
+
+        let action_request = ActionRequest {
+            parameter: "ForceRestart".to_string(),
+        };
+
+        let bmc = create_test_bmc(&mock_server);
+
+        let action = create_test_action(
+            "https://bmc.example.evil/redfish/v1/systems/1/Actions/ComputerSystem.Reset",
+        );
+
+        let error = bmc
+            .action(&action, &action_request)
+            .await
+            .expect_err("expected cross-origin action target error");
+
+        assert!(matches!(error, BmcError::InvalidRequest(_)));
 
         Ok(())
     }

--- a/bmc-http/tests/reqwest_client_tests.rs
+++ b/bmc-http/tests/reqwest_client_tests.rs
@@ -756,6 +756,45 @@ mod reqwest_client_tests {
     }
 
     #[tokio::test]
+    async fn test_action_request_absolute_target() -> Result<(), Box<dyn std::error::Error>> {
+        let mock_server = MockServer::start().await;
+        let action_path = "/redfish/v1/systems/1/Actions/ComputerSystem.Reset";
+        let action_url = format!("{}{action_path}", mock_server.uri());
+
+        let action_request = ActionRequest {
+            parameter: "ForceRestart".to_string(),
+        };
+
+        let action_response = ActionResponse {
+            result: "Reset initiated".to_string(),
+            success: true,
+        };
+
+        Mock::given(method("POST"))
+            .and(path(action_path))
+            .and(body_json(&action_request))
+            .and(header("authorization", "Basic cm9vdDpwYXNzd29yZA=="))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&action_response))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let bmc = create_test_bmc(&mock_server);
+
+        let action = create_test_action(&action_url);
+        let response = bmc.action(&action, &action_request).await?;
+
+        let ModificationResponse::Entity(action_response) = response else {
+            return Err(String::from("expected typed response body").into());
+        };
+
+        assert_eq!(action_response.result, "Reset initiated");
+        assert!(action_response.success);
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_action_request_empty_body_returns_empty() -> Result<(), Box<dyn std::error::Error>>
     {
         let mock_server = MockServer::start().await;

--- a/core/src/action.rs
+++ b/core/src/action.rs
@@ -56,7 +56,11 @@ use serde::Deserialize;
 use serde::Serialize;
 use std::marker::PhantomData;
 
-/// Type for the `target` field of an Action.
+/// URI reference for the `target` field of an action.
+///
+/// The [`Bmc`] implementation resolves this value when the action is run.
+/// Callers that need outbound URI restrictions should validate before calling
+/// or use a policy-enforcing [`Bmc`] implementation.
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
 pub struct ActionTarget(String);
@@ -82,7 +86,7 @@ impl Display for ActionTarget {
 /// `R` is the type for the return value.
 #[derive(Deserialize, Debug)]
 pub struct Action<T, R> {
-    /// Path that is used to trigger the action.
+    /// URI reference used to trigger the action.
     #[serde(rename = "target")]
     pub target: ActionTarget,
     // TODO: we can retrieve constraints on attributes here.
@@ -103,6 +107,10 @@ pub trait ActionError {
 
 impl<T: Send + Sync + Serialize, R: Send + Sync + Sized + for<'de> Deserialize<'de>> Action<T, R> {
     /// Run specific action with parameters passed as argument.
+    ///
+    /// URI-reference resolution is handled by [`Bmc::action`]. Callers that
+    /// need outbound URI restrictions should validate before calling or use a
+    /// policy-enforcing [`Bmc`] implementation.
     ///
     /// # Errors
     ///

--- a/core/src/action.rs
+++ b/core/src/action.rs
@@ -58,9 +58,8 @@ use std::marker::PhantomData;
 
 /// URI reference for the `target` field of an action.
 ///
-/// The [`Bmc`] implementation resolves this value when the action is run.
-/// Callers that need outbound URI restrictions should validate before calling
-/// or use a policy-enforcing [`Bmc`] implementation.
+/// The [`Bmc`] implementation resolves this value when the action is run and
+/// may reject values that violate its outbound request policy before transport.
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
 pub struct ActionTarget(String);
@@ -70,6 +69,12 @@ impl ActionTarget {
     #[must_use]
     pub const fn new(v: String) -> Self {
         Self(v)
+    }
+
+    /// Returns the action target URI reference.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
     }
 }
 
@@ -108,13 +113,13 @@ pub trait ActionError {
 impl<T: Send + Sync + Serialize, R: Send + Sync + Sized + for<'de> Deserialize<'de>> Action<T, R> {
     /// Run specific action with parameters passed as argument.
     ///
-    /// URI-reference resolution is handled by [`Bmc::action`]. Callers that
-    /// need outbound URI restrictions should validate before calling or use a
-    /// policy-enforcing [`Bmc`] implementation.
+    /// URI-reference resolution and outbound request policy are handled by
+    /// [`Bmc::action`].
     ///
     /// # Errors
     ///
-    /// Return error if BMC returned error on action.
+    /// Returns an error if the [`Bmc`] implementation rejects the action
+    /// request or if the Redfish service returns an error.
     pub async fn run<B: Bmc>(
         &self,
         bmc: &B,

--- a/core/src/bmc.rs
+++ b/core/src/bmc.rs
@@ -143,6 +143,15 @@ pub trait Bmc: Send + Sync {
 
     /// Run action.
     ///
+    /// Implementations should resolve the action `target` as a Redfish URI
+    /// reference. Absolute targets are allowed by Redfish and BMC-relative
+    /// targets should remain supported.
+    ///
+    /// Absolute URI references can point to a host other than the configured
+    /// BMC. Callers that need destination-host restrictions or
+    /// credential-forwarding controls should enforce them through a shared
+    /// outbound URI policy, not by changing URI resolution for one method.
+    ///
     /// `T` is structure that contains action parameters.
     /// `R` is structure with return type.
     fn action<T: Send + Sync + Serialize, R: Send + Sync + Sized + for<'de> Deserialize<'de>>(
@@ -152,6 +161,14 @@ pub trait Bmc: Send + Sync {
     ) -> impl Future<Output = Result<ModificationResponse<R>, Self::Error>> + Send;
 
     /// POST a Redfish `UpdateService` multipart upload using a named stream.
+    ///
+    /// `uri` is the service-provided `MultipartHttpPushUri` and should be
+    /// resolved as a Redfish URI reference.
+    ///
+    /// Absolute URI references can point to a host other than the configured
+    /// BMC. Callers that need destination-host restrictions or
+    /// credential-forwarding controls should enforce them through a shared
+    /// outbound URI policy.
     fn multipart_update<U, V, R>(
         &self,
         uri: &str,
@@ -163,6 +180,14 @@ pub trait Bmc: Send + Sync {
         V: Send + Sync + Serialize;
 
     /// POST a raw binary stream to a Redfish `UpdateService` `HttpPushUri`.
+    ///
+    /// `uri` is the service-provided `HttpPushUri` and should be resolved as a
+    /// Redfish URI reference.
+    ///
+    /// Absolute URI references can point to a host other than the configured
+    /// BMC. Callers that need destination-host restrictions or
+    /// credential-forwarding controls should enforce them through a shared
+    /// outbound URI policy.
     #[cfg(feature = "update-service-deprecated")]
     fn http_push_uri_update<U, R>(
         &self,
@@ -174,6 +199,13 @@ pub trait Bmc: Send + Sync {
         R: Send + Sync + for<'de> Deserialize<'de>;
 
     /// Stream data for the URI.
+    ///
+    /// `uri` should be resolved as a Redfish URI reference.
+    ///
+    /// Absolute URI references can point to a host other than the configured
+    /// BMC. Callers that need destination-host restrictions or
+    /// credential-forwarding controls should enforce them through a shared
+    /// outbound URI policy.
     ///
     /// `T` is structure that is used for the stream return type.
     fn stream<T: Sized + for<'de> Deserialize<'de> + Send + 'static>(

--- a/core/src/bmc.rs
+++ b/core/src/bmc.rs
@@ -147,10 +147,8 @@ pub trait Bmc: Send + Sync {
     /// reference. Absolute targets are allowed by Redfish and BMC-relative
     /// targets should remain supported.
     ///
-    /// Absolute URI references can point to a host other than the configured
-    /// BMC. Callers that need destination-host restrictions or
-    /// credential-forwarding controls should enforce them through a shared
-    /// outbound URI policy, not by changing URI resolution for one method.
+    /// Implementations may reject URI references that violate their outbound
+    /// request policy before transport.
     ///
     /// `T` is structure that contains action parameters.
     /// `R` is structure with return type.
@@ -165,10 +163,8 @@ pub trait Bmc: Send + Sync {
     /// `uri` is the service-provided `MultipartHttpPushUri` and should be
     /// resolved as a Redfish URI reference.
     ///
-    /// Absolute URI references can point to a host other than the configured
-    /// BMC. Callers that need destination-host restrictions or
-    /// credential-forwarding controls should enforce them through a shared
-    /// outbound URI policy.
+    /// Implementations may reject URI references that violate their outbound
+    /// request policy before transport.
     fn multipart_update<U, V, R>(
         &self,
         uri: &str,
@@ -184,10 +180,8 @@ pub trait Bmc: Send + Sync {
     /// `uri` is the service-provided `HttpPushUri` and should be resolved as a
     /// Redfish URI reference.
     ///
-    /// Absolute URI references can point to a host other than the configured
-    /// BMC. Callers that need destination-host restrictions or
-    /// credential-forwarding controls should enforce them through a shared
-    /// outbound URI policy.
+    /// Implementations may reject URI references that violate their outbound
+    /// request policy before transport.
     #[cfg(feature = "update-service-deprecated")]
     fn http_push_uri_update<U, R>(
         &self,
@@ -202,10 +196,8 @@ pub trait Bmc: Send + Sync {
     ///
     /// `uri` should be resolved as a Redfish URI reference.
     ///
-    /// Absolute URI references can point to a host other than the configured
-    /// BMC. Callers that need destination-host restrictions or
-    /// credential-forwarding controls should enforce them through a shared
-    /// outbound URI policy.
+    /// Implementations may reject URI references that violate their outbound
+    /// request policy before transport.
     ///
     /// `T` is structure that is used for the stream return type.
     fn stream<T: Sized + for<'de> Deserialize<'de> + Send + 'static>(


### PR DESCRIPTION
I debated this a bit, but this seems like a good addition overall. It lets `nv-redfish` handle action target URLs the same way it already handles update and stream URLs. If the service returns an absolute action target, we now use that URL directly instead of forcing it under the configured BMC endpoint.

The main tradeoff is that absolute action targets are followed as provided by the service. If such a target uses a different host than the configured BMC endpoint, the action request goes to that host using the `HttpBmc` credentials and custom headers. This flexibility already exists elsewhere in the client, but this extends it to actions. It seems reasonable to me, since outbound policy should be the caller's responsibility. I am open to feedback if a stricter default would be preferred.