### PR TITLE
Fix query-aware HTTP cache keys

### DIFF
--- a/bmc-http/src/lib.rs
+++ b/bmc-http/src/lib.rs
@@ -214,8 +214,8 @@ pub struct HttpBmc<C: HttpClient> {
     client: C,
     redfish_endpoint: RedfishEndpoint,
     credentials: RwLock<Arc<BmcCredentials>>,
-    cache: RwLock<TypeErasedCarCache<ODataId>>,
-    etags: RwLock<HashMap<ODataId, ODataETag>>,
+    cache: RwLock<TypeErasedCarCache<Url>>,
+    etags: RwLock<HashMap<Url, ODataETag>>,
     custom_headers: HeaderMap,
 }
 
@@ -531,15 +531,16 @@ where
     async fn get_with_cache<T: EntityTypeRef + for<'de> Deserialize<'de> + 'static>(
         &self,
         endpoint_url: Url,
-        id: &ODataId,
     ) -> Result<Arc<T>, C::Error> {
+        let cache_key = endpoint_url.clone();
+
         // Retrieve cached etag
         let etag: Option<ODataETag> = {
             let etags = self
                 .etags
                 .read()
                 .map_err(|e| C::Error::cache_error(e.to_string()))?;
-            etags.get(id).cloned()
+            etags.get(&cache_key).cloned()
         };
         let credentials = self.read_credentials();
 
@@ -569,10 +570,12 @@ where
                         .write()
                         .map_err(|e| C::Error::cache_error(e.to_string()))?;
 
-                    if let Some(evicted_id) = cache.put_typed(id.clone(), Arc::clone(&entity)) {
-                        etags.remove(&evicted_id);
+                    if let Some(evicted_url) =
+                        cache.put_typed(cache_key.clone(), Arc::clone(&entity))
+                    {
+                        etags.remove(&evicted_url);
                     }
-                    etags.insert(id.clone(), etag.clone());
+                    etags.insert(cache_key.clone(), etag.clone());
                 }
                 Ok(entity)
             }
@@ -584,7 +587,7 @@ where
                         .write()
                         .map_err(|e| C::Error::cache_error(e.to_string()))?;
                     cache
-                        .get_typed::<Arc<T>>(id)
+                        .get_typed::<Arc<T>>(&cache_key)
                         .cloned()
                         .ok_or_else(C::Error::cache_miss)
                 } else {
@@ -606,7 +609,7 @@ where
         id: &ODataId,
     ) -> Result<Arc<T>, Self::Error> {
         let endpoint_url = self.redfish_endpoint.with_path(&id.to_string());
-        self.get_with_cache(endpoint_url, id).await
+        self.get_with_cache(endpoint_url).await
     }
 
     async fn expand<T: Expandable + 'static>(
@@ -618,7 +621,7 @@ where
             .redfish_endpoint
             .with_path_and_query(&id.to_string(), &query.to_query_string());
 
-        self.get_with_cache(endpoint_url, id).await
+        self.get_with_cache(endpoint_url).await
     }
 
     async fn create<V: Sync + Send + Serialize, R: Sync + Send + for<'de> Deserialize<'de>>(
@@ -764,7 +767,7 @@ where
             .redfish_endpoint
             .with_path_and_query(&id.to_string(), &query.to_query_string());
 
-        self.get_with_cache(endpoint_url, id).await
+        self.get_with_cache(endpoint_url).await
     }
 
     async fn stream<T: Send + Sized + for<'de> Deserialize<'de>>(

--- a/bmc-http/tests/etag_cache_tests.rs
+++ b/bmc-http/tests/etag_cache_tests.rs
@@ -20,12 +20,68 @@ mod cache_integration_tests {
     use crate::common::test_utils::*;
 
     use nv_redfish_bmc_http::reqwest::BmcError;
+    use nv_redfish_core::query::{ExpandQuery, FilterQuery};
     use nv_redfish_core::Bmc;
     use std::sync::Arc;
     use wiremock::{
-        matchers::{header, method, path},
+        matchers::{header, method, path, query_param},
         Mock, MockServer, ResponseTemplate,
     };
+
+    async fn mount_distinct_query_cache_mocks(
+        mock_server: &MockServer,
+        resource_path: &str,
+        query_name: &str,
+        first_query_value: &str,
+        first_resource: &TestResource,
+        second_query_value: &str,
+        second_resource: &TestResource,
+        etag_value: &str,
+    ) {
+        Mock::given(method("GET"))
+            .and(path(resource_path))
+            .and(query_param(query_name, first_query_value))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(first_resource)
+                    .insert_header("etag", etag_value),
+            )
+            .up_to_n_times(1)
+            .expect(1)
+            .mount(mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path(resource_path))
+            .and(query_param(query_name, second_query_value))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(second_resource)
+                    .insert_header("etag", etag_value),
+            )
+            .up_to_n_times(1)
+            .expect(1)
+            .mount(mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path(resource_path))
+            .and(query_param(query_name, first_query_value))
+            .and(header("if-none-match", etag_value))
+            .respond_with(ResponseTemplate::new(304))
+            .expect(1)
+            .mount(mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path(resource_path))
+            .and(query_param(query_name, second_query_value))
+            .and(header("if-none-match", etag_value))
+            .respond_with(ResponseTemplate::new(304))
+            .expect(1)
+            .mount(mock_server)
+            .await;
+    }
 
     #[tokio::test]
     async fn test_initial_request_caches_resource() {
@@ -104,6 +160,119 @@ mod cache_integration_tests {
         assert_eq!(retrieved1.value, retrieved2.value);
 
         assert!(Arc::ptr_eq(&retrieved1, &retrieved2));
+    }
+
+    #[tokio::test]
+    async fn test_expand_cache_key_includes_query() {
+        let mock_server = MockServer::start().await;
+        let resource_path = paths::SYSTEMS_1;
+        let etag_value = "shared-expand";
+
+        let shallow_resource =
+            create_test_resource(resource_path, Some(etag_value), "Shallow System", 1);
+        let deep_resource = create_test_resource(resource_path, Some(etag_value), "Deep System", 2);
+
+        mount_distinct_query_cache_mocks(
+            &mock_server,
+            resource_path,
+            "$expand",
+            ".($levels=1)",
+            &shallow_resource,
+            ".($levels=2)",
+            &deep_resource,
+            etag_value,
+        )
+        .await;
+
+        let bmc = create_test_bmc(&mock_server);
+        let resource_id = create_odata_id(resource_path);
+
+        let shallow = bmc
+            .expand::<TestResource>(&resource_id, ExpandQuery::current().levels(1))
+            .await
+            .unwrap();
+        assert_eq!(shallow.name, "Shallow System");
+        assert_eq!(shallow.value, 1);
+
+        let deep = bmc
+            .expand::<TestResource>(&resource_id, ExpandQuery::current().levels(2))
+            .await
+            .unwrap();
+        assert_eq!(deep.name, "Deep System");
+        assert_eq!(deep.value, 2);
+
+        let shallow_cached = bmc
+            .expand::<TestResource>(&resource_id, ExpandQuery::current().levels(1))
+            .await
+            .unwrap();
+        assert_eq!(shallow_cached.name, "Shallow System");
+        assert_eq!(shallow_cached.value, 1);
+        assert!(Arc::ptr_eq(&shallow, &shallow_cached));
+
+        let deep_cached = bmc
+            .expand::<TestResource>(&resource_id, ExpandQuery::current().levels(2))
+            .await
+            .unwrap();
+        assert_eq!(deep_cached.name, "Deep System");
+        assert_eq!(deep_cached.value, 2);
+        assert!(Arc::ptr_eq(&deep, &deep_cached));
+    }
+
+    #[tokio::test]
+    async fn test_filter_cache_key_includes_query() {
+        let mock_server = MockServer::start().await;
+        let resource_path = paths::SYSTEMS_1;
+        let etag_value = "shared-filter";
+
+        let smaller_resource =
+            create_test_resource(resource_path, Some(etag_value), "Smaller System", 10);
+        let larger_resource =
+            create_test_resource(resource_path, Some(etag_value), "Larger System", 100);
+
+        mount_distinct_query_cache_mocks(
+            &mock_server,
+            resource_path,
+            "$filter",
+            "value gt 10",
+            &smaller_resource,
+            "value gt 100",
+            &larger_resource,
+            etag_value,
+        )
+        .await;
+
+        let bmc = create_test_bmc(&mock_server);
+        let resource_id = create_odata_id(resource_path);
+
+        let smaller = bmc
+            .filter::<TestResource>(&resource_id, FilterQuery::gt(&"value", 10))
+            .await
+            .unwrap();
+        assert_eq!(smaller.name, "Smaller System");
+        assert_eq!(smaller.value, 10);
+
+        let larger = bmc
+            .filter::<TestResource>(&resource_id, FilterQuery::gt(&"value", 100))
+            .await
+            .unwrap();
+        assert_eq!(larger.name, "Larger System");
+        assert_eq!(larger.value, 100);
+
+        let smaller_cached = bmc
+            .filter::<TestResource>(&resource_id, FilterQuery::gt(&"value", 10))
+            .await
+            .unwrap();
+        assert_eq!(smaller_cached.name, "Smaller System");
+        assert_eq!(smaller_cached.value, 10);
+        assert!(Arc::ptr_eq(&smaller, &smaller_cached));
+
+        let larger_cached = bmc
+            .filter::<TestResource>(&resource_id, FilterQuery::gt(&"value", 100))
+            .await
+            .unwrap();
+        assert_eq!(larger_cached.name, "Larger System");
+        assert_eq!(larger_cached.value, 100);
+        assert!(Arc::ptr_eq(&larger, &larger_cached));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- key HTTP cache and ETag entries by the full request URL instead of only the ODataId
- keep different $expand and $filter representations independent even when they share an ETag
- add regression tests for distinct query responses and 304 cache hits

## Validation
- cargo fmt -p nv-redfish-bmc-http -- --check
- cargo test -p nv-redfish-bmc-http --features reqwest