### PR TITLE
fix(account)!: preserve modify responses

### DIFF
--- a/bmc-mock/src/expect.rs
+++ b/bmc-mock/src/expect.rs
@@ -18,7 +18,9 @@
 use std::fmt::Display;
 
 use nv_redfish_core::action::ActionTarget;
+use nv_redfish_core::AsyncTask;
 use nv_redfish_core::ODataId;
+
 use serde_json::from_str;
 use serde_json::Value as JsonValue;
 
@@ -29,12 +31,36 @@ pub type Response<E> = Result<JsonValue, E>;
 pub enum ExpectedRequest {
     /// Expected Get.
     Get { id: ODataId },
+
     /// Expected Expand.
     Expand { id: ODataId },
+
     /// Expected Update.
     Update { id: ODataId, request: JsonValue },
+
+    /// Expected asynchronous update.
+    UpdateTask {
+        id: ODataId,
+        request: JsonValue,
+        task: AsyncTask,
+    },
+
+    /// Expected update with no response body.
+    UpdateEmpty { id: ODataId, request: JsonValue },
+
     /// Expected Create.
     Create { id: ODataId, request: JsonValue },
+
+    /// Expected asynchronous create.
+    CreateTask {
+        id: ODataId,
+        request: JsonValue,
+        task: AsyncTask,
+    },
+
+    /// Expected create with no response body.
+    CreateEmpty { id: ODataId, request: JsonValue },
+
     /// Expected Redfish session creation.
     CreateSession {
         id: ODataId,
@@ -42,11 +68,13 @@ pub enum ExpectedRequest {
         auth_token: String,
         location: ODataId,
     },
+
     /// Expected ActionTarget
     Action {
         target: ActionTarget,
         request: JsonValue,
     },
+
     /// Expected multipart update.
     MultipartUpdate {
         uri: String,
@@ -54,11 +82,17 @@ pub enum ExpectedRequest {
         file_name: String,
         oem_parts: Vec<String>,
     },
+
     /// Expected raw HttpPushUri update.
     #[cfg(feature = "update-service-deprecated")]
     HttpPushUriUpdate { uri: String },
+
     /// Expected Delete.
     Delete { id: ODataId },
+
+    /// Expected asynchronous delete.
+    DeleteTask { id: ODataId, task: AsyncTask },
+
     /// Expected Stream.
     Stream { uri: String },
 }
@@ -96,6 +130,28 @@ impl<E> Expect<E> {
             response: Ok(from_str(&response.to_string()).expect("invalid json")),
         }
     }
+
+    pub fn update_task(uri: impl Display, request: impl Display, task: AsyncTask) -> Self {
+        Expect {
+            request: ExpectedRequest::UpdateTask {
+                id: uri.to_string().into(),
+                request: from_str(&request.to_string()).expect("invalid json"),
+                task,
+            },
+            response: Ok(JsonValue::Null),
+        }
+    }
+
+    pub fn update_empty(uri: impl Display, request: impl Display) -> Self {
+        Expect {
+            request: ExpectedRequest::UpdateEmpty {
+                id: uri.to_string().into(),
+                request: from_str(&request.to_string()).expect("invalid json"),
+            },
+            response: Ok(JsonValue::Null),
+        }
+    }
+
     pub fn create(uri: impl Display, request: impl Display, response: impl Display) -> Self {
         Expect {
             request: ExpectedRequest::Create {
@@ -105,6 +161,28 @@ impl<E> Expect<E> {
             response: Ok(from_str(&response.to_string()).expect("invalid json")),
         }
     }
+
+    pub fn create_task(uri: impl Display, request: impl Display, task: AsyncTask) -> Self {
+        Expect {
+            request: ExpectedRequest::CreateTask {
+                id: uri.to_string().into(),
+                request: from_str(&request.to_string()).expect("invalid json"),
+                task,
+            },
+            response: Ok(JsonValue::Null),
+        }
+    }
+
+    pub fn create_empty(uri: impl Display, request: impl Display) -> Self {
+        Expect {
+            request: ExpectedRequest::CreateEmpty {
+                id: uri.to_string().into(),
+                request: from_str(&request.to_string()).expect("invalid json"),
+            },
+            response: Ok(JsonValue::Null),
+        }
+    }
+
     pub fn create_session(
         uri: impl Display,
         request: impl Display,
@@ -185,6 +263,16 @@ impl<E> Expect<E> {
         Expect {
             request: ExpectedRequest::Delete {
                 id: uri.to_string().into(),
+            },
+            response: Ok(JsonValue::Null),
+        }
+    }
+
+    pub fn delete_task(uri: impl Display, task: AsyncTask) -> Self {
+        Expect {
+            request: ExpectedRequest::DeleteTask {
+                id: uri.to_string().into(),
+                task,
             },
             response: Ok(JsonValue::Null),
         }

--- a/bmc-mock/src/lib.rs
+++ b/bmc-mock/src/lib.rs
@@ -232,7 +232,9 @@ where
             .map_err(Error::mutex_lock)?
             .pop_front()
             .ok_or(Error::NothingIsExpected)?;
+
         let in_request = to_value(update).expect("json serializable");
+
         match expect {
             Expect {
                 request: ExpectedRequest::Update { id, request },
@@ -242,6 +244,14 @@ where
                 let result: R = from_value(response).map_err(Error::BadResponseJson)?;
                 Ok(ModificationResponse::Entity(result))
             }
+            Expect {
+                request: ExpectedRequest::UpdateTask { id, request, task },
+                ..
+            } if id == *in_id && request == in_request => Ok(ModificationResponse::Task(task)),
+            Expect {
+                request: ExpectedRequest::UpdateEmpty { id, request },
+                ..
+            } if id == *in_id && request == in_request => Ok(ModificationResponse::Empty),
             _ => Err(Error::UnexpectedUpdate(
                 in_id.clone(),
                 in_request.to_string(),
@@ -264,7 +274,9 @@ where
             .map_err(Error::mutex_lock)?
             .pop_front()
             .ok_or(Error::NothingIsExpected)?;
+
         let in_request = to_value(create).expect("json serializable");
+
         match expect {
             Expect {
                 request: ExpectedRequest::Create { id, request },
@@ -274,6 +286,14 @@ where
                 let result: R = from_value(response).map_err(Error::BadResponseJson)?;
                 Ok(ModificationResponse::Entity(result))
             }
+            Expect {
+                request: ExpectedRequest::CreateTask { id, request, task },
+                ..
+            } if id == *in_id && request == in_request => Ok(ModificationResponse::Task(task)),
+            Expect {
+                request: ExpectedRequest::CreateEmpty { id, request },
+                ..
+            } if id == *in_id && request == in_request => Ok(ModificationResponse::Empty),
             _ => Err(Error::UnexpectedCreate(
                 in_id.clone(),
                 in_request.to_string(),
@@ -339,6 +359,10 @@ where
                 request: ExpectedRequest::Delete { id },
                 ..
             } if id == *in_id => Ok(ModificationResponse::Empty),
+            Expect {
+                request: ExpectedRequest::DeleteTask { id, task },
+                ..
+            } if id == *in_id => Ok(ModificationResponse::Task(task)),
             _ => Err(Error::UnexpectedDelete(in_id.clone(), expect.request)),
         }
     }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -222,6 +222,22 @@ pub enum ModificationResponse<T> {
     Empty,
 }
 
+impl<T> ModificationResponse<T> {
+    /// Maps a synchronous entity response while preserving task and empty
+    /// outcomes.
+    #[must_use]
+    pub fn map<U, F>(self, f: F) -> ModificationResponse<U>
+    where
+        F: FnOnce(T) -> U,
+    {
+        match self {
+            Self::Entity(entity) => ModificationResponse::Entity(f(entity)),
+            Self::Task(task) => ModificationResponse::Task(task),
+            Self::Empty => ModificationResponse::Empty,
+        }
+    }
+}
+
 /// Redfish session creation returns the session resource in the response body,
 /// the authentication token in the `X-Auth-Token` header, and the session URI in
 /// the `Location` header.

--- a/redfish/src/account/collection.rs
+++ b/redfish/src/account/collection.rs
@@ -52,6 +52,7 @@ use crate::Error;
 use crate::NvBmc;
 use nv_redfish_core::Bmc;
 use nv_redfish_core::EntityTypeRef as _;
+use nv_redfish_core::ModificationResponse;
 use nv_redfish_core::NavProperty;
 use nv_redfish_core::ODataId;
 use std::sync::Arc;
@@ -148,13 +149,20 @@ impl<B: Bmc> AccountCollection<B> {
 
     /// Create a new account.
     ///
+    /// Returns one of the following modification outcomes:
+    ///
+    /// - `ModificationResponse::Entity` contains the newly created account.
+    /// - `ModificationResponse::Task` identifies an asynchronous operation.
+    /// - `ModificationResponse::Empty` reports synchronous success without a
+    ///   response body.
+    ///
     /// # Errors
     ///
     /// Returns an error if creating a new account fails.
     pub async fn create_account(
         &self,
         create: ManagerAccountCreate,
-    ) -> Result<Option<Account<B>>, Error<B>> {
+    ) -> Result<ModificationResponse<Account<B>>, Error<B>> {
         if let Some(cfg) = &self.config.slot_defined_user_accounts {
             // For slot-defined configuration, find the first account
             // that is disabled (and whose id is >= `min_slot`, if defined)
@@ -205,15 +213,14 @@ impl<B: Bmc> AccountCollection<B> {
             Err(Error::AccountSlotNotAvailable)
         } else {
             let outcome = self.create_with_patch(&create).await?;
-            Ok(match outcome {
-                nv_redfish_core::ModificationResponse::Entity(account) => Some(Account::from_data(
-                    self.bmc.clone(),
-                    account,
-                    self.config.account.clone(),
+
+            match outcome {
+                ModificationResponse::Entity(account) => Ok(ModificationResponse::Entity(
+                    Account::from_data(self.bmc.clone(), account, self.config.account.clone()),
                 )),
-                nv_redfish_core::ModificationResponse::Task(_)
-                | nv_redfish_core::ModificationResponse::Empty => None,
-            })
+                ModificationResponse::Task(task) => Ok(ModificationResponse::Task(task)),
+                ModificationResponse::Empty => Ok(ModificationResponse::Empty),
+            }
         }
     }
 

--- a/redfish/src/account/collection.rs
+++ b/redfish/src/account/collection.rs
@@ -212,15 +212,9 @@ impl<B: Bmc> AccountCollection<B> {
             // No available slot found
             Err(Error::AccountSlotNotAvailable)
         } else {
-            let outcome = self.create_with_patch(&create).await?;
-
-            match outcome {
-                ModificationResponse::Entity(account) => Ok(ModificationResponse::Entity(
-                    Account::from_data(self.bmc.clone(), account, self.config.account.clone()),
-                )),
-                ModificationResponse::Task(task) => Ok(ModificationResponse::Task(task)),
-                ModificationResponse::Empty => Ok(ModificationResponse::Empty),
-            }
+            Ok(self.create_with_patch(&create).await?.map(|account| {
+                Account::from_data(self.bmc.clone(), account, self.config.account.clone())
+            }))
         }
     }
 

--- a/redfish/src/account/item.rs
+++ b/redfish/src/account/item.rs
@@ -118,32 +118,49 @@ impl<B: Bmc> Account<B> {
 
     /// Update the account.
     ///
-    /// Returns the new (updated) account.
+    /// Returns one of the following modification outcomes:
+    ///
+    /// - `ModificationResponse::Entity` contains the updated account.
+    /// - `ModificationResponse::Task` identifies an asynchronous operation.
+    /// - `ModificationResponse::Empty` reports synchronous success without a
+    ///   response body.
     ///
     /// # Errors
     ///
     /// Returns an error if the server responds with an error or if the
     /// response cannot be parsed.
-    pub async fn update(&self, update: &ManagerAccountUpdate) -> Result<Option<Self>, Error<B>> {
+    pub async fn update(
+        &self,
+        update: &ManagerAccountUpdate,
+    ) -> Result<ModificationResponse<Self>, Error<B>> {
         match self.update_with_patch(update).await? {
-            ModificationResponse::Entity(ma) => Ok(Some(Self::from_data(
+            ModificationResponse::Entity(ma) => Ok(ModificationResponse::Entity(Self::from_data(
                 self.bmc.clone(),
                 ma,
                 self.config.clone(),
             ))),
-            ModificationResponse::Task(_) | ModificationResponse::Empty => Ok(None),
+            ModificationResponse::Task(task) => Ok(ModificationResponse::Task(task)),
+            ModificationResponse::Empty => Ok(ModificationResponse::Empty),
         }
     }
 
     /// Update the account's password.
     ///
-    /// Returns the new (updated) account.
+    /// Returns one of the following modification outcomes:
+    ///
+    /// - `ModificationResponse::Entity` contains the updated account.
+    /// - `ModificationResponse::Task` identifies an asynchronous operation.
+    /// - `ModificationResponse::Empty` reports synchronous success without a
+    ///   response body.
     ///
     /// # Errors
     ///
     /// Returns an error if the server responds with an error or if the
     /// response cannot be parsed.
-    pub async fn update_password(&self, password: String) -> Result<Option<Self>, Error<B>> {
+    pub async fn update_password(
+        &self,
+        password: String,
+    ) -> Result<ModificationResponse<Self>, Error<B>> {
         self.update(
             &ManagerAccountUpdate::builder()
                 .with_password(password)
@@ -154,13 +171,21 @@ impl<B: Bmc> Account<B> {
 
     /// Update the account's user name.
     ///
-    /// Returns the new (updated) account.
+    /// Returns one of the following modification outcomes:
+    ///
+    /// - `ModificationResponse::Entity` contains the updated account.
+    /// - `ModificationResponse::Task` identifies an asynchronous operation.
+    /// - `ModificationResponse::Empty` reports synchronous success without a
+    ///   response body.
     ///
     /// # Errors
     ///
     /// Returns an error if the server responds with an error or if the
     /// response cannot be parsed.
-    pub async fn update_user_name(&self, user_name: String) -> Result<Option<Self>, Error<B>> {
+    pub async fn update_user_name(
+        &self,
+        user_name: String,
+    ) -> Result<ModificationResponse<Self>, Error<B>> {
         self.update(
             &ManagerAccountUpdate::builder()
                 .with_user_name(user_name)
@@ -171,10 +196,19 @@ impl<B: Bmc> Account<B> {
 
     /// Delete the current account.
     ///
+    /// Returns one of the following modification outcomes:
+    ///
+    /// - `ModificationResponse::Entity` contains the account returned by the
+    ///   server. When deletion is configured to disable the account, this is the
+    ///   updated account.
+    /// - `ModificationResponse::Task` identifies an asynchronous operation.
+    /// - `ModificationResponse::Empty` reports synchronous success without a
+    ///   response body.
+    ///
     /// # Errors
     ///
     /// Returns an error if deletion fails.
-    pub async fn delete(&self) -> Result<Option<Self>, Error<B>> {
+    pub async fn delete(&self) -> Result<ModificationResponse<Self>, Error<B>> {
         if self.config.disable_account_on_delete {
             self.update(&ManagerAccountUpdate::builder().with_enabled(false).build())
                 .await
@@ -186,10 +220,11 @@ impl<B: Bmc> Account<B> {
                 .await
                 .map_err(Error::Bmc)?
             {
-                ModificationResponse::Entity(nav) => {
-                    Self::new(&self.bmc, &nav, &self.config).await.map(Some)
-                }
-                ModificationResponse::Task(_) | ModificationResponse::Empty => Ok(None),
+                ModificationResponse::Entity(nav) => Self::new(&self.bmc, &nav, &self.config)
+                    .await
+                    .map(ModificationResponse::Entity),
+                ModificationResponse::Task(task) => Ok(ModificationResponse::Task(task)),
+                ModificationResponse::Empty => Ok(ModificationResponse::Empty),
             }
         }
     }

--- a/redfish/src/account/item.rs
+++ b/redfish/src/account/item.rs
@@ -133,15 +133,10 @@ impl<B: Bmc> Account<B> {
         &self,
         update: &ManagerAccountUpdate,
     ) -> Result<ModificationResponse<Self>, Error<B>> {
-        match self.update_with_patch(update).await? {
-            ModificationResponse::Entity(ma) => Ok(ModificationResponse::Entity(Self::from_data(
-                self.bmc.clone(),
-                ma,
-                self.config.clone(),
-            ))),
-            ModificationResponse::Task(task) => Ok(ModificationResponse::Task(task)),
-            ModificationResponse::Empty => Ok(ModificationResponse::Empty),
-        }
+        Ok(self
+            .update_with_patch(update)
+            .await?
+            .map(|ma| Self::from_data(self.bmc.clone(), ma, self.config.clone())))
     }
 
     /// Update the account's password.

--- a/tests/tests/tests-account-service.rs
+++ b/tests/tests/tests-account-service.rs
@@ -15,27 +15,35 @@
 
 //! Integration tests of Account Service.
 
+use std::error::Error as StdError;
+use std::sync::Arc;
+use std::time::Duration;
+
 use nv_redfish::account::AccountCollection;
 use nv_redfish::account::AccountService;
 use nv_redfish::account::AccountTypes;
 use nv_redfish::account::ManagerAccountCreate;
+use nv_redfish::account::ManagerAccountUpdate;
 use nv_redfish::ServiceRoot;
+use nv_redfish_core::AsyncTask;
 use nv_redfish_core::EntityTypeRef;
+use nv_redfish_core::ModificationResponse;
 use nv_redfish_core::ODataId;
 use nv_redfish_tests::json_merge;
 use nv_redfish_tests::Bmc;
 use nv_redfish_tests::Expect;
 use nv_redfish_tests::ODATA_ID;
 use nv_redfish_tests::ODATA_TYPE;
+
 use serde_json::json;
 use serde_json::Value as JsonValue;
-use std::error::Error as StdError;
-use std::sync::Arc;
 use tokio::test;
 
 const ACCOUNT_SERVICE_DATA_TYPE: &str = "#AccountService.v1_5_0.AccountService";
 const ACCOUNTS_DATA_TYPE: &str = "#ManagerAccountCollection.ManagerAccountCollection";
 const MANAGER_ACCOUNT_DATA_TYPE: &str = "#ManagerAccount.v1_3_0.ManagerAccount";
+
+type TestResult<T> = Result<T, Box<dyn StdError>>;
 
 #[test]
 async fn list_accounts() -> Result<(), Box<dyn StdError>> {
@@ -124,8 +132,9 @@ async fn get_account_service(
 ) -> Result<AccountService<Bmc>, Box<dyn StdError>> {
     let account_service_id = format!("{root_id}/AccountService");
     let data_type = "#ServiceRoot.v1_13_0.ServiceRoot";
+
     bmc.expect(Expect::get(
-        &root_id,
+        root_id,
         json!({
             ODATA_ID: &root_id,
             ODATA_TYPE: &data_type,
@@ -195,24 +204,86 @@ fn slot_member(accounts_id: &str, id: u32, enabled: bool, user_name: &str) -> Js
     })
 }
 
+async fn account_fixture(
+    vendor: &str,
+    slots: &[(u32, bool, &str)],
+) -> TestResult<(Arc<Bmc>, String, AccountCollection<Bmc>)> {
+    let bmc = Arc::new(Bmc::default());
+    let root_id = ODataId::service_root();
+    let account_service = get_account_service(bmc.clone(), &root_id, vendor).await?;
+    let accounts_id = format!("{}/Accounts", account_service.raw().odata_id());
+
+    let members = JsonValue::Array(
+        slots
+            .iter()
+            .map(|&(id, enabled, user_name)| slot_member(&accounts_id, id, enabled, user_name))
+            .collect(),
+    );
+
+    let accounts = get_account_collection(bmc.clone(), &account_service, members).await?;
+
+    Ok((bmc, accounts_id, accounts))
+}
+
+fn async_task(location: &str, retry_after_secs: u64) -> AsyncTask {
+    AsyncTask {
+        location: ODataId::from(location.to_string()).into(),
+        retry_after: Some(Duration::from_secs(retry_after_secs)),
+    }
+}
+
+fn create_request(user_name: &str) -> ManagerAccountCreate {
+    ManagerAccountCreate::builder("password".into(), user_name.to_string(), "Operator".into())
+        .build()
+}
+
+fn slot_update() -> ManagerAccountUpdate {
+    ManagerAccountUpdate::builder()
+        .with_user_name("user".into())
+        .with_password("password".into())
+        .with_role_id("Operator".into())
+        .with_enabled(true)
+        .build()
+}
+
+fn assert_task<T>(response: ModificationResponse<T>, location: &str, retry_after_secs: u64) {
+    let ModificationResponse::Task(task) = response else {
+        panic!("expected an asynchronous task response");
+    };
+
+    assert_eq!(task.location.0.to_string(), location);
+
+    assert_eq!(
+        task.retry_after,
+        Some(Duration::from_secs(retry_after_secs))
+    );
+}
+
+fn assert_empty<T>(response: ModificationResponse<T>) {
+    assert!(matches!(response, ModificationResponse::Empty));
+}
+
+fn into_entity<T>(response: ModificationResponse<T>) -> T {
+    let ModificationResponse::Entity(entity) = response else {
+        panic!("expected an entity response");
+    };
+
+    entity
+}
+
 // Create account (standard vendor): request includes required fields, response
 // provides `AccountTypes: []` without patching.
 #[test]
-async fn create_account_standard() -> Result<(), Box<dyn StdError>> {
-    let bmc = Arc::new(Bmc::default());
-    let root_id = ODataId::service_root();
-    let account_service = get_account_service(bmc.clone(), &root_id, "Contoso").await?;
-    let accounts = get_account_collection(bmc.clone(), &account_service, json!([])).await?;
-    let accounts_id = format!("{}/Accounts", account_service.raw().odata_id());
-    let maccount_id = format!("{accounts_id}/1");
-    let create_req =
-        ManagerAccountCreate::builder("password".into(), "user".into(), "Operator".into()).build();
+async fn create_account_standard_preserves_all_response_variants() -> TestResult<()> {
+    let (bmc, accounts_id, accounts) = account_fixture("Contoso", &[]).await?;
+    let create_req = create_request("user");
     let create_json = serde_json::to_value(&create_req).unwrap();
+
     bmc.expect(Expect::create(
         &accounts_id,
         create_json,
         json!({
-            ODATA_ID: maccount_id,
+            ODATA_ID: format!("{accounts_id}/1"),
             ODATA_TYPE: MANAGER_ACCOUNT_DATA_TYPE,
             "Id": "1",
             "Name": "User Account",
@@ -221,35 +292,50 @@ async fn create_account_standard() -> Result<(), Box<dyn StdError>> {
             "AccountTypes": []
         }),
     ));
-    let account = accounts.create_account(create_req).await?;
-    let account = account.expect("create_account should return account entity");
-    let account = account.raw();
+
+    let account = into_entity(accounts.create_account(create_req).await?).raw();
+
     assert_eq!(account.user_name, Some("user".into()));
     assert_eq!(account.role_id, Some("Operator".into()));
     assert_eq!(account.base.id, "1");
     assert_eq!(account.base.name, "User Account");
     assert!(account.account_types.as_ref().is_some_and(Vec::is_empty));
+
+    let task_id = "/redfish/v1/TaskService/Tasks/42";
+    let create_req = create_request("task-user");
+    let create_json = serde_json::to_value(&create_req).unwrap();
+
+    bmc.expect(Expect::create_task(
+        &accounts_id,
+        create_json,
+        async_task(task_id, 7),
+    ));
+
+    assert_task(accounts.create_account(create_req).await?, task_id, 7);
+
+    let create_req = create_request("empty-user");
+    let create_json = serde_json::to_value(&create_req).unwrap();
+
+    bmc.expect(Expect::create_empty(&accounts_id, create_json));
+
+    assert_empty(accounts.create_account(create_req).await?);
+
     Ok(())
 }
 
 // Create account (HPE-like vendor): response omits `AccountTypes`, expect
 // defaulting to `[Redfish]` via read patching.
 #[test]
-async fn create_account_hpe_patched() -> Result<(), Box<dyn StdError>> {
-    let bmc = Arc::new(Bmc::default());
-    let root_id = ODataId::service_root();
-    let account_service = get_account_service(bmc.clone(), &root_id, "HPE").await?;
-    let accounts = get_account_collection(bmc.clone(), &account_service, json!([])).await?;
-    let accounts_id = format!("{}/Accounts", account_service.raw().odata_id());
-    let maccount_id = format!("{accounts_id}/1");
-    let create_req =
-        ManagerAccountCreate::builder("password".into(), "user".into(), "Operator".into()).build();
+async fn create_account_hpe_patched() -> TestResult<()> {
+    let (bmc, accounts_id, accounts) = account_fixture("HPE", &[]).await?;
+    let create_req = create_request("user");
     let create_json = serde_json::to_value(&create_req).unwrap();
+
     bmc.expect(Expect::create(
         &accounts_id,
         create_json,
         json!({
-            ODATA_ID: maccount_id,
+            ODATA_ID: format!("{accounts_id}/1"),
             ODATA_TYPE: MANAGER_ACCOUNT_DATA_TYPE,
             "Id": "1",
             "Name": "User Account",
@@ -257,41 +343,34 @@ async fn create_account_hpe_patched() -> Result<(), Box<dyn StdError>> {
             "RoleId": "Operator"
         }),
     ));
-    let account = accounts.create_account(create_req).await?;
-    let account = account.expect("create_account should return account entity");
-    let account = account.raw();
+
+    let account = into_entity(accounts.create_account(create_req).await?).raw();
+
     assert_eq!(account.user_name, Some("user".into()));
     assert_eq!(account.account_types, Some(vec![AccountTypes::Redfish]));
+
     Ok(())
 }
 
 // Create account (Dell slot-defined): choose first disabled slot with id >= min_slot (3).
 #[test]
-async fn create_account_dell_slot_defined_first_available() -> Result<(), Box<dyn StdError>> {
-    let bmc = Arc::new(Bmc::default());
-    let root_id = ODataId::service_root();
-    let account_service = get_account_service(bmc.clone(), &root_id, "Dell").await?;
+async fn create_account_dell_slot_defined_first_available() -> TestResult<()> {
+    let (bmc, accounts_id, accounts) = account_fixture(
+        "Dell",
+        &[
+            (1, true, "root"),
+            (2, false, ""),
+            (3, false, ""),
+            (4, false, ""),
+        ],
+    )
+    .await?;
 
-    let accounts_id = format!("{}/Accounts", account_service.raw().odata_id());
-    let members = json!([
-        slot_member(&accounts_id, 1, true, "root"), // below min_slot, enabled
-        slot_member(&accounts_id, 2, false, ""),    // below min_slot, disabled (must be skipped)
-        slot_member(&accounts_id, 3, false, ""),    // first eligible slot
-        slot_member(&accounts_id, 4, false, ""),
-    ]);
-    let accounts = get_account_collection(bmc.clone(), &account_service, members).await?;
-
-    // Expect update on slot 3 with create params + enable.
-    let update_req = nv_redfish::account::ManagerAccountUpdate::builder()
-        .with_user_name("user".into())
-        .with_password("password".into())
-        .with_role_id("Operator".into())
-        .with_enabled(true)
-        .build();
+    let update_req = slot_update();
     let update_json = serde_json::to_value(&update_req).unwrap();
-    let maccount_id = format!("{accounts_id}/3");
+
     bmc.expect(Expect::update(
-        &maccount_id,
+        format!("{accounts_id}/3"),
         update_json,
         json_merge([
             &slot_member(&accounts_id, 3, true, "user"),
@@ -299,60 +378,149 @@ async fn create_account_dell_slot_defined_first_available() -> Result<(), Box<dy
         ]),
     ));
 
-    let create_req =
-        ManagerAccountCreate::builder("password".into(), "user".into(), "Operator".into()).build();
-    let account = accounts.create_account(create_req).await?;
-    let account = account.expect("create_account should return account entity");
-    let account = account.raw();
+    let account = into_entity(accounts.create_account(create_request("user")).await?).raw();
+
     assert_eq!(account.base.id, "3");
     assert_eq!(account.user_name, Some("user".into()));
     assert_eq!(account.role_id, Some("Operator".into()));
     assert_eq!(account.enabled, Some(true));
+
+    Ok(())
+}
+
+#[test]
+async fn create_account_slot_defined_preserves_async_task() -> TestResult<()> {
+    let (bmc, accounts_id, accounts) =
+        account_fixture("Dell", &[(1, true, "root"), (3, false, "")]).await?;
+
+    let update_req = slot_update();
+    let update_json = serde_json::to_value(&update_req).unwrap();
+    let account_id = format!("{accounts_id}/3");
+    let task_id = "/redfish/v1/TaskService/Tasks/43";
+
+    bmc.expect(Expect::update_task(
+        &account_id,
+        update_json,
+        async_task(task_id, 8),
+    ));
+
+    assert_task(
+        accounts.create_account(create_request("user")).await?,
+        task_id,
+        8,
+    );
+
+    Ok(())
+}
+
+#[test]
+async fn update_account_preserves_task_and_empty_responses() -> TestResult<()> {
+    let (bmc, accounts_id, accounts) = account_fixture("Contoso", &[(1, true, "user")]).await?;
+    let account = accounts
+        .all_accounts_data()
+        .await?
+        .into_iter()
+        .next()
+        .ok_or("missing account")?;
+
+    let account_id = format!("{accounts_id}/1");
+
+    let update_req = ManagerAccountUpdate::builder()
+        .with_password("new-password".into())
+        .build();
+
+    let update_json = serde_json::to_value(&update_req).unwrap();
+
+    bmc.expect(Expect::update_empty(&account_id, update_json));
+
+    assert_empty(account.update(&update_req).await?);
+
+    let update_req = ManagerAccountUpdate::builder()
+        .with_password("newer-password".into())
+        .build();
+
+    let update_json = serde_json::to_value(&update_req).unwrap();
+    let task_id = "/redfish/v1/TaskService/Tasks/44";
+
+    bmc.expect(Expect::update_task(
+        &account_id,
+        update_json,
+        async_task(task_id, 9),
+    ));
+
+    assert_task(
+        account.update_password("newer-password".into()).await?,
+        task_id,
+        9,
+    );
+
+    Ok(())
+}
+
+#[test]
+async fn delete_account_preserves_task_and_empty_responses() -> TestResult<()> {
+    let (bmc, _, accounts) =
+        account_fixture("Contoso", &[(1, true, "first"), (2, true, "second")]).await?;
+
+    let mut account_data = accounts.all_accounts_data().await?.into_iter();
+    let task_account = account_data.next().ok_or("missing first account")?;
+    let empty_account = account_data.next().ok_or("missing second account")?;
+    let task_account_id = task_account.raw().odata_id().to_string();
+    let empty_account_id = empty_account.raw().odata_id().to_string();
+    let task_id = "/redfish/v1/TaskService/Tasks/45";
+
+    bmc.expect(Expect::delete_task(
+        task_account_id,
+        async_task(task_id, 10),
+    ));
+
+    assert_task(task_account.delete().await?, task_id, 10);
+
+    bmc.expect(Expect::delete(empty_account_id));
+
+    assert_empty(empty_account.delete().await?);
+
     Ok(())
 }
 
 // Create account (Dell slot-defined): error when no disabled slot id >= min_slot is available.
 #[test]
-async fn create_account_dell_slot_defined_no_slot_available() -> Result<(), Box<dyn StdError>> {
-    let bmc = Arc::new(Bmc::default());
-    let root_id = ODataId::service_root();
-    let account_service = get_account_service(bmc.clone(), &root_id, "Dell").await?;
+async fn create_account_dell_slot_defined_no_slot_available() -> TestResult<()> {
+    let (_, _, accounts) = account_fixture(
+        "Dell",
+        &[
+            (1, false, ""),
+            (2, false, ""),
+            (3, true, "root"),
+            (4, true, "other"),
+        ],
+    )
+    .await?;
 
-    let accounts_id = format!("{}/Accounts", account_service.raw().odata_id());
-    // All eligible (>=3) are enabled; no disabled slots available.
-    let members = json!([
-        slot_member(&accounts_id, 1, false, ""),
-        slot_member(&accounts_id, 2, false, ""),
-        slot_member(&accounts_id, 3, true, "root"),
-        slot_member(&accounts_id, 4, true, "other"),
-    ]);
-    let accounts = get_account_collection(bmc.clone(), &account_service, members).await?;
+    assert!(accounts
+        .create_account(create_request("user"))
+        .await
+        .is_err());
 
-    let create_req =
-        ManagerAccountCreate::builder("password".into(), "user".into(), "Operator".into()).build();
-    assert!(accounts.create_account(create_req).await.is_err());
     Ok(())
 }
 
 // List accounts (Dell slot-defined): disabled accounts are hidden.
 #[test]
-async fn list_dell_accounts_hide_disabled() -> Result<(), Box<dyn StdError>> {
-    let bmc = Arc::new(Bmc::default());
-    let root_id = ODataId::service_root();
-    let account_service = get_account_service(bmc.clone(), &root_id, "Dell").await?;
+async fn list_dell_accounts_hide_disabled() -> TestResult<()> {
+    let (_, _, accounts) = account_fixture(
+        "Dell",
+        &[(1, true, "root"), (3, false, ""), (4, true, "other")],
+    )
+    .await?;
 
-    let accounts_id = format!("{}/Accounts", account_service.raw().odata_id());
-    let members = json!([
-        slot_member(&accounts_id, 1, true, "root"),
-        slot_member(&accounts_id, 3, false, ""),
-        slot_member(&accounts_id, 4, true, "other"),
-    ]);
-    let accounts = get_account_collection(bmc.clone(), &account_service, members).await?;
     let data = accounts.all_accounts_data().await?;
     let ids: Vec<_> = data
         .into_iter()
         .map(|a| a.raw().as_ref().base.id.clone())
         .collect();
+
     assert_eq!(ids, vec!["1", "4"]);
+
     Ok(())
 }


### PR DESCRIPTION
## Why

Redfish account changes can finish with an entity, finish with no body, or return a task. The `Option<Account>` API turned both `Task` and `Empty` into `None`, losing the task handle callers need to track completion and failures.

## Changes

- Return `ModificationResponse<Account<B>>` from account create/update/delete paths.
- Preserve `Entity`, `Task`, and `Empty` instead of collapsing non-entity success.
- Add mock support and integration coverage for task and empty responses.

## Breaking Change

Account create/update/delete APIs now return `ModificationResponse<Account<B>>` instead of `Option<Account<B>>`, so callers need to handle `Entity`, `Task`, and `Empty`.