### PR TITLE
fix(core): prevent empty OData type panic

### DIFF
--- a/core/src/odata.rs
+++ b/core/src/odata.rs
@@ -136,7 +136,7 @@ impl ODataType<'_> {
     pub fn parse_from(v: &serde_json::Value) -> Option<ODataType<'_>> {
         v.get("@odata.type")
             .and_then(|v| v.as_str())
-            .and_then(|v| v.starts_with('#').then_some(&v[1..]))
+            .and_then(|v| v.strip_prefix('#'))
             .and_then(|v| {
                 let mut all = v.split('.').collect::<Vec<_>>();
                 all.pop().map(|type_name| ODataType {
@@ -149,7 +149,16 @@ impl ODataType<'_> {
 
 #[cfg(test)]
 mod tests {
-    use super::ODataId;
+    use super::*;
+
+    #[test]
+    fn parse_from_returns_none_for_empty_odata_type() {
+        let value = serde_json::json!({ "@odata.type": "" });
+
+        let odata_type = ODataType::parse_from(&value);
+
+        assert!(odata_type.is_none());
+    }
 
     #[test]
     fn last_segment_returns_last_path_segment() {


### PR DESCRIPTION
Fix a panic in `ODataType::parse_from` when BMC JSON contains an empty `@odata.type`.

## Root cause

```rust
.and_then(|v| v.starts_with('#').then_some(&v[1..]))
```

`bool::then_some` evaluates its argument eagerly. For an empty string, `&v[1..]` is evaluated before the `starts_with('#')` result is applied, causing an out-of-bounds panic.

## Minimal reproduction

```rust
use serde_json::json;

fn main() {
    let s = json!({ "@odata.type": "" });
    let _ = nv_redfish_core::odata::ODataType::parse_from(&s);
}
```