### PR TITLE
fix(bmc-http): disable ETags when cache capacity is zero

### DIFF
--- a/bmc-http/src/lib.rs
+++ b/bmc-http/src/lib.rs
@@ -568,15 +568,13 @@ where
             )
             .await
         {
-            Ok(response) => {
-                let entity = Arc::new(response);
-
+            Ok(response) if !self.cache_enabled => {
                 // With capacity zero, `put_typed` stores no representation and always returns
                 // `None`, and we can return early with the response entity.
-                if !self.cache_enabled {
-                    return Ok(entity);
-                }
-
+                Ok(Arc::new(response))
+            }
+            Ok(response) => {
+                let entity = Arc::new(response);
                 // Update cache if entity has etag
                 if let Some(etag) = entity.etag() {
                     let mut cache = self

--- a/bmc-http/src/lib.rs
+++ b/bmc-http/src/lib.rs
@@ -217,6 +217,10 @@ pub struct HttpBmc<C: HttpClient> {
     cache: RwLock<TypeErasedCarCache<Url>>,
     etags: RwLock<HashMap<Url, ODataETag>>,
     custom_headers: HeaderMap,
+
+    // Response bodies and ETags are enabled or disabled together because a
+    // 304 Not Modified response contains no replacement body.
+    cache_enabled: bool,
 }
 
 impl<C: HttpClient> HttpBmc<C>
@@ -329,6 +333,7 @@ where
             cache: RwLock::new(TypeErasedCarCache::new(cache_settings.capacity)),
             etags: RwLock::new(HashMap::new()),
             custom_headers,
+            cache_enabled: cache_settings.capacity > 0,
         }
     }
 
@@ -536,14 +541,20 @@ where
     ) -> Result<Arc<T>, C::Error> {
         let cache_key = endpoint_url.clone();
 
-        // Retrieve cached etag
-        let etag: Option<ODataETag> = {
+        // The `etag` is always `None` when caching is disabled. Check the flag here so we can save
+        // a read lock acquisition and guarantee that disabled caching never sends If-None-Match,
+        // which could produce a 304 response without a cached body.
+        let etag = if self.cache_enabled {
             let etags = self
                 .etags
                 .read()
                 .map_err(|e| C::Error::cache_error(e.to_string()))?;
+
             etags.get(&cache_key).cloned()
+        } else {
+            None
         };
+
         let credentials = self.read_credentials();
 
         // Perform GET request
@@ -559,6 +570,12 @@ where
         {
             Ok(response) => {
                 let entity = Arc::new(response);
+
+                // With capacity zero, `put_typed` stores no representation and always returns
+                // `None`, and we can return early with the response entity.
+                if !self.cache_enabled {
+                    return Ok(entity);
+                }
 
                 // Update cache if entity has etag
                 if let Some(etag) = entity.etag() {

--- a/bmc-http/tests/etag_cache_tests.rs
+++ b/bmc-http/tests/etag_cache_tests.rs
@@ -17,12 +17,17 @@ mod common;
 
 #[cfg(feature = "reqwest")]
 mod cache_integration_tests {
+    use std::{error::Error, sync::Arc};
+
     use crate::common::test_utils::*;
 
-    use nv_redfish_bmc_http::reqwest::BmcError;
+    use nv_redfish_bmc_http::{
+        reqwest::{BmcError, Client},
+        CacheSettings, HttpBmc,
+    };
     use nv_redfish_core::query::{ExpandQuery, FilterQuery};
     use nv_redfish_core::Bmc;
-    use std::sync::Arc;
+    use url::Url;
     use wiremock::{
         matchers::{header, method, path, query_param},
         Mock, MockServer, ResponseTemplate,
@@ -365,6 +370,58 @@ mod cache_integration_tests {
         assert!(result.is_err());
         let error = result.unwrap_err();
         assert!(matches!(error, BmcError::CacheMiss));
+    }
+
+    #[tokio::test]
+    async fn zero_capacity_disables_etag_and_body_caching() -> Result<(), Box<dyn Error>> {
+        let mock_server = MockServer::start().await;
+        let resource_path = paths::SYSTEMS_1;
+        let etag_value = "zero-capacity-etag";
+        let test_resource =
+            create_test_resource(resource_path, Some(etag_value), names::TEST_SYSTEM, 42);
+
+        Mock::given(method("GET"))
+            .and(path(resource_path))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(&test_resource)
+                    .insert_header("etag", etag_value),
+            )
+            .expect(2)
+            .mount(&mock_server)
+            .await;
+
+        let client = Client::new()?;
+        let bmc = HttpBmc::new(
+            client,
+            Url::parse(&mock_server.uri())?,
+            create_test_credentials(),
+            // Capacity zero must disable both response-body and ETag caching.
+            CacheSettings::with_capacity(0),
+        );
+
+        let resource_id = create_odata_id(resource_path);
+
+        let first_result = bmc.get::<TestResource>(&resource_id).await?;
+        let second_result = bmc.get::<TestResource>(&resource_id).await?;
+
+        mock_server.verify().await;
+
+        let Some(received_requests) = mock_server.received_requests().await else {
+            panic!("request recording should be enabled");
+        };
+
+        assert_eq!(first_result.name, names::TEST_SYSTEM);
+        assert_eq!(first_result.value, 42);
+        assert_eq!(second_result.name, names::TEST_SYSTEM);
+        assert_eq!(second_result.value, 42);
+        assert!(!Arc::ptr_eq(&first_result, &second_result));
+        assert_eq!(received_requests.len(), 2);
+        assert!(received_requests
+            .iter()
+            .all(|request| !request.headers.contains_key("if-none-match")));
+
+        Ok(())
     }
 
     #[tokio::test]


### PR DESCRIPTION
Cache capacity zero disables caching, but the following workflow would fail:

- The first GET returns `200` with a response body and an ETag.
- `put_typed` does not store the response entity when cache capacity is zero, but the ETag is still stored in `etags`.
- A subsequent GET sends `If-None-Match` using that ETag.
- If the BMC supports `If-None-Match` and the resource is unchanged, it returns `304 Not Modified` without a response body [RFC 9110 15.4.5](https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4.5).
- `HttpBmc` attempts to load the response entity from its zero-capacity cache.
- The caller receives `CacheMiss`.

Changed resources would still work in this case as `200` will be returned. Unchanged resources cause a `CacheMiss` when the BMC supports `If-None-Match` and returns `304`.