### PR TITLE
ci(fmt): add `cargo fmt` check and format code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ ci-features-list := $(subst $(space),$(comma),$(all-std-features))
 compile-one-feature = $(indent)cargo build -p nv-redfish --features $1$(new-line)
 
 define build-and-test
+	cargo fmt --all -- --check
 	cargo build -p nv-redfish --features computer-systems,processors,controls
 	cargo build -p nv-redfish --features managers,oem-hpe
 	cargo build -p nv-redfish --features managers,oem-supermicro
@@ -101,7 +102,7 @@ ci: rust-install
 	$(call build-and-test,--features $(ci-features-list))
 
 rust-install:
-	rustup component add clippy
+	rustup component add clippy rustfmt
 
 clean:
 	rm -rf $(schema-dir)

--- a/dispatcher/examples/composable_tree.rs
+++ b/dispatcher/examples/composable_tree.rs
@@ -238,17 +238,21 @@ async fn main() {
     let handle = runtime.handle();
 
     // 3a. Add another leaf to the root, dynamically.
-    handle.with_root_mut(|root: &mut RoundRobin<Work, ()>| {
-        root.add_child(PollLeaf::new("sensor-C", Duration::from_secs(3)));
-    }).expect("downcast failed");
+    handle
+        .with_root_mut(|root: &mut RoundRobin<Work, ()>| {
+            root.add_child(PollLeaf::new("sensor-C", Duration::from_secs(3)));
+        })
+        .expect("downcast failed");
 
     // 3b. Add an entirely new sub-branch with its own children.
-    handle.with_root_mut(|root: &mut RoundRobin<Work, ()>| {
-        let mut subnet: RoundRobin<Work, ()> = RoundRobin::new();
-        subnet.add_child(PollLeaf::new("subnet-1-a", Duration::from_secs(5)));
-        subnet.add_child(PollLeaf::new("subnet-1-b", Duration::from_secs(5)));
-        root.add_child(subnet);
-    }).expect("downcast failed");
+    handle
+        .with_root_mut(|root: &mut RoundRobin<Work, ()>| {
+            let mut subnet: RoundRobin<Work, ()> = RoundRobin::new();
+            subnet.add_child(PollLeaf::new("subnet-1-a", Duration::from_secs(5)));
+            subnet.add_child(PollLeaf::new("subnet-1-b", Duration::from_secs(5)));
+            root.add_child(subnet);
+        })
+        .expect("downcast failed");
 
     // 4. Drive the runtime. `next()` is the single ordered output stream.
     let start = Instant::now();

--- a/dispatcher/src/runtime.rs
+++ b/dispatcher/src/runtime.rs
@@ -30,15 +30,15 @@
 //! [`RuntimeHandle::with_root`] / [`RuntimeHandle::with_root_mut`] share
 //! the same lock, so user mutations and driver steps serialize naturally.
 
+use crate::scheduler::private::SchedulerObj;
+use crate::scheduler::Scheduler;
+use crate::stats::RuntimeStats;
+use crate::work::WorkMeta;
 use crate::Completion;
 use crate::CompletionOutcome;
 use crate::RoutingPath;
 use crate::RuntimeEventType;
 use crate::ScheduledWork;
-use crate::scheduler::Scheduler;
-use crate::scheduler::private::SchedulerObj;
-use crate::stats::RuntimeStats;
-use crate::work::WorkMeta;
 use core::future::Future;
 use core::marker::PhantomData;
 use core::pin::Pin;

--- a/dispatcher/src/schedulers/bounded_concurrency.rs
+++ b/dispatcher/src/schedulers/bounded_concurrency.rs
@@ -95,9 +95,9 @@ mod tests {
     use std::time::Instant;
 
     use super::BoundedConcurrency;
-    use crate::schedulers::round_robin::RoundRobin;
-    use crate::schedulers::tests::{MockLeaf, TestPayload, dispatch_and_complete};
     use crate::scheduler::Scheduler as _;
+    use crate::schedulers::round_robin::RoundRobin;
+    use crate::schedulers::tests::{dispatch_and_complete, MockLeaf, TestPayload};
     use crate::work::{Completion, CompletionOutcome, RoutingPath};
 
     fn cap(value: u32) -> NonZeroU32 {
@@ -108,7 +108,8 @@ mod tests {
     fn under_cap_passes_work_through() {
         let leaf = MockLeaf::ready_firing(0, 7);
         let handle = leaf.handle();
-        let mut bc: BoundedConcurrency<TestPayload, MockLeaf<()>> = BoundedConcurrency::new(cap(2), leaf);
+        let mut bc: BoundedConcurrency<TestPayload, MockLeaf<()>> =
+            BoundedConcurrency::new(cap(2), leaf);
 
         assert!(bc.update_ready(Instant::now()).ready);
         let work = bc.take_next().expect("ready");
@@ -176,13 +177,18 @@ mod tests {
     fn passes_meta_and_routing_unmodified() {
         let leaf = MockLeaf::ready_firing(0, 99);
         let handle = leaf.handle();
-        let mut bc: BoundedConcurrency<TestPayload, MockLeaf<()>> = BoundedConcurrency::new(cap(1), leaf);
+        let mut bc: BoundedConcurrency<TestPayload, MockLeaf<()>> =
+            BoundedConcurrency::new(cap(1), leaf);
 
-        let routing = dispatch_and_complete(&mut bc, CompletionOutcome::Failed, Duration::from_millis(3))
-            .expect("ready");
+        let routing =
+            dispatch_and_complete(&mut bc, CompletionOutcome::Failed, Duration::from_millis(3))
+                .expect("ready");
 
         assert_eq!(routing, RoutingPath::empty());
         assert_eq!(handle.completion_count(), 1);
-        assert_eq!(handle.last_completion_outcome(), Some(CompletionOutcome::Failed));
+        assert_eq!(
+            handle.last_completion_outcome(),
+            Some(CompletionOutcome::Failed)
+        );
     }
 }

--- a/dispatcher/src/schedulers/circuit_breaker.rs
+++ b/dispatcher/src/schedulers/circuit_breaker.rs
@@ -232,8 +232,8 @@ mod tests {
     use std::time::Instant;
 
     use super::{BreakerState, CircuitBreaker, CircuitBreakerConfig};
-    use crate::schedulers::tests::{MockLeaf, TestPayload};
     use crate::scheduler::Scheduler as _;
+    use crate::schedulers::tests::{MockLeaf, TestPayload};
     use crate::work::{Completion, CompletionOutcome};
 
     fn cfg(cool_down: Duration) -> CircuitBreakerConfig {

--- a/dispatcher/src/schedulers/round_robin.rs
+++ b/dispatcher/src/schedulers/round_robin.rs
@@ -141,8 +141,8 @@ mod tests {
     use std::time::Instant;
 
     use super::RoundRobin;
-    use crate::schedulers::tests::{MockLeaf, dispatch_and_complete};
     use crate::scheduler::Scheduler as _;
+    use crate::schedulers::tests::{dispatch_and_complete, MockLeaf};
     use crate::work::CompletionOutcome;
 
     #[test]
@@ -262,12 +262,19 @@ mod tests {
         rr.add_child(l0);
         rr.add_child(l1);
 
-        dispatch_and_complete(&mut rr, CompletionOutcome::Succeeded, Duration::from_millis(7))
-            .expect("l1 should fire");
+        dispatch_and_complete(
+            &mut rr,
+            CompletionOutcome::Succeeded,
+            Duration::from_millis(7),
+        )
+        .expect("l1 should fire");
 
         // The completion must have landed on l1, not l0.
         assert_eq!(h0.completion_count(), 0);
         assert_eq!(h1.completion_count(), 1);
-        assert_eq!(h1.last_completion_outcome(), Some(CompletionOutcome::Succeeded));
+        assert_eq!(
+            h1.last_completion_outcome(),
+            Some(CompletionOutcome::Succeeded)
+        );
     }
 }

--- a/dispatcher/src/schedulers/strict_priority.rs
+++ b/dispatcher/src/schedulers/strict_priority.rs
@@ -135,8 +135,8 @@ mod tests {
     use std::time::Instant;
 
     use super::StrictPriority;
-    use crate::schedulers::tests::{MockLeaf, TestPayload, dispatch_and_complete};
     use crate::scheduler::Scheduler as _;
+    use crate::schedulers::tests::{dispatch_and_complete, MockLeaf, TestPayload};
     use crate::work::CompletionOutcome;
 
     #[test]

--- a/examples/task-service/src/main.rs
+++ b/examples/task-service/src/main.rs
@@ -20,14 +20,14 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use clap::Parser;
-use nv_redfish::ServiceRoot;
+use nv_redfish::bmc_http::reqwest::Client;
+use nv_redfish::bmc_http::reqwest::ClientParams;
 use nv_redfish::bmc_http::BmcCredentials;
 use nv_redfish::bmc_http::CacheSettings;
 use nv_redfish::bmc_http::HttpBmc;
-use nv_redfish::bmc_http::reqwest::Client;
-use nv_redfish::bmc_http::reqwest::ClientParams;
 use nv_redfish::core::AsyncTask;
 use nv_redfish::core::ODataId;
+use nv_redfish::ServiceRoot;
 use url::Url;
 
 #[derive(Debug, Parser)]

--- a/redfish/build.rs
+++ b/redfish/build.rs
@@ -68,12 +68,7 @@ fn run() -> Result<(), Box<dyn StdError>> {
         .copied()
         .chain(service_root.iter().copied())
         .map(redfish_schema)
-        .chain(
-            features
-                .csdl_files
-                .iter()
-                .map(|f| redfish_schema(f)),
-        )
+        .chain(features.csdl_files.iter().map(|f| redfish_schema(f)))
         .chain(
             features
                 .swordfish_csdl_files

--- a/redfish/src/bmc_quirks.rs
+++ b/redfish/src/bmc_quirks.rs
@@ -222,6 +222,9 @@ impl BmcQuirks {
     /// members; the standalone resource GETs are complete, so disabling expand
     /// makes nv-redfish fetch each member individually and parse correctly.
     pub(crate) const fn expand_is_not_working_properly(&self) -> bool {
-        matches!(self.platform, Some(Platform::AmiViking | Platform::AmiGb300))
+        matches!(
+            self.platform,
+            Some(Platform::AmiViking | Platform::AmiGb300)
+        )
     }
 }

--- a/redfish/src/oem/ami/ami_service_root.rs
+++ b/redfish/src/oem/ami/ami_service_root.rs
@@ -15,11 +15,11 @@
 
 //! Support AMI Service root extensions
 
-use crate::Error;
-use crate::NvBmc;
 use crate::core::Bmc;
 use crate::oem::ami::schema::ami_service_root::AmiServiceRoot as AmiServiceRootSchema;
 use crate::schema::service_root::ServiceRoot as ServiceRootSchema;
+use crate::Error;
+use crate::NvBmc;
 use std::marker::PhantomData;
 use std::sync::Arc;
 

--- a/redfish/src/service_root.rs
+++ b/redfish/src/service_root.rs
@@ -15,16 +15,16 @@
 
 use std::sync::Arc;
 
-use crate::Error;
-use crate::NvBmc;
-use crate::ProtocolFeatures;
-use crate::Resource;
-use crate::ResourceSchema;
 use crate::bmc_quirks::BmcQuirks;
 use crate::core::Bmc;
 use crate::core::NavProperty;
 use crate::core::ODataId;
 use crate::schema::service_root::ServiceRoot as SchemaServiceRoot;
+use crate::Error;
+use crate::NvBmc;
+use crate::ProtocolFeatures;
+use crate::Resource;
+use crate::ResourceSchema;
 
 use tagged_types::TaggedType;
 

--- a/redfish/src/task_service/mod.rs
+++ b/redfish/src/task_service/mod.rs
@@ -23,17 +23,17 @@
 
 use std::sync::Arc;
 
-use crate::Error;
-use crate::NvBmc;
-use crate::Resource;
-use crate::ResourceSchema;
-use crate::ServiceRoot;
 use crate::core::Bmc;
 use crate::core::EntityTypeRef as _;
 use crate::core::NavProperty;
 use crate::entity_link::EntityLink;
 use crate::schema::task::Task as TaskSchema;
 use crate::schema::task_service::TaskService as TaskServiceSchema;
+use crate::Error;
+use crate::NvBmc;
+use crate::Resource;
+use crate::ResourceSchema;
+use crate::ServiceRoot;
 
 use nv_redfish_core::AsyncTask;
 

--- a/redfish/src/update_service/mod.rs
+++ b/redfish/src/update_service/mod.rs
@@ -23,16 +23,16 @@ mod software_inventory;
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::Error;
-use crate::NvBmc;
-use crate::Resource;
-use crate::ResourceSchema;
-use crate::ServiceRoot;
 use crate::core::NavProperty;
 use crate::patch_support::Payload;
 use crate::patch_support::ReadPatchFn;
 use crate::schema::update_service::UpdateService as UpdateServiceSchema;
 use crate::schema::update_service::UpdateServiceSimpleUpdateAction;
+use crate::Error;
+use crate::NvBmc;
+use crate::Resource;
+use crate::ResourceSchema;
+use crate::ServiceRoot;
 
 use nv_redfish_core::Bmc;
 use nv_redfish_core::DataStream;

--- a/tests/tests/test-task-service.rs
+++ b/tests/tests/test-task-service.rs
@@ -20,11 +20,11 @@ use std::io::Error as IoError;
 use std::io::ErrorKind;
 use std::sync::Arc;
 
-use nv_redfish::ServiceRoot;
 use nv_redfish::core::AsyncTask;
 use nv_redfish::core::ODataId;
 use nv_redfish::schema::resource::Health as TaskStatus;
 use nv_redfish::schema::task::TaskState;
+use nv_redfish::ServiceRoot;
 use nv_redfish_tests::Bmc;
 use nv_redfish_tests::Expect;
 use nv_redfish_tests::ODATA_ID;


### PR DESCRIPTION
Ran formatting for the codebase and it didn't produce a large diff -- it's probably a good time now to do it and add format check in CI.