### PR TITLE
fix(csdl-compiler): omit absent optional action parameters

### DIFF
--- a/csdl-compiler/src/generator/rust/struct_def.rs
+++ b/csdl-compiler/src/generator/rust/struct_def.rs
@@ -89,6 +89,14 @@ struct SerializableProperty<'a> {
     required_on_create: bool,
 }
 
+// Action request fields are generated as two coordinated token streams. Keeping
+// them in one value makes it harder to change the serde omission rule without
+// also considering the generated Rust field type.
+struct ActionParameterField {
+    serde_annotation: TokenStream,
+    field_type: TokenStream,
+}
+
 impl<'a> StructDef<'a> {
     /// Create `StructDef` builder.
     #[must_use]
@@ -601,7 +609,7 @@ impl<'a> StructDef<'a> {
         }
     }
 
-    // Returns serde annotation and field type token streams.
+    // Returns the Rust field type token stream.
     fn gen_de_struct_field_type<T>(
         cardinality: &OneOrCollection<T>,
         ftype: impl ToTokens,
@@ -697,7 +705,7 @@ impl<'a> StructDef<'a> {
         let doc = doc_format_and_generate(p.name, &p.odata);
         let rename = Literal::string(p.name.inner().inner());
         let name = StructFieldName::new_parameter(p.name);
-        let (serde, ptype) = match p.ptype {
+        let field = match p.ptype {
             ParameterType::Type(
                 ptype
                 @ (PropertyType::One((typeinfo, v)) | PropertyType::Collection((typeinfo, v))),
@@ -706,31 +714,80 @@ impl<'a> StructDef<'a> {
                     return quote! {};
                 }
                 let full_type = FullTypeName::new(v, config).for_update(Some(typeinfo.class));
-                Self::gen_de_struct_field(
-                    &ptype,
-                    full_type,
-                    rename,
-                    p.nullable,
-                    p.required,
-                    RigidArraySupport::new(false),
-                )
+                Self::gen_action_parameter_field(&ptype, full_type, &rename, p.nullable, p.required)
             }
             ParameterType::Entity(e) => {
                 let top = &config.top_module_alias;
-                Self::gen_de_struct_field(
+                Self::gen_action_parameter_field(
                     &e,
                     quote! { #top::Reference },
-                    rename,
+                    &rename,
                     p.nullable,
                     p.required,
-                    RigidArraySupport::new(false),
                 )
             }
         };
+        let serde = field.serde_annotation;
+        let ptype = field.field_type;
         quote! {
             #doc
             #serde
             pub #name: #ptype,
+        }
+    }
+
+    fn gen_action_parameter_field<T>(
+        cardinality: &OneOrCollection<T>,
+        ftype: impl ToTokens,
+        rename: impl ToTokens,
+        nullable: IsNullable,
+        required: IsRequired,
+    ) -> ActionParameterField {
+        //
+        // NOTE:
+        //
+        // Action request serialization depends on the generated Rust field
+        // type and serde annotation agreeing on the same `required` and
+        // `nullable` facts.
+        //
+        // `gen_de_struct_field_type` decides the Rust field type, such as
+        // `Option<T>` or `Option<Option<T>>`, so nullability is encoded in that
+        // type.
+        //
+        // `gen_action_parameter_serde_annotation` controls whether the field is
+        // always present in the action request body, or omitted when the outer
+        // `Option` is `None`. `skip_serializing_if = "Option::is_none"` is only
+        // valid when the generated field type has an outer `Option`; otherwise,
+        // a required field such as `Vec<T>` could be annotated with
+        // `Option::is_none`.
+        //
+        // The non-obvious coordination is that both helpers branch on
+        // `required`. In `gen_de_struct_field_type`, `required` generates a
+        // non-`Option` type, or an `Option` whose `None` should serialize as
+        // JSON `null`. That matches `gen_action_parameter_serde_annotation`:
+        // required fields have no `skip_serializing_if`, while optional fields
+        // omit outer `None`.
+        //
+        ActionParameterField {
+            serde_annotation: Self::gen_action_parameter_serde_annotation(rename, required),
+            field_type: Self::gen_de_struct_field_type(
+                cardinality,
+                ftype,
+                nullable,
+                required,
+                RigidArraySupport::new(false),
+            ),
+        }
+    }
+
+    fn gen_action_parameter_serde_annotation(
+        rename: impl ToTokens,
+        required: IsRequired,
+    ) -> TokenStream {
+        if required.into_inner() {
+            quote! { #[serde(rename=#rename)] }
+        } else {
+            quote! { #[serde(rename=#rename, skip_serializing_if = "Option::is_none")] }
         }
     }
 
@@ -1001,3 +1058,6 @@ impl<'a> StructDefBuilder<'a> {
         Ok(self.0)
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/csdl-compiler/src/generator/rust/struct_def/tests.rs
+++ b/csdl-compiler/src/generator/rust/struct_def/tests.rs
@@ -1,0 +1,124 @@
+use super::StructDef;
+use crate::IsNullable;
+use crate::IsRequired;
+use crate::OneOrCollection;
+
+use proc_macro2::Literal;
+use proc_macro2::TokenStream;
+use quote::quote;
+
+#[test]
+fn action_parameter_field_generation_combinations() {
+    struct TestCase {
+        name: &'static str,
+        cardinality: OneOrCollection<()>,
+        nullable: bool,
+        required: bool,
+        expected_serde_annotation: TokenStream,
+        expected_field_type: TokenStream,
+    }
+
+    // Cover the full action-parameter matrix that affects the coordinated
+    // serde annotation and Rust field type generation.
+    let cases = [
+        TestCase {
+            name: "required scalar",
+            cardinality: OneOrCollection::One(()),
+            nullable: false,
+            required: true,
+            expected_serde_annotation: quote! { #[serde(rename = "TestParam")] },
+            expected_field_type: quote! { TestType },
+        },
+        TestCase {
+            name: "required nullable scalar",
+            cardinality: OneOrCollection::One(()),
+            nullable: true,
+            required: true,
+            expected_serde_annotation: quote! { #[serde(rename = "TestParam")] },
+            expected_field_type: quote! { Option<TestType> },
+        },
+        TestCase {
+            name: "optional scalar",
+            cardinality: OneOrCollection::One(()),
+            nullable: false,
+            required: false,
+            expected_serde_annotation: quote! {
+                #[serde(rename = "TestParam", skip_serializing_if = "Option::is_none")]
+            },
+            expected_field_type: quote! { Option<TestType> },
+        },
+        TestCase {
+            name: "optional nullable scalar",
+            cardinality: OneOrCollection::One(()),
+            nullable: true,
+            required: false,
+            expected_serde_annotation: quote! {
+                #[serde(rename = "TestParam", skip_serializing_if = "Option::is_none")]
+            },
+            expected_field_type: quote! { Option<Option<TestType>> },
+        },
+        TestCase {
+            name: "required collection",
+            cardinality: OneOrCollection::Collection(()),
+            nullable: false,
+            required: true,
+            expected_serde_annotation: quote! { #[serde(rename = "TestParam")] },
+            expected_field_type: quote! { Vec<TestType> },
+        },
+        TestCase {
+            name: "required nullable collection",
+            cardinality: OneOrCollection::Collection(()),
+            nullable: true,
+            required: true,
+            expected_serde_annotation: quote! { #[serde(rename = "TestParam")] },
+            expected_field_type: quote! { Option<Vec<TestType>> },
+        },
+        TestCase {
+            name: "optional collection",
+            cardinality: OneOrCollection::Collection(()),
+            nullable: false,
+            required: false,
+            expected_serde_annotation: quote! {
+                #[serde(rename = "TestParam", skip_serializing_if = "Option::is_none")]
+            },
+            expected_field_type: quote! { Option<Vec<TestType>> },
+        },
+        TestCase {
+            name: "optional nullable collection",
+            cardinality: OneOrCollection::Collection(()),
+            nullable: true,
+            required: false,
+            expected_serde_annotation: quote! {
+                #[serde(rename = "TestParam", skip_serializing_if = "Option::is_none")]
+            },
+            expected_field_type: quote! { Option<Option<Vec<TestType>>> },
+        },
+    ];
+
+    for case in cases {
+        let field = StructDef::gen_action_parameter_field(
+            &case.cardinality,
+            quote! { TestType },
+            Literal::string("TestParam"),
+            IsNullable::new(case.nullable),
+            IsRequired::new(case.required),
+        );
+
+        assert_token_eq(
+            &field.serde_annotation,
+            &case.expected_serde_annotation,
+            case.name,
+            "serde annotation",
+        );
+        assert_token_eq(
+            &field.field_type,
+            &case.expected_field_type,
+            case.name,
+            "field type",
+        );
+    }
+}
+
+fn assert_token_eq(actual: &TokenStream, expected: &TokenStream, case: &str, field: &str) {
+    assert_eq!(actual.to_string(), expected.to_string(), "{case}: {field}");
+}

--- a/tests/schemas/base/schema.xml
+++ b/tests/schemas/base/schema.xml
@@ -190,6 +190,26 @@
         <Parameter Name="TestActionsService" Type="ServiceRoot.v1_0_0.TestActionsServiceActions"/>
         <Parameter Name="ActionType" Type="ServiceRoot.v1_0_0.ActionType" Nullable="false"/>
       </Action>
+      <Action Name="TestSerializationAction" IsBound="true">
+        <Parameter Name="TestActionsService" Type="ServiceRoot.v1_0_0.TestActionsServiceActions"/>
+        <Parameter Name="RequiredValue" Type="Edm.String" Nullable="false">
+          <Annotation Term="Redfish.Required"/>
+        </Parameter>
+        <Parameter Name="RequiredNullableValue" Type="Edm.String" Nullable="true">
+          <Annotation Term="Redfish.Required"/>
+        </Parameter>
+        <Parameter Name="RequiredCollection" Type="Collection(Edm.String)" Nullable="false">
+          <Annotation Term="Redfish.Required"/>
+        </Parameter>
+        <Parameter Name="RequiredNullableCollection" Type="Collection(Edm.String)" Nullable="true">
+          <Annotation Term="Redfish.Required"/>
+        </Parameter>
+        <Parameter Name="OptionalValue" Type="Edm.String" Nullable="false"/>
+        <Parameter Name="OptionalNullableValue" Type="Edm.String" Nullable="true"/>
+        <Parameter Name="OptionalCollection" Type="Collection(Edm.String)" Nullable="false"/>
+        <Parameter Name="OptionalNullableCollection" Type="Collection(Edm.String)" Nullable="true"/>
+        <Parameter Name="OptionalNullableEntity" Type="ServiceRoot.v1_0_0.TestRequiredService" Nullable="true"/>
+      </Action>
       <EnumType Name="ActionType">
         <Member Name="Option1"/>
         <Member Name="Option2"/>

--- a/tests/tests/tests-base-operations.rs
+++ b/tests/tests/tests-base-operations.rs
@@ -19,6 +19,8 @@ use nv_redfish_core::ModificationResponse;
 use nv_redfish_core::NavProperty;
 use nv_redfish_core::ODataId;
 use nv_redfish_core::RedfishSettings;
+use nv_redfish_core::Reference;
+use nv_redfish_core::ReferenceLeaf;
 use nv_redfish_core::Updatable;
 use nv_redfish_tests::base::expect_root;
 use nv_redfish_tests::base::expect_root_srv;
@@ -28,6 +30,7 @@ use nv_redfish_tests::base::redfish::service_root::ActionType;
 use nv_redfish_tests::base::redfish::service_root::ReadOnlyComplexTypeUpdate;
 use nv_redfish_tests::base::redfish::service_root::RootSetOnlyComplexType;
 use nv_redfish_tests::base::redfish::service_root::ServiceRootUpdate;
+use nv_redfish_tests::base::redfish::service_root::TestActionsServiceTestSerializationActionAction;
 use nv_redfish_tests::base::redfish::service_root::TestCollectionMemberCreate;
 use nv_redfish_tests::json_merge;
 use nv_redfish_tests::Bmc;
@@ -36,6 +39,7 @@ use nv_redfish_tests::Expect;
 use nv_redfish_tests::ODATA_ID;
 use nv_redfish_tests::ODATA_TYPE;
 use serde_json::json;
+use serde_json::Value;
 use tokio::test;
 
 // Check trivial service root retrieval and version read.
@@ -616,6 +620,105 @@ async fn action_method_test() -> Result<(), Error> {
         .test_action(&bmc, Some(ActionType::Option1))
         .await
         .map_err(Error::Bmc)?;
+
+    Ok(())
+}
+
+#[test]
+async fn action_parameter_serialization_test() -> Result<(), Error> {
+    struct TestCase {
+        name: &'static str,
+        request: TestActionsServiceTestSerializationActionAction,
+        expected: Value,
+    }
+
+    fn reference(id: &str) -> Reference {
+        Reference::from(&ReferenceLeaf {
+            odata_id: id.to_string().into(),
+        })
+    }
+
+    let cases = [
+        TestCase {
+            name: "optional fields are omitted and required nullable null is present",
+            request: TestActionsServiceTestSerializationActionAction {
+                required_value: "required".into(),
+                required_nullable_value: None,
+                required_collection: vec!["required collection".into()],
+                required_nullable_collection: None,
+                optional_value: None,
+                optional_nullable_value: None,
+                optional_collection: None,
+                optional_nullable_collection: None,
+                optional_nullable_entity: None,
+            },
+            expected: json!({
+                "RequiredValue": "required",
+                "RequiredNullableValue": null,
+                "RequiredCollection": ["required collection"],
+                "RequiredNullableCollection": null,
+            }),
+        },
+        TestCase {
+            name: "optional nullable fields can serialize explicit null",
+            request: TestActionsServiceTestSerializationActionAction {
+                required_value: "required".into(),
+                required_nullable_value: Some("required nullable".into()),
+                required_collection: vec!["required collection".into()],
+                required_nullable_collection: Some(vec!["required nullable collection".into()]),
+                optional_value: None,
+                optional_nullable_value: Some(None),
+                optional_collection: None,
+                optional_nullable_collection: Some(None),
+                optional_nullable_entity: Some(None),
+            },
+            expected: json!({
+                "RequiredValue": "required",
+                "RequiredNullableValue": "required nullable",
+                "RequiredCollection": ["required collection"],
+                "RequiredNullableCollection": ["required nullable collection"],
+                "OptionalNullableValue": null,
+                "OptionalNullableCollection": null,
+                "OptionalNullableEntity": null,
+            }),
+        },
+        TestCase {
+            name: "optional fields serialize values when present",
+            request: TestActionsServiceTestSerializationActionAction {
+                required_value: "required".into(),
+                required_nullable_value: Some("required nullable".into()),
+                required_collection: vec!["required collection".into()],
+                required_nullable_collection: Some(vec!["required nullable collection".into()]),
+                optional_value: Some("optional".into()),
+                optional_nullable_value: Some(Some("optional nullable".into())),
+                optional_collection: Some(vec!["a".into(), "b".into()]),
+                optional_nullable_collection: Some(Some(vec!["c".into(), "d".into()])),
+                optional_nullable_entity: Some(Some(reference("/redfish/v1/TestRequiredService"))),
+            },
+            expected: json!({
+                "RequiredValue": "required",
+                "RequiredNullableValue": "required nullable",
+                "RequiredCollection": ["required collection"],
+                "RequiredNullableCollection": ["required nullable collection"],
+                "OptionalValue": "optional",
+                "OptionalNullableValue": "optional nullable",
+                "OptionalCollection": ["a", "b"],
+                "OptionalNullableCollection": ["c", "d"],
+                "OptionalNullableEntity": {
+                    "@odata.id": "/redfish/v1/TestRequiredService",
+                },
+            }),
+        },
+    ];
+
+    for case in cases {
+        assert_eq!(
+            serde_json::to_value(&case.request).expect("action request should serialize"),
+            case.expected,
+            "{}",
+            case.name
+        );
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Generate action request fields so optional parameters are omitted when the caller leaves the top-level `Option` as None, while required nullable parameters still serialize `None` as JSON null.

Added test coverage for the required/nullability/cardinality matrix and the generated request-body serialization behavior.