### PR TITLE
fix(bmc-http): resolve Location references

### DIFF
--- a/bmc-http/src/lib.rs
+++ b/bmc-http/src/lib.rs
@@ -398,6 +398,41 @@ impl RedfishEndpoint {
         url
     }
 
+    /// Convert an OData identifier, including its optional query, to an endpoint URL.
+    ///
+    /// `ODataId` is opaque and can contain a query, particularly when it comes
+    /// from a task or session `Location` header. Passing the whole identifier to
+    /// `Url::set_path` would encode `?` as path data, so split the two URL
+    /// components before applying them.
+    fn with_odata_id(&self, id: &ODataId) -> Url {
+        let id = id.to_string();
+        let (path, query) = id
+            .split_once('?')
+            .map_or((id.as_str(), None), |(path, query)| (path, Some(query)));
+
+        let mut url = self.with_path(path);
+        url.set_query(query);
+        url
+    }
+
+    /// Convert an OData identifier and append query parameters.
+    ///
+    /// Existing parameters can carry continuation or monitor tokens and must
+    /// survive when callers add `$expand` or `$filter` parameters.
+    fn with_odata_id_and_query(&self, id: &ODataId, query: &str) -> Url {
+        let mut url = self.with_odata_id(id);
+
+        match url.query() {
+            Some(existing) if !existing.is_empty() => {
+                let combined_query = format!("{existing}&{query}");
+                url.set_query(Some(&combined_query));
+            }
+            _ => url.set_query(Some(query)),
+        }
+
+        url
+    }
+
     /// Resolve a URI reference and verify that it stays on the BMC origin.
     ///
     /// Callers must explicitly wrap service-provided values in
@@ -625,7 +660,7 @@ where
         &self,
         id: &ODataId,
     ) -> Result<Arc<T>, Self::Error> {
-        let endpoint_url = self.redfish_endpoint.with_path(&id.to_string());
+        let endpoint_url = self.redfish_endpoint.with_odata_id(id);
         self.get_with_cache(endpoint_url).await
     }
 
@@ -636,7 +671,7 @@ where
     ) -> Result<Arc<T>, Self::Error> {
         let endpoint_url = self
             .redfish_endpoint
-            .with_path_and_query(&id.to_string(), &query.to_query_string());
+            .with_odata_id_and_query(id, &query.to_query_string());
 
         self.get_with_cache(endpoint_url).await
     }
@@ -646,7 +681,7 @@ where
         id: &ODataId,
         v: &V,
     ) -> Result<ModificationResponse<R>, Self::Error> {
-        let endpoint_url = self.redfish_endpoint.with_path(&id.to_string());
+        let endpoint_url = self.redfish_endpoint.with_odata_id(id);
         let credentials = self.read_credentials();
         self.client
             .post(endpoint_url, v, credentials.as_ref(), &self.custom_headers)
@@ -661,7 +696,7 @@ where
         id: &ODataId,
         v: &V,
     ) -> Result<SessionCreateResponse<R>, Self::Error> {
-        let endpoint_url = self.redfish_endpoint.with_path(&id.to_string());
+        let endpoint_url = self.redfish_endpoint.with_odata_id(id);
         self.client
             .post_session(endpoint_url, v, &self.custom_headers)
             .await
@@ -673,7 +708,7 @@ where
         etag: Option<&ODataETag>,
         v: &V,
     ) -> Result<ModificationResponse<R>, Self::Error> {
-        let endpoint_url = self.redfish_endpoint.with_path(&id.to_string());
+        let endpoint_url = self.redfish_endpoint.with_odata_id(id);
         let etag = etag
             .cloned()
             .unwrap_or_else(|| ODataETag::from(String::from("*")));
@@ -693,7 +728,7 @@ where
         &self,
         id: &ODataId,
     ) -> Result<ModificationResponse<T>, Self::Error> {
-        let endpoint_url = self.redfish_endpoint.with_path(&id.to_string());
+        let endpoint_url = self.redfish_endpoint.with_odata_id(id);
         let credentials = self.read_credentials();
         self.client
             .delete(endpoint_url, credentials.as_ref(), &self.custom_headers)
@@ -782,7 +817,7 @@ where
     ) -> Result<Arc<T>, Self::Error> {
         let endpoint_url = self
             .redfish_endpoint
-            .with_path_and_query(&id.to_string(), &query.to_query_string());
+            .with_odata_id_and_query(id, &query.to_query_string());
 
         self.get_with_cache(endpoint_url).await
     }
@@ -840,6 +875,37 @@ mod tests {
                 "{uri}"
             );
         }
+
+        Ok(())
+    }
+
+    #[test]
+    fn odata_id_query_is_preserved_as_url_query() -> Result<(), Box<dyn Error>> {
+        let endpoint = RedfishEndpoint::new(Url::parse("https://bmc.example")?);
+        let id =
+            ODataId::from("/redfish/v1/TaskService/Tasks/42?token=a%2Fb&state=ready".to_string());
+
+        let resolved = endpoint.with_odata_id(&id);
+
+        assert_eq!(resolved.path(), "/redfish/v1/TaskService/Tasks/42");
+        assert_eq!(resolved.query(), Some("token=a%2Fb&state=ready"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn odata_id_query_is_combined_with_request_query() -> Result<(), Box<dyn Error>> {
+        let endpoint = RedfishEndpoint::new(Url::parse("https://bmc.example")?);
+        let id = ODataId::from("/redfish/v1/Systems?$skiptoken=abc".to_string());
+
+        let resolved = endpoint.with_odata_id_and_query(&id, "$filter=value%20gt%2010");
+
+        assert_eq!(resolved.path(), "/redfish/v1/Systems");
+
+        assert_eq!(
+            resolved.query(),
+            Some("$skiptoken=abc&$filter=value%20gt%2010")
+        );
 
         Ok(())
     }

--- a/bmc-http/src/reqwest.rs
+++ b/bmc-http/src/reqwest.rs
@@ -569,12 +569,17 @@ impl Client {
         }
 
         let etag = etag_from_headers(&headers);
-        let location = location_from_headers(&headers);
+
+        // Resolve the header once, but defer propagating its error until a
+        // status branch actually uses Location. A malformed, irrelevant
+        // Location must not turn a valid 204 or body-bearing 200/201 into an
+        // error.
+        let location = location_from_headers(&headers, &url, status);
 
         match status {
             reqwest::StatusCode::NO_CONTENT => Ok(ModificationResponse::Empty),
             reqwest::StatusCode::ACCEPTED => {
-                let Some(task_location) = location else {
+                let Some(task_location) = location? else {
                     return Err(BmcError::InvalidResponse {
                         url,
                         status,
@@ -622,7 +627,7 @@ impl Client {
                     };
                 }
 
-                if let Some(location) = location {
+                if let Some(location) = location? {
                     let value = serde_json::json!({ "@odata.id": location });
                     return serde_path_to_error::deserialize(value)
                         .map(ModificationResponse::Entity)
@@ -664,7 +669,10 @@ impl Client {
                 text: String::from("session creation response missing X-Auth-Token header"),
             });
         };
-        let Some(location) = location_from_headers(&headers) else {
+
+        // The returned location is the durable session identifier used for
+        // later deletion, so normalize and validate it before exposing it.
+        let Some(location) = location_from_headers(&headers, &url, status)? else {
             return Err(BmcError::InvalidResponse {
                 url,
                 status,
@@ -732,23 +740,65 @@ fn same_origin_redirect_policy(redirect_policy: RedirectPolicy) -> RedirectPolic
     })
 }
 
-fn location_from_headers(headers: &HeaderMap) -> Option<ODataId> {
-    headers
-        .get(header::LOCATION)
-        .and_then(|value| value.to_str().ok())
-        .map(|raw| {
-            Url::parse(raw).map_or_else(
-                |_| raw.to_string().into(),
-                |url| {
-                    let mut path = url.path().to_string();
-                    if let Some(query) = url.query() {
-                        path.push('?');
-                        path.push_str(query);
-                    }
-                    path.into()
-                },
-            )
-        })
+/// Resolve a Redfish `Location` header into a same-origin path and query.
+///
+/// HTTP defines `Location` as a URI reference, so values may be absolute,
+/// root-relative, path-relative, or query-only. Resolution must use the final
+/// response URL; treating a relative value as a path rooted at the configured
+/// BMC endpoint can target a different resource. The returned `ODataId` keeps
+/// only path and query because fragments are not sent in subsequent HTTP
+/// requests and transport always uses the configured BMC origin.
+fn location_from_headers(
+    headers: &HeaderMap,
+    response_url: &Url,
+    status: reqwest::StatusCode,
+) -> Result<Option<ODataId>, BmcError> {
+    let invalid_response = |text: &'static str| BmcError::InvalidResponse {
+        url: response_url.clone(),
+        status,
+        text: text.to_string(),
+    };
+
+    let Some(value) = headers.get(header::LOCATION) else {
+        return Ok(None);
+    };
+
+    let raw = value
+        .to_str()
+        .map_err(|_| invalid_response("Location header is not valid text"))?;
+
+    let raw = raw.trim();
+
+    // Joining either value would resolve back to the response resource, which
+    // cannot identify a newly created session or asynchronous task monitor.
+    if raw.is_empty() || raw.starts_with('#') {
+        return Err(invalid_response(
+            "Location header does not identify a resource",
+        ));
+    }
+
+    let resolved = response_url
+        .join(raw)
+        .map_err(|_| invalid_response("Location header is not a valid URI reference"))?;
+
+    // Redfish follow-up requests carry BMC credentials. Reject another origin
+    // before reducing the URL to an OData path and losing that distinction.
+    if resolved.origin() != response_url.origin() {
+        return Err(invalid_response(
+            "Location header resolves to a different origin",
+        ));
+    }
+
+    let mut path_and_query = resolved.path().to_string();
+
+    // Preserve the query separately from the path so later polling or deletion
+    // sends it as a query instead of percent-encoded path text.
+    if let Some(query) = resolved.query() {
+        path_and_query.push('?');
+        path_and_query.push_str(query);
+    }
+
+    Ok(Some(path_and_query.into()))
 }
 
 fn auth_token_from_headers(headers: &HeaderMap) -> Option<String> {
@@ -1109,6 +1159,7 @@ mod tests {
     use super::*;
 
     use futures_util::io::Cursor;
+    use http::HeaderValue;
     use wiremock::matchers::header;
     use wiremock::matchers::method;
     use wiremock::matchers::path;
@@ -1250,6 +1301,78 @@ mod tests {
 
         assert_eq!(response["redirected"], true);
         mock_server.verify().await;
+
+        Ok(())
+    }
+
+    #[test]
+    fn location_header_resolves_valid_and_rejects_invalid_references(
+    ) -> Result<(), Box<dyn StdError>> {
+        struct TestCase(&'static str, Result<&'static str, &'static str>);
+
+        let response_url = Url::parse("https://bmc.example/redfish/v1/SessionService/Sessions")?;
+
+        let cases = [
+            TestCase(
+                "https://bmc.example/redfish/v1/SessionService/Sessions/1?token=abc",
+                Ok("/redfish/v1/SessionService/Sessions/1?token=abc"),
+            ),
+            TestCase(
+                "/redfish/v1/SessionService/Sessions/1?token=abc",
+                Ok("/redfish/v1/SessionService/Sessions/1?token=abc"),
+            ),
+            TestCase(
+                "Sessions/1?token=abc",
+                Ok("/redfish/v1/SessionService/Sessions/1?token=abc"),
+            ),
+            TestCase(
+                "../TaskService/Tasks/42?token=abc",
+                Ok("/redfish/v1/TaskService/Tasks/42?token=abc"),
+            ),
+            TestCase(
+                "?token=abc",
+                Ok("/redfish/v1/SessionService/Sessions?token=abc"),
+            ),
+            TestCase(
+                "//bmc.example/redfish/v1/TaskService/Tasks/42",
+                Ok("/redfish/v1/TaskService/Tasks/42"),
+            ),
+            TestCase("", Err("Location header does not identify a resource")),
+            TestCase(
+                "#fragment",
+                Err("Location header does not identify a resource"),
+            ),
+            TestCase(
+                "https://other.example/redfish/v1/TaskService/Tasks/42",
+                Err("Location header resolves to a different origin"),
+            ),
+            TestCase(
+                "//bmc.example:8443/redfish/v1/TaskService/Tasks/42",
+                Err("Location header resolves to a different origin"),
+            ),
+            TestCase(
+                "//host:99999/path",
+                Err("Location header is not a valid URI reference"),
+            ),
+        ];
+
+        for TestCase(raw, expected) in cases {
+            let mut headers = HeaderMap::new();
+            headers.insert(header::LOCATION, raw.parse::<HeaderValue>()?);
+
+            let result =
+                location_from_headers(&headers, &response_url, reqwest::StatusCode::CREATED);
+
+            match (result, expected) {
+                (Ok(Some(location)), Ok(expected)) => {
+                    assert_eq!(location.to_string(), expected, "{raw}");
+                }
+                (Err(BmcError::InvalidResponse { text, .. }), Err(expected)) => {
+                    assert_eq!(text, expected, "{raw}");
+                }
+                _ => return Err(format!("{raw}: unexpected Location result").into()),
+            }
+        }
 
         Ok(())
     }
@@ -1450,7 +1573,7 @@ mod tests {
             })
             .respond_with(
                 ResponseTemplate::new(202)
-                    .insert_header("Location", format!("https://bmc.example{task_path}"))
+                    .insert_header("Location", format!("{}{task_path}", mock_server.uri()))
                     .insert_header("Retry-After", "15"),
             )
             .expect(0)
@@ -1520,7 +1643,7 @@ mod tests {
             })
             .respond_with(
                 ResponseTemplate::new(202)
-                    .insert_header("Location", format!("https://bmc.example{task_path}"))
+                    .insert_header("Location", format!("{}{task_path}", mock_server.uri()))
                     .insert_header("Retry-After", "15"),
             )
             .expect(1)

--- a/bmc-http/tests/reqwest_client_tests.rs
+++ b/bmc-http/tests/reqwest_client_tests.rs
@@ -184,6 +184,7 @@ mod reqwest_client_tests {
 
         Mock::given(method("GET"))
             .and(path(resource_path))
+            .and(query_param("$skiptoken", "abc"))
             .and(query_param("$expand", ".($levels=2)"))
             .and(header("authorization", "Basic cm9vdDpwYXNzd29yZA=="))
             .respond_with(ResponseTemplate::new(200).set_body_json(&test_resource))
@@ -193,7 +194,7 @@ mod reqwest_client_tests {
 
         let bmc = create_test_bmc(&mock_server);
 
-        let resource_id = create_odata_id(resource_path);
+        let resource_id = create_odata_id(&format!("{resource_path}?$skiptoken=abc"));
         let expand_query = ExpandQuery::current().levels(2);
         let result = bmc.expand::<TestResource>(&resource_id, expand_query).await;
 
@@ -213,6 +214,7 @@ mod reqwest_client_tests {
 
         Mock::given(method("GET"))
             .and(path(resource_path))
+            .and(query_param("$skiptoken", "abc"))
             .and(query_param("$filter", "value gt 10"))
             .and(header("authorization", "Basic cm9vdDpwYXNzd29yZA=="))
             .respond_with(ResponseTemplate::new(200).set_body_json(&test_resource))
@@ -222,7 +224,7 @@ mod reqwest_client_tests {
 
         let bmc = create_test_bmc(&mock_server);
 
-        let resource_id = create_odata_id(resource_path);
+        let resource_id = create_odata_id(&format!("{resource_path}?$skiptoken=abc"));
         let filter_query = FilterQuery::gt(&"value", 10);
         let result = bmc.filter::<TestResource>(&resource_id, filter_query).await;
 
@@ -233,7 +235,8 @@ mod reqwest_client_tests {
     }
 
     #[tokio::test]
-    async fn test_post_create_request() {
+    async fn body_bearing_create_response_ignores_invalid_location(
+    ) -> Result<(), Box<dyn std::error::Error>> {
         let mock_server = MockServer::start().await;
         let collection_path = paths::SYSTEMS_1;
 
@@ -249,46 +252,9 @@ mod reqwest_client_tests {
             .and(path(collection_path))
             .and(body_json(&create_request))
             .and(header("authorization", "Basic cm9vdDpwYXNzd29yZA=="))
-            .respond_with(ResponseTemplate::new(201).set_body_json(&created_resource))
-            .expect(1)
-            .mount(&mock_server)
-            .await;
-
-        let bmc = create_test_bmc(&mock_server);
-
-        let collection_id = create_odata_id(collection_path);
-        let result = bmc
-            .create::<CreateRequest, TestResource>(&collection_id, &create_request)
-            .await;
-
-        assert!(result.is_ok());
-        let created = match result.unwrap() {
-            ModificationResponse::Entity(created) => created,
-            _ => panic!("expected entity response"),
-        };
-        assert_eq!(created.name, names::TEST_SYSTEM);
-        assert_eq!(created.value, 999);
-    }
-
-    #[tokio::test]
-    async fn test_create_session_response() {
-        let mock_server = MockServer::start().await;
-        let collection_path = "/redfish/v1/SessionService/Sessions";
-        let session_path = "/redfish/v1/SessionService/Sessions/1";
-
-        let create_request = CreateRequest {
-            name: names::TEST_SYSTEM.to_string(),
-            value: 999,
-        };
-        let created_resource = create_test_resource(session_path, None, names::TEST_SYSTEM, 999);
-
-        Mock::given(method("POST"))
-            .and(path(collection_path))
-            .and(body_json(&create_request))
             .respond_with(
                 ResponseTemplate::new(201)
-                    .insert_header("X-Auth-Token", "session-token-123")
-                    .insert_header("Location", format!("https://bmc.example{session_path}"))
+                    .insert_header("Location", "#fragment")
                     .set_body_json(&created_resource),
             )
             .expect(1)
@@ -299,14 +265,222 @@ mod reqwest_client_tests {
 
         let collection_id = create_odata_id(collection_path);
         let response = bmc
+            .create::<CreateRequest, TestResource>(&collection_id, &create_request)
+            .await?;
+
+        let ModificationResponse::Entity(created) = response else {
+            return Err(String::from("expected entity response").into());
+        };
+
+        assert_eq!(created.name, names::TEST_SYSTEM);
+        assert_eq!(created.value, 999);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn relative_session_location_with_query_is_used_for_delete(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mock_server = MockServer::start().await;
+        let collection_path = "/redfish/v1/SessionService/Sessions";
+        let session_path = "/redfish/v1/SessionService/Sessions/1";
+        let expected_location = format!("{session_path}?session=abc");
+
+        let create_request = CreateRequest {
+            name: names::TEST_SYSTEM.to_string(),
+            value: 999,
+        };
+
+        let created_resource = create_test_resource(session_path, None, names::TEST_SYSTEM, 999);
+
+        Mock::given(method("POST"))
+            .and(path(collection_path))
+            .and(body_json(&create_request))
+            .respond_with(
+                ResponseTemplate::new(201)
+                    .insert_header("X-Auth-Token", "session-token-123")
+                    .insert_header("Location", "Sessions/1?session=abc")
+                    .set_body_json(&created_resource),
+            )
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("DELETE"))
+            .and(path(session_path))
+            .and(query_param("session", "abc"))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let bmc = create_test_bmc(&mock_server);
+        let collection_id = create_odata_id(collection_path);
+
+        let response = bmc
             .create_session::<CreateRequest, TestResource>(&collection_id, &create_request)
-            .await
-            .unwrap();
+            .await?;
 
         assert_eq!(response.auth_token, "session-token-123");
-        assert_eq!(response.location.to_string(), session_path);
+        assert_eq!(response.location.to_string(), expected_location);
         assert_eq!(response.entity.name, names::TEST_SYSTEM);
         assert_eq!(response.entity.value, 999);
+
+        let deleted = bmc.delete::<TestResource>(&response.location).await?;
+
+        assert!(matches!(deleted, ModificationResponse::Empty));
+        mock_server.verify().await;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn absolute_session_location_is_used_for_delete() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let mock_server = MockServer::start().await;
+        let collection_path = "/redfish/v1/SessionService/Sessions";
+        let session_path = "/redfish/v1/SessionService/Sessions/2";
+        let absolute_location = format!("{}{session_path}", mock_server.uri());
+
+        let create_request = CreateRequest {
+            name: names::TEST_SYSTEM.to_string(),
+            value: 1000,
+        };
+
+        let created_resource = create_test_resource(session_path, None, names::TEST_SYSTEM, 1000);
+
+        Mock::given(method("POST"))
+            .and(path(collection_path))
+            .and(body_json(&create_request))
+            .respond_with(
+                ResponseTemplate::new(201)
+                    .insert_header("X-Auth-Token", "session-token-456")
+                    .insert_header("Location", absolute_location)
+                    .set_body_json(&created_resource),
+            )
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("DELETE"))
+            .and(path(session_path))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let bmc = create_test_bmc(&mock_server);
+        let collection_id = create_odata_id(collection_path);
+
+        let response = bmc
+            .create_session::<CreateRequest, TestResource>(&collection_id, &create_request)
+            .await?;
+
+        assert_eq!(response.auth_token, "session-token-456");
+        assert_eq!(response.location.to_string(), session_path);
+        assert_eq!(response.entity.value, 1000);
+
+        let deleted = bmc.delete::<TestResource>(&response.location).await?;
+
+        assert!(matches!(deleted, ModificationResponse::Empty));
+        mock_server.verify().await;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn relative_task_location_with_query_can_be_polled(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mock_server = MockServer::start().await;
+        let collection_path = "/redfish/v1/Systems";
+        let task_path = "/redfish/v1/TaskService/Tasks/42";
+        let expected_location = format!("{task_path}?monitor=abc");
+
+        let create_request = CreateRequest {
+            name: names::TEST_SYSTEM.to_string(),
+            value: 999,
+        };
+
+        let task_resource = create_test_resource(task_path, None, "Update task", 50);
+
+        Mock::given(method("POST"))
+            .and(path(collection_path))
+            .and(body_json(&create_request))
+            .respond_with(
+                ResponseTemplate::new(202)
+                    .insert_header("Location", "TaskService/Tasks/42?monitor=abc"),
+            )
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path(task_path))
+            .and(query_param("monitor", "abc"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&task_resource))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let bmc = create_test_bmc(&mock_server);
+        let collection_id = create_odata_id(collection_path);
+
+        let response = bmc
+            .create::<CreateRequest, TestResource>(&collection_id, &create_request)
+            .await?;
+
+        let ModificationResponse::Task(task) = response else {
+            return Err(String::from("expected task response").into());
+        };
+
+        assert_eq!(task.location.0.to_string(), expected_location);
+
+        let task = bmc.get::<TestResource>(&task.location.0).await?;
+
+        assert_eq!(task.name, "Update task");
+        assert_eq!(task.value, 50);
+        mock_server.verify().await;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn async_operation_rejects_cross_origin_location(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mock_server = MockServer::start().await;
+        let collection_path = "/redfish/v1/Systems";
+
+        let create_request = CreateRequest {
+            name: names::TEST_SYSTEM.to_string(),
+            value: 999,
+        };
+
+        Mock::given(method("POST"))
+            .and(path(collection_path))
+            .and(body_json(&create_request))
+            .respond_with(ResponseTemplate::new(202).insert_header(
+                "Location",
+                "https://other.example/redfish/v1/TaskService/Tasks/42",
+            ))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let bmc = create_test_bmc(&mock_server);
+        let collection_id = create_odata_id(collection_path);
+
+        let result = bmc
+            .create::<CreateRequest, TestResource>(&collection_id, &create_request)
+            .await;
+
+        let Err(BmcError::InvalidResponse { status, text, .. }) = result else {
+            return Err(String::from("expected invalid response error").into());
+        };
+
+        assert_eq!(status, reqwest::StatusCode::ACCEPTED);
+        assert_eq!(text, "Location header resolves to a different origin");
+
+        Ok(())
     }
 
     #[tokio::test]
@@ -378,7 +552,7 @@ mod reqwest_client_tests {
             .and(|request: &Request| request.body == b"firmware-bytes")
             .respond_with(
                 ResponseTemplate::new(202)
-                    .insert_header("Location", format!("https://bmc.example{task_path}"))
+                    .insert_header("Location", format!("{}{task_path}", mock_server.uri()))
                     .insert_header("Retry-After", "15"),
             )
             .expect(1)
@@ -748,14 +922,15 @@ mod reqwest_client_tests {
     }
 
     #[tokio::test]
-    async fn test_delete_request() {
+    async fn no_content_delete_response_ignores_invalid_location(
+    ) -> Result<(), Box<dyn std::error::Error>> {
         let mock_server = MockServer::start().await;
         let resource_path = "/redfish/v1/systems/1";
 
         Mock::given(method("DELETE"))
             .and(path(resource_path))
             .and(header("authorization", "Basic cm9vdDpwYXNzd29yZA=="))
-            .respond_with(ResponseTemplate::new(204))
+            .respond_with(ResponseTemplate::new(204).insert_header("Location", "#fragment"))
             .expect(1)
             .mount(&mock_server)
             .await;
@@ -763,9 +938,11 @@ mod reqwest_client_tests {
         let bmc = create_test_bmc(&mock_server);
 
         let resource_id = create_odata_id(resource_path);
-        let result = bmc.delete::<TestResource>(&resource_id).await;
+        let response = bmc.delete::<TestResource>(&resource_id).await?;
 
-        assert!(result.is_ok());
+        assert!(matches!(response, ModificationResponse::Empty));
+
+        Ok(())
     }
 
     #[tokio::test]


### PR DESCRIPTION
### What

- Resolve `Location` relative to response URL, rejecting empty, malformed, or cross-origin values.
- Preserve URL paths and queries separately, preventing `?` from becoming `%3F`.
- Keep existing query parameters when adding `$expand` or `$filter`.
- Require valid `Location` only when response semantics need it: session creation, `202` tasks, and bodyless `200/201` responses.

### Why

Previously, some valid BMC responses could break core workflows:

- Query-bearing task locations could become invalid polling URLs, causing 404s, timeouts, or unknown firmware update state.
- Relative session locations could produce incorrect logout URLs, leaving sessions active.
- Existing continuation tokens could be lost when adding `$expand` or `$filter`, causing incorrect or repeated pages.
- Invalid or cross-origin locations could fail later with misleading errors instead of a clear protocol error.

Query-bearing and relative locations are rare, but supporting them improves interoperability with OEM BMCs and proxies.