### PR TITLE
fix: add bmc-quirks for lenovo-gb300 [AMI]

### DIFF
--- a/redfish/src/bmc_quirks.rs
+++ b/redfish/src/bmc_quirks.rs
@@ -32,7 +32,7 @@ enum Platform {
     Hpe,
     Dell,
     AmiViking,
-    Ami,
+    AmiGb300,
     Nvidia,
     NvidiaDpu,
     Anonymous1_9_0,
@@ -44,11 +44,22 @@ impl BmcQuirks {
         let vendor_str = root.vendor.as_ref().and_then(Option::as_deref);
         let redfish_version_str = root.redfish_version.as_deref();
         let product_str = root.product.as_ref().and_then(Option::as_deref);
+        // The GB300 host BMC exposes an AMI OEM `RtpVersion` in the service
+        // root; use it to distinguish GB300 from other AMI BMCs so the
+        // expand workaround is not applied to every AMI platform.
+        let rtp_version = root
+            .base
+            .base
+            .oem
+            .as_ref()
+            .and_then(|oem| oem.additional_properties.get("Ami"))
+            .and_then(|ami| ami.get("RtpVersion"))
+            .and_then(|v| v.as_str());
         let platform = match vendor_str {
             Some("HPE") => Some(Platform::Hpe),
             Some("Dell") => Some(Platform::Dell),
             Some("AMI") if redfish_version_str == Some("1.11.0") => Some(Platform::AmiViking),
-            Some("AMI") => Some(Platform::Ami),
+            Some("AMI") if rtp_version == Some("13.09.1") => Some(Platform::AmiGb300),
             Some("NVIDIA") if product_str == Some("P3809") => Some(Platform::NvSwitch),
             Some("NVIDIA") => Some(Platform::Nvidia),
             Some("Nvidia") if product_str == Some("Nvidia-BMCMezz") => Some(Platform::NvidiaDpu),
@@ -210,7 +221,7 @@ impl BmcQuirks {
     /// responses that drop Required fields (Id/Name/ChassisType) from embedded
     /// members; the standalone resource GETs are complete, so disabling expand
     /// makes nv-redfish fetch each member individually and parse correctly.
-    pub(crate) fn expand_is_not_working_properly(&self) -> bool {
-        matches!(self.platform, Some(Platform::AmiViking | Platform::Ami))
+    pub(crate) const fn expand_is_not_working_properly(&self) -> bool {
+        matches!(self.platform, Some(Platform::AmiViking | Platform::AmiGb300))
     }
 }

--- a/redfish/src/bmc_quirks.rs
+++ b/redfish/src/bmc_quirks.rs
@@ -32,6 +32,7 @@ enum Platform {
     Hpe,
     Dell,
     AmiViking,
+    Ami,
     Nvidia,
     NvidiaDpu,
     Anonymous1_9_0,
@@ -47,6 +48,7 @@ impl BmcQuirks {
             Some("HPE") => Some(Platform::Hpe),
             Some("Dell") => Some(Platform::Dell),
             Some("AMI") if redfish_version_str == Some("1.11.0") => Some(Platform::AmiViking),
+            Some("AMI") => Some(Platform::Ami),
             Some("NVIDIA") if product_str == Some("P3809") => Some(Platform::NvSwitch),
             Some("NVIDIA") => Some(Platform::Nvidia),
             Some("Nvidia") if product_str == Some("Nvidia-BMCMezz") => Some(Platform::NvidiaDpu),
@@ -202,8 +204,13 @@ impl BmcQuirks {
 
     /// In some cases we expand is not working according to spec,
     /// if it is the case for specific chassis, we would disable
-    /// expand api
+    /// expand api.
+    ///
+    /// AMI host BMCs (Viking and the GB300-class `Ami`) return `$expand`
+    /// responses that drop Required fields (Id/Name/ChassisType) from embedded
+    /// members; the standalone resource GETs are complete, so disabling expand
+    /// makes nv-redfish fetch each member individually and parse correctly.
     pub(crate) fn expand_is_not_working_properly(&self) -> bool {
-        self.platform == Some(Platform::AmiViking)
+        matches!(self.platform, Some(Platform::AmiViking | Platform::Ami))
     }
 }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -66,6 +66,40 @@ pub fn ami_viking_service_root(root_id: &ODataId, fields: Value) -> Value {
     json_merge([&base, &fields])
 }
 
+/// Build an AMI ServiceRoot payload (`Vendor=AMI`) with the given
+/// `RedfishVersion` and optional AMI OEM `RtpVersion`, merged with `fields`.
+///
+/// `RtpVersion=Some("13.09.1")` identifies a Grace-based NVIDIA GB300 host BMC.
+pub fn ami_service_root(
+    root_id: &ODataId,
+    redfish_version: &str,
+    rtp_version: Option<&str>,
+    fields: Value,
+) -> Value {
+    let mut base = json!({
+        ODATA_ID: root_id,
+        ODATA_TYPE: "#ServiceRoot.v1_13_0.ServiceRoot",
+        "Id": "RootService",
+        "Name": "RootService",
+        "ProtocolFeaturesSupported": {
+            "ExpandQuery": {
+                "NoLinks": true
+            }
+        },
+        "Vendor": "AMI",
+        "RedfishVersion": redfish_version,
+        "Links": {
+            "Sessions": {
+                ODATA_ID: format!("{root_id}/SessionService/Sessions"),
+            }
+        },
+    });
+    if let Some(rtp) = rtp_version {
+        base["Oem"] = json!({ "Ami": { "RtpVersion": rtp } });
+    }
+    json_merge([&base, &fields])
+}
+
 /// Build a ServiceRoot payload for anonymous Redfish 1.9.0 platforms
 /// (Liteon powershelf class) merged with the provided `fields`.
 pub fn anonymous_1_9_service_root(root_id: &ODataId, fields: Value) -> Value {

--- a/tests/tests/test-chassis.rs
+++ b/tests/tests/test-chassis.rs
@@ -21,6 +21,7 @@ use nv_redfish::resource::ResetType;
 use nv_redfish::ServiceRoot;
 use nv_redfish_core::ModificationResponse;
 use nv_redfish_core::ODataId;
+use nv_redfish_tests::ami_service_root;
 use nv_redfish_tests::ami_viking_service_root;
 use nv_redfish_tests::anonymous_1_9_service_root;
 use nv_redfish_tests::expect_redfish_reset_action;
@@ -333,6 +334,68 @@ async fn ami_viking_missing_chassis_name_workaround() -> Result<(), Box<dyn StdE
 }
 
 #[test]
+async fn ami_gb300_disables_expand_for_chassis_collection() -> Result<(), Box<dyn StdError>> {
+    // Platform under test: Grace-based NVIDIA GB300 host BMC (AMI, RtpVersion 13.09.1).
+    // Quirk under test: its `$expand` drops Required fields (Id/Name/ChassisType)
+    // from embedded members, so the collection is fetched with a plain GET and
+    // members are fetched individually (complete) rather than via `$expand`.
+    let bmc = Arc::new(Bmc::default());
+    let ids = ids();
+    let root = expect_gb300_service_root(
+        bmc.clone(),
+        &ids,
+        json!({
+            "Chassis": { ODATA_ID: &ids.chassis_collection_id }
+        }),
+    )
+    .await?;
+    // A plain (non-`$expand`) collection GET; if the quirk did not apply the
+    // collection would be fetched via `$expand` and this expectation would not
+    // match.
+    expect_chassis_collection(bmc.clone(), &ids);
+
+    let collection = root.chassis().await?.unwrap();
+    expect_chassis_get(bmc.clone(), &ids, valid_chassis_payload(&ids));
+    let members = collection.members().await?;
+    assert_eq!(members.len(), 1);
+
+    Ok(())
+}
+
+#[test]
+async fn ami_without_gb300_rtp_version_uses_expand() -> Result<(), Box<dyn StdError>> {
+    // A non-GB300 AMI BMC (no GB300 `RtpVersion`) must NOT be penalized: it keeps
+    // using `$expand` for collections.
+    let bmc = Arc::new(Bmc::default());
+    let ids = ids();
+    let root = expect_generic_ami_service_root(
+        bmc.clone(),
+        &ids,
+        json!({
+            "Chassis": { ODATA_ID: &ids.chassis_collection_id }
+        }),
+    )
+    .await?;
+    // Collection fetched via `$expand` with the member inline.
+    bmc.expect(Expect::expand(
+        &ids.chassis_collection_id,
+        json!({
+            ODATA_ID: &ids.chassis_collection_id,
+            ODATA_TYPE: CHASSIS_COLLECTION_DATA_TYPE,
+            "Id": "Chassis",
+            "Name": "Chassis Collection",
+            "Members": [valid_chassis_payload(&ids)]
+        }),
+    ));
+
+    let collection = root.chassis().await?.unwrap();
+    let members = collection.members().await?;
+    assert_eq!(members.len(), 1);
+
+    Ok(())
+}
+
+#[test]
 async fn anonymous_1_9_0_wrong_chassis_status_state_workaround() -> Result<(), Box<dyn StdError>> {
     // Platform under test: Liteon powershelf class (anonymous Redfish 1.9.0 root).
     // Quirk under test: invalid Chassis.Status.State="Standby".
@@ -526,6 +589,30 @@ async fn expect_viking_service_root(
     bmc.expect(Expect::get(
         &ids.root_id,
         ami_viking_service_root(&ids.root_id, fields),
+    ));
+    ServiceRoot::new(bmc).await.map_err(Into::into)
+}
+
+async fn expect_gb300_service_root(
+    bmc: Arc<Bmc>,
+    ids: &Ids,
+    fields: Value,
+) -> Result<ServiceRoot<Bmc>, Box<dyn StdError>> {
+    bmc.expect(Expect::get(
+        &ids.root_id,
+        ami_service_root(&ids.root_id, "1.21.1", Some("13.09.1"), fields),
+    ));
+    ServiceRoot::new(bmc).await.map_err(Into::into)
+}
+
+async fn expect_generic_ami_service_root(
+    bmc: Arc<Bmc>,
+    ids: &Ids,
+    fields: Value,
+) -> Result<ServiceRoot<Bmc>, Box<dyn StdError>> {
+    bmc.expect(Expect::get(
+        &ids.root_id,
+        ami_service_root(&ids.root_id, "1.21.1", None, fields),
     ));
     ServiceRoot::new(bmc).await.map_err(Into::into)
 }


### PR DESCRIPTION
## Summary
AMI host BMCs return `$expand` collection responses that drop Redfish-`Required` fields (`Id`, `Name`, `ChassisType`) from embedded members, causing deserialization to fail with `missing field ...` for the whole collection. The standalone resource GETs are complete however.

We already handle this for Viking via `expand_is_not_working_properly`, which makes nv-redfish fetch each member with an individual GET. This extends the same workaround to the Grace-based NVIDIA GB300 host BMC, identified by its AMI OEM `RtpVersion` in the service root.

## Changes
- Add a `Platform::AmiGb300` variant.
- Classify `Vendor == "AMI"` with `Oem.Ami.RtpVersion == "13.09.1"` (and not Viking) as `Platform::AmiGb300`. Other AMI BMCs are unchanged and keep using `$expand`.
- Extend `expand_is_not_working_properly()` to `AmiViking | AmiGb300`.

`Platform::AmiGb300` deliberately does **not** inherit Viking's other quirks (the `filter_computer_system_odata_ids` / `filter_manager_odata_ids` allowlists are Viking-topology-specific and would drop GB300's real host system/manager; the `ChassisType` / `Name` / root-nav defaults aren't needed since GB300's standalone GETs are complete).

## Testing
Added integration tests (`test-chassis.rs`): a GB300 root (`RtpVersion 13.09.1`) fetches members individually, and a non-GB300 AMI root still uses `$expand`.

Verified against a live Lenovo GB300 BMC: exploration previously failed on `missing field ChassisType` / `Id`; with expand disabled it now returns a full report (chassis, systems, managers, firmware inventory).

Even with expand functionality removed, report generation happens relatively quickly:
```
real    0m21.550s
user    0m0.784s
sys     0m0.188s
```