### PR TITLE
Handle members: null response

### DIFF
--- a/core/src/deserialize.rs
+++ b/core/src/deserialize.rs
@@ -44,3 +44,13 @@ where
 {
     Deserialize::deserialize(de)
 }
+
+/// Deserialize a `null` field as an empty array.
+/// Some BMCs return `{"Members": null}` instead of `{"Members": []}`.
+pub fn de_null_to_empty_vec<'de, D, T>(deserializer: D) -> Result<Vec<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    Ok(Option::<Vec<T>>::deserialize(deserializer)?.unwrap_or_default())
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -101,6 +101,8 @@ pub use action::ActionError;
 #[doc(inline)]
 pub use bmc::Bmc;
 #[doc(inline)]
+pub use deserialize::de_null_to_empty_vec;
+#[doc(inline)]
 pub use deserialize::de_optional_nullable;
 #[doc(inline)]
 pub use deserialize::de_required_nullable;

--- a/csdl-compiler/src/generator/rust/mod.rs
+++ b/csdl-compiler/src/generator/rust/mod.rs
@@ -187,6 +187,7 @@ impl<'a> RustGenerator<'a> {
                 ToSnakeCase,
                 de_optional_nullable,
                 de_required_nullable,
+                de_null_to_empty_vec,
             };
 
             pub mod edm {

--- a/csdl-compiler/src/generator/rust/mod_def.rs
+++ b/csdl-compiler/src/generator/rust/mod_def.rs
@@ -384,7 +384,7 @@ impl<'a> ModDef<'a> {
                 Self::generate_ref_to_top_module(self.depth, config),
                 quote! {
                     use serde::{Serialize, Deserialize};
-                    use #top::{NavProperty, ODataId, ODataETag, de_optional_nullable, de_required_nullable};
+                    use #top::{NavProperty, ODataId, ODataETag, de_optional_nullable, de_required_nullable, de_null_to_empty_vec};
                     use #top::ActionError as _;
                 },
             ]);

--- a/csdl-compiler/src/generator/rust/struct_def.rs
+++ b/csdl-compiler/src/generator/rust/struct_def.rs
@@ -582,7 +582,7 @@ impl<'a> StructDef<'a> {
         rigid_array_support: RigidArraySupport,
     ) -> (TokenStream, TokenStream) {
         (
-            Self::gen_de_struct_field_serde_annot(rename, nullable, required),
+            Self::gen_de_struct_field_serde_annot(cardinality, rename, nullable, required),
             Self::gen_de_struct_field_type(
                 cardinality,
                 ftype,
@@ -593,16 +593,24 @@ impl<'a> StructDef<'a> {
         )
     }
 
-    fn gen_de_struct_field_serde_annot(
+    fn gen_de_struct_field_serde_annot<T>(
+        cardinality: &OneOrCollection<T>,
         rename: impl ToTokens,
         nullable: IsNullable,
         required: IsRequired,
     ) -> TokenStream {
-        if required.into_inner() && nullable.into_inner() {
+        let nullable = nullable.into_inner();
+        let required = required.into_inner();
+
+        if matches!( (cardinality, true, false), (OneOrCollection::Collection(_), req , nul)
+            if req == required && nul == nullable)
+        {
+            quote! { #[serde(rename=#rename, deserialize_with="de_null_to_empty_vec")] }
+        } else if required && nullable {
             quote! { #[serde(rename=#rename, deserialize_with="de_required_nullable")] }
-        } else if required.into_inner() {
+        } else if required {
             quote! { #[serde(rename=#rename)] }
-        } else if nullable.into_inner() {
+        } else if nullable {
             quote! { #[serde(rename=#rename, default, deserialize_with="de_optional_nullable")] }
         } else {
             quote! { #[serde(rename=#rename, default)] }

--- a/tests/tests/tests-base-operations.rs
+++ b/tests/tests/tests-base-operations.rs
@@ -537,6 +537,43 @@ async fn create_collection_member_test() -> Result<(), Error> {
     Ok(())
 }
 
+// Check that collection with {"Members":null} returns empty collection.
+#[test]
+async fn null_collection_member_test() -> Result<(), Error> {
+    let bmc = Bmc::default();
+    let root_id = ODataId::service_root();
+    let collection_name = "TestCollection";
+    let collection_id = format!("{root_id}/{collection_name}");
+    let collection_data_type = format!("ServiceRoot.v1_0_0.{collection_name}");
+    bmc.expect(expect_root_srv(collection_name, &collection_id));
+    let service_root = get_service_root(&bmc).await.map_err(Error::Bmc)?;
+
+    assert!(matches!(
+        service_root.test_collection.as_ref(),
+        Some(NavProperty::Reference(_))
+    ));
+
+    let collection_tpl = json!({
+        ODATA_ID: &collection_id,
+        ODATA_TYPE: &collection_data_type,
+    });
+    bmc.expect(Expect::get(
+        &collection_id,
+        json_merge([&collection_tpl, &json!({ "Members": null })]),
+    ));
+    let collection = service_root
+        .test_collection
+        .as_ref()
+        .ok_or(Error::ExpectedProperty("test_collection"))?
+        .get(&bmc)
+        .await
+        .map_err(Error::Bmc)?;
+    let members_numbers = collection.members.len();
+    assert_eq!(members_numbers, 0);
+
+    Ok(())
+}
+
 #[test]
 async fn create_struct_required_on_create_and_writable_fields_test() -> Result<(), Error> {
     let create = TestCollectionMemberCreate::builder(


### PR DESCRIPTION
Some BMCs (for example, BF-24.10-17 on BlueField-3 cards) return `null` instead of an empty array for `members` fields. This causes [NICO](https://github.com/NVIDIA/infra-controller) pre-ingestion to fail with a deserialization error, for example:
`level=INFO span_id=0xfef03873c4xxxxxx msg="Failed to explore 10.xx.xx.xx:443: Error while performing Redfish request: context: boot options; json error: invalid type: null, expected a sequence: None (response code: None)" error="Error while performing Redfish request: context: boot options; json error: invalid type: null, expected a sequence: None (response code: None)" location="crates/site-explorer/src/lib.rs:1849"`
This PR handles that case by deserializing null values into empty arrays for required non-nullable collections.