### PR TITLE
fix(redfish)!: preserve modify responses

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -212,21 +212,22 @@ pub struct AsyncTask {
 }
 
 /// Outcome of a mutating Redfish operation.
+#[must_use = "mutating Redfish responses may contain an asynchronous task handle"]
 #[derive(Debug)]
 pub enum ModificationResponse<T> {
-    /// Request completed synchronously
+    /// Request completed synchronously.
     Entity(T),
+
     /// Request is completing asynchronously with the provided task location.
     Task(AsyncTask),
-    /// Request completed successfully with no response body
+
+    /// Request completed successfully with no response body.
     Empty,
 }
 
 impl<T> ModificationResponse<T> {
-    /// Maps a synchronous entity response while preserving task and empty
-    /// outcomes.
-    #[must_use]
-    pub fn map<U, F>(self, f: F) -> ModificationResponse<U>
+    /// Maps an entity outcome while preserving task and empty outcomes.
+    pub fn map_entity<U, F>(self, f: F) -> ModificationResponse<U>
     where
         F: FnOnce(T) -> U,
     {
@@ -234,6 +235,44 @@ impl<T> ModificationResponse<T> {
             Self::Entity(entity) => ModificationResponse::Entity(f(entity)),
             Self::Task(task) => ModificationResponse::Task(task),
             Self::Empty => ModificationResponse::Empty,
+        }
+    }
+
+    /// Maps an entity outcome with a fallible function while preserving task
+    /// and empty outcomes.
+    ///
+    /// # Errors
+    ///
+    /// Returns the error produced by `f` when this response contains an entity.
+    pub fn try_map_entity<U, E, F>(self, f: F) -> Result<ModificationResponse<U>, E>
+    where
+        F: FnOnce(T) -> Result<U, E>,
+    {
+        match self {
+            Self::Entity(entity) => f(entity).map(ModificationResponse::Entity),
+            Self::Task(task) => Ok(ModificationResponse::Task(task)),
+            Self::Empty => Ok(ModificationResponse::Empty),
+        }
+    }
+
+    /// Asynchronously maps an entity outcome with a fallible function while
+    /// preserving task and empty outcomes.
+    ///
+    /// # Errors
+    ///
+    /// Returns the error produced by `f` when this response contains an entity.
+    pub async fn try_map_entity_async<U, E, F, Fut>(
+        self,
+        f: F,
+    ) -> Result<ModificationResponse<U>, E>
+    where
+        F: FnOnce(T) -> Fut,
+        Fut: Future<Output = Result<U, E>>,
+    {
+        match self {
+            Self::Entity(entity) => f(entity).await.map(ModificationResponse::Entity),
+            Self::Task(task) => Ok(ModificationResponse::Task(task)),
+            Self::Empty => Ok(ModificationResponse::Empty),
         }
     }
 }
@@ -317,4 +356,125 @@ pub trait ToSnakeCase {
 pub trait FilterProperty {
     /// Returns the `OData` property path for this property
     fn property_path(&self) -> &str;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_entity(
+        response: ModificationResponse<u32>,
+        expected: u32,
+    ) -> Result<(), &'static str> {
+        let ModificationResponse::Entity(value) = response else {
+            return Err("expected an entity response");
+        };
+
+        assert_eq!(value, expected);
+
+        Ok(())
+    }
+
+    fn assert_task<T>(response: ModificationResponse<T>) -> Result<(), &'static str> {
+        let ModificationResponse::Task(task) = response else {
+            return Err("expected a task response");
+        };
+
+        assert_eq!(
+            task.location.0.to_string(),
+            "/redfish/v1/TaskService/Tasks/1"
+        );
+
+        Ok(())
+    }
+
+    fn assert_empty<T>(response: ModificationResponse<T>) -> Result<(), &'static str> {
+        if !matches!(response, ModificationResponse::Empty) {
+            return Err("expected an empty response");
+        }
+
+        Ok(())
+    }
+
+    fn task_response() -> ModificationResponse<()> {
+        ModificationResponse::Task(AsyncTask {
+            location: ODataId::from("/redfish/v1/TaskService/Tasks/1".to_string()).into(),
+            retry_after: None,
+        })
+    }
+
+    #[test]
+    fn map_entity_maps_entity_and_preserves_task_and_empty() -> Result<(), &'static str> {
+        assert_entity(
+            ModificationResponse::Entity(21_u32).map_entity(|value| value * 2),
+            42,
+        )?;
+
+        assert_task(task_response().map_entity(|()| 42_u32))?;
+        assert_empty(ModificationResponse::<()>::Empty.map_entity(|()| 42_u32))?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn try_map_entity_maps_entity_and_propagates_error() -> Result<(), &'static str> {
+        assert_entity(
+            ModificationResponse::Entity(21_u32).try_map_entity(|value| Ok(value * 2))?,
+            42,
+        )?;
+
+        let error = ModificationResponse::Entity(21_u32)
+            .try_map_entity(|_| Err::<u32, _>("mapping failed"));
+
+        assert!(matches!(error, Err("mapping failed")));
+
+        Ok(())
+    }
+
+    #[test]
+    fn try_map_entity_preserves_task_and_empty() -> Result<(), &'static str> {
+        assert_task(task_response().try_map_entity(|()| Ok::<u32, &'static str>(42))?)?;
+
+        assert_empty(
+            ModificationResponse::<()>::Empty.try_map_entity(|()| Ok::<u32, &'static str>(42))?,
+        )?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn try_map_entity_async_maps_entity_and_preserves_task_and_empty(
+    ) -> Result<(), &'static str> {
+        assert_entity(
+            ModificationResponse::Entity(21_u32)
+                .try_map_entity_async(|value| async move { Ok(value * 2) })
+                .await?,
+            42,
+        )?;
+
+        assert_task(
+            task_response()
+                .try_map_entity_async(|()| async { Ok::<u32, &'static str>(42) })
+                .await?,
+        )?;
+
+        assert_empty(
+            ModificationResponse::<()>::Empty
+                .try_map_entity_async(|()| async { Ok::<u32, &'static str>(42) })
+                .await?,
+        )?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn try_map_entity_async_propagates_mapper_error() {
+        let response = ModificationResponse::Entity(21_u32);
+
+        let mapped = response
+            .try_map_entity_async(|_| async { Err::<u32, _>("mapping failed") })
+            .await;
+
+        assert!(matches!(mapped, Err("mapping failed")));
+    }
 }

--- a/examples/explore-with-dummy-bmc/src/main.rs
+++ b/examples/explore-with-dummy-bmc/src/main.rs
@@ -789,7 +789,7 @@ async fn main() -> Result<(), Error> {
     );
 
     println!("Performing system reset...");
-    system
+    let _reset = system
         .actions
         .as_ref()
         .ok_or(Error::ExpectedField("actions"))?

--- a/examples/explore-with-reqwest-bmc/src/main.rs
+++ b/examples/explore-with-reqwest-bmc/src/main.rs
@@ -112,7 +112,7 @@ async fn main() -> Result<(), BmcError> {
         .get(&bmc)
         .await?;
 
-    system
+    let _change_password = system
         .bios
         .as_ref()
         .expect("no bios")
@@ -159,7 +159,7 @@ async fn main() -> Result<(), BmcError> {
         .get(&bmc)
         .await?;
 
-    acc.delete(&bmc).await?;
+    let _delete = acc.delete(&bmc).await?;
 
     let _ = NavProperty::<ManagerAccount>::new_reference(account.odata_id().clone())
         .get(&bmc)

--- a/redfish/src/account/collection.rs
+++ b/redfish/src/account/collection.rs
@@ -212,9 +212,12 @@ impl<B: Bmc> AccountCollection<B> {
             // No available slot found
             Err(Error::AccountSlotNotAvailable)
         } else {
-            Ok(self.create_with_patch(&create).await?.map(|account| {
-                Account::from_data(self.bmc.clone(), account, self.config.account.clone())
-            }))
+            Ok(self
+                .create_with_patch(&create)
+                .await?
+                .map_entity(|account| {
+                    Account::from_data(self.bmc.clone(), account, self.config.account.clone())
+                }))
         }
     }
 

--- a/redfish/src/account/item.rs
+++ b/redfish/src/account/item.rs
@@ -136,7 +136,7 @@ impl<B: Bmc> Account<B> {
         Ok(self
             .update_with_patch(update)
             .await?
-            .map(|ma| Self::from_data(self.bmc.clone(), ma, self.config.clone())))
+            .map_entity(|ma| Self::from_data(self.bmc.clone(), ma, self.config.clone())))
     }
 
     /// Update the account's password.
@@ -208,19 +208,15 @@ impl<B: Bmc> Account<B> {
             self.update(&ManagerAccountUpdate::builder().with_enabled(false).build())
                 .await
         } else {
-            match self
-                .bmc
+            self.bmc
                 .as_ref()
                 .delete::<NavProperty<ManagerAccount>>(self.data.odata_id())
                 .await
                 .map_err(Error::Bmc)?
-            {
-                ModificationResponse::Entity(nav) => Self::new(&self.bmc, &nav, &self.config)
-                    .await
-                    .map(ModificationResponse::Entity),
-                ModificationResponse::Task(task) => Ok(ModificationResponse::Task(task)),
-                ModificationResponse::Empty => Ok(ModificationResponse::Empty),
-            }
+                .try_map_entity_async(|nav| async move {
+                    Self::new(&self.bmc, &nav, &self.config).await
+                })
+                .await
         }
     }
 }

--- a/redfish/src/computer_system/item.rs
+++ b/redfish/src/computer_system/item.rs
@@ -236,13 +236,20 @@ impl<B: Bmc> ComputerSystem<B> {
 
     /// Update the persistent boot order for this computer system.
     ///
+    /// Returns one of the following modification outcomes:
+    ///
+    /// - `ModificationResponse::Entity` contains the updated computer system.
+    /// - `ModificationResponse::Task` identifies an asynchronous operation.
+    /// - `ModificationResponse::Empty` reports synchronous success without a
+    ///   response body.
+    ///
     /// # Errors
     ///
     /// Returns an error if updating the system fails.
     pub async fn set_boot_order(
         &self,
         boot_order: Vec<BootOptionReference<String>>,
-    ) -> Result<Option<Self>, Error<B>> {
+    ) -> Result<ModificationResponse<Self>, Error<B>> {
         let update = ComputerSystemBootOrderUpdate {
             boot: BootPatch { boot_order },
         };
@@ -253,22 +260,20 @@ impl<B: Bmc> ComputerSystem<B> {
             .as_ref()
             .map_or_else(|| self.data.odata_id(), |settings| settings.odata_id());
 
-        match self
-            .bmc
+        self.bmc
             .as_ref()
             .update::<_, NavProperty<ComputerSystemSchema>>(update_odata, None, &update)
             .await
             .map_err(Error::Bmc)?
-        {
-            ModificationResponse::Entity(nav) => {
+            .try_map_entity_async(|nav| async move {
                 let data = nav.get(self.bmc.as_ref()).await.map_err(Error::Bmc)?;
-                Ok(Some(Self {
+
+                Ok(Self {
                     bmc: self.bmc.clone(),
                     data,
-                }))
-            }
-            ModificationResponse::Task(_) | ModificationResponse::Empty => Ok(None),
-        }
+                })
+            })
+            .await
     }
 
     /// Bios associated with this system.

--- a/redfish/src/control.rs
+++ b/redfish/src/control.rs
@@ -19,13 +19,23 @@
 //!
 //! ```ignore
 //! use nv_redfish::control::ControlUpdate;
+//! use nv_redfish_core::ModificationResponse;
 //!
 //! let Some(power_limit) = chassis.environment_power_limit_control().await? else {
 //!     return Ok(());
 //! };
 //!
 //! let update = ControlUpdate::builder().with_set_point(700.0).build();
-//! power_limit.update(&update).await?;
+//!
+//! match power_limit.update(&update).await? {
+//!     ModificationResponse::Entity(updated) => {
+//!         let _updated_control = updated.raw();
+//!     }
+//!     ModificationResponse::Task(task) => {
+//!         let _task = task;
+//!     }
+//!     ModificationResponse::Empty => {}
+//! }
 //! ```
 
 use std::sync::Arc;
@@ -182,19 +192,13 @@ impl<B: Bmc> Control<B> {
         &self,
         update: &ControlUpdate,
     ) -> Result<ModificationResponse<Self>, Error<B>> {
-        match self
-            .bmc
+        self.bmc
             .as_ref()
             .update::<_, NavProperty<ControlSchema>>(self.data.odata_id(), self.data.etag(), update)
             .await
             .map_err(Error::Bmc)?
-        {
-            ModificationResponse::Entity(nav) => Self::new(&self.bmc, &nav)
-                .await
-                .map(ModificationResponse::Entity),
-            ModificationResponse::Task(task) => Ok(ModificationResponse::Task(task)),
-            ModificationResponse::Empty => Ok(ModificationResponse::Empty),
-        }
+            .try_map_entity_async(|nav| async move { Self::new(&self.bmc, &nav).await })
+            .await
     }
 }
 

--- a/redfish/src/patch_support/collection.rs
+++ b/redfish/src/patch_support/collection.rs
@@ -131,20 +131,13 @@ impl Collection {
         C: Serialize + Sync + Send,
         F: Fn(JsonValue) -> JsonValue + Sync + Send,
     {
-        let result = Creator {
+        Creator {
             id: orig.odata_id(),
         }
         .create(bmc, create)
         .await
-        .map_err(Error::Bmc)?;
-
-        match result {
-            ModificationResponse::Entity(payload) => payload
-                .to_target::<V, B, _>(&f)
-                .map(ModificationResponse::Entity),
-            ModificationResponse::Task(task) => Ok(ModificationResponse::Task(task)),
-            ModificationResponse::Empty => Ok(ModificationResponse::Empty),
-        }
+        .map_err(Error::Bmc)?
+        .try_map_entity(|payload| payload.to_target::<V, B, _>(&f))
     }
 
     fn base(&self) -> ResourceCollection {

--- a/redfish/src/patch_support/payload.rs
+++ b/redfish/src/patch_support/payload.rs
@@ -204,16 +204,9 @@ impl Updator<'_> {
         U: Serialize + Send + Sync,
         F: Fn(JsonValue) -> JsonValue + Sync + Send,
     {
-        match bmc
-            .update::<U, Payload>(self.odata_id(), self.etag(), update)
+        bmc.update::<U, Payload>(self.odata_id(), self.etag(), update)
             .await
             .map_err(Error::Bmc)?
-        {
-            ModificationResponse::Entity(payload) => payload
-                .to_target::<T, B, _>(&patch_fn)
-                .map(ModificationResponse::Entity),
-            ModificationResponse::Task(task) => Ok(ModificationResponse::Task(task)),
-            ModificationResponse::Empty => Ok(ModificationResponse::Empty),
-        }
+            .try_map_entity(|payload| payload.to_target::<T, B, _>(&patch_fn))
     }
 }

--- a/redfish/src/session_service/item.rs
+++ b/redfish/src/session_service/item.rs
@@ -85,12 +85,19 @@ impl<B: Bmc> Session<B> {
 
     /// Delete the current session.
     ///
+    /// Returns one of the following modification outcomes:
+    ///
+    /// - `ModificationResponse::Entity` contains the session returned by the
+    ///   server.
+    /// - `ModificationResponse::Task` identifies an asynchronous operation.
+    /// - `ModificationResponse::Empty` reports synchronous success without a
+    ///   response body.
+    ///
     /// # Errors
     ///
     /// Returns an error if deletion fails.
-    pub async fn delete(&self) -> Result<Option<Self>, Error<B>> {
-        match self
-            .bmc
+    pub async fn delete(&self) -> Result<ModificationResponse<Self>, Error<B>> {
+        self.bmc
             .as_ref()
             .delete::<NavProperty<SessionSchema>>(
                 self.delete_location
@@ -99,10 +106,8 @@ impl<B: Bmc> Session<B> {
             )
             .await
             .map_err(Error::Bmc)?
-        {
-            ModificationResponse::Entity(nav) => Self::new(&self.bmc, &nav).await.map(Some),
-            ModificationResponse::Task(_) | ModificationResponse::Empty => Ok(None),
-        }
+            .try_map_entity_async(|nav| async move { Self::new(&self.bmc, &nav).await })
+            .await
     }
 }
 

--- a/redfish/src/telemetry_service/metric_definition.rs
+++ b/redfish/src/telemetry_service/metric_definition.rs
@@ -53,12 +53,21 @@ impl<B: Bmc> MetricDefinition<B> {
 
     /// Update this metric definition.
     ///
+    /// Returns one of the following modification outcomes:
+    ///
+    /// - `ModificationResponse::Entity` contains the updated metric definition.
+    /// - `ModificationResponse::Task` identifies an asynchronous operation.
+    /// - `ModificationResponse::Empty` reports synchronous success without a
+    ///   response body.
+    ///
     /// # Errors
     ///
     /// Returns an error if updating the entity fails.
-    pub async fn update(&self, update: &MetricDefinitionUpdate) -> Result<Option<Self>, Error<B>> {
-        match self
-            .bmc
+    pub async fn update(
+        &self,
+        update: &MetricDefinitionUpdate,
+    ) -> Result<ModificationResponse<Self>, Error<B>> {
+        self.bmc
             .as_ref()
             .update::<_, NavProperty<MetricDefinitionSchema>>(
                 self.data.odata_id(),
@@ -67,27 +76,30 @@ impl<B: Bmc> MetricDefinition<B> {
             )
             .await
             .map_err(Error::Bmc)?
-        {
-            ModificationResponse::Entity(nav) => Self::new(&self.bmc, &nav).await.map(Some),
-            ModificationResponse::Task(_) | ModificationResponse::Empty => Ok(None),
-        }
+            .try_map_entity_async(|nav| async move { Self::new(&self.bmc, &nav).await })
+            .await
     }
 
     /// Delete this metric definition.
     ///
+    /// Returns one of the following modification outcomes:
+    ///
+    /// - `ModificationResponse::Entity` contains the metric definition returned
+    ///   by the server.
+    /// - `ModificationResponse::Task` identifies an asynchronous operation.
+    /// - `ModificationResponse::Empty` reports synchronous success without a
+    ///   response body.
+    ///
     /// # Errors
     ///
     /// Returns an error if deleting the entity fails.
-    pub async fn delete(&self) -> Result<Option<Self>, Error<B>> {
-        match self
-            .bmc
+    pub async fn delete(&self) -> Result<ModificationResponse<Self>, Error<B>> {
+        self.bmc
             .as_ref()
             .delete::<NavProperty<MetricDefinitionSchema>>(self.data.odata_id())
             .await
             .map_err(Error::Bmc)?
-        {
-            ModificationResponse::Entity(nav) => Self::new(&self.bmc, &nav).await.map(Some),
-            ModificationResponse::Task(_) | ModificationResponse::Empty => Ok(None),
-        }
+            .try_map_entity_async(|nav| async move { Self::new(&self.bmc, &nav).await })
+            .await
     }
 }

--- a/redfish/src/telemetry_service/metric_report_definition.rs
+++ b/redfish/src/telemetry_service/metric_report_definition.rs
@@ -57,15 +57,22 @@ impl<B: Bmc> MetricReportDefinition<B> {
 
     /// Update this metric report definition.
     ///
+    /// Returns one of the following modification outcomes:
+    ///
+    /// - `ModificationResponse::Entity` contains the updated metric report
+    ///   definition.
+    /// - `ModificationResponse::Task` identifies an asynchronous operation.
+    /// - `ModificationResponse::Empty` reports synchronous success without a
+    ///   response body.
+    ///
     /// # Errors
     ///
     /// Returns an error if updating the entity fails.
     pub async fn update(
         &self,
         update: &MetricReportDefinitionUpdate,
-    ) -> Result<Option<Self>, Error<B>> {
-        match self
-            .bmc
+    ) -> Result<ModificationResponse<Self>, Error<B>> {
+        self.bmc
             .as_ref()
             .update::<_, NavProperty<MetricReportDefinitionSchema>>(
                 self.data.odata_id(),
@@ -74,27 +81,30 @@ impl<B: Bmc> MetricReportDefinition<B> {
             )
             .await
             .map_err(Error::Bmc)?
-        {
-            ModificationResponse::Entity(nav) => Self::new(&self.bmc, &nav).await.map(Some),
-            ModificationResponse::Task(_) | ModificationResponse::Empty => Ok(None),
-        }
+            .try_map_entity_async(|nav| async move { Self::new(&self.bmc, &nav).await })
+            .await
     }
 
     /// Delete this metric report definition.
     ///
+    /// Returns one of the following modification outcomes:
+    ///
+    /// - `ModificationResponse::Entity` contains the metric report definition
+    ///   returned by the server.
+    /// - `ModificationResponse::Task` identifies an asynchronous operation.
+    /// - `ModificationResponse::Empty` reports synchronous success without a
+    ///   response body.
+    ///
     /// # Errors
     ///
     /// Returns an error if deleting the entity fails.
-    pub async fn delete(&self) -> Result<Option<Self>, Error<B>> {
-        match self
-            .bmc
+    pub async fn delete(&self) -> Result<ModificationResponse<Self>, Error<B>> {
+        self.bmc
             .as_ref()
             .delete::<NavProperty<MetricReportDefinitionSchema>>(self.data.odata_id())
             .await
             .map_err(Error::Bmc)?
-        {
-            ModificationResponse::Entity(nav) => Self::new(&self.bmc, &nav).await.map(Some),
-            ModificationResponse::Task(_) | ModificationResponse::Empty => Ok(None),
-        }
+            .try_map_entity_async(|nav| async move { Self::new(&self.bmc, &nav).await })
+            .await
     }
 }

--- a/redfish/src/telemetry_service/mod.rs
+++ b/redfish/src/telemetry_service/mod.rs
@@ -94,16 +94,22 @@ impl<B: Bmc> TelemetryService<B> {
 
     /// Enable or disable telemetry service.
     ///
+    /// Returns one of the following modification outcomes:
+    ///
+    /// - `ModificationResponse::Entity` contains the updated telemetry service.
+    /// - `ModificationResponse::Task` identifies an asynchronous operation.
+    /// - `ModificationResponse::Empty` reports synchronous success without a
+    ///   response body.
+    ///
     /// # Errors
     ///
     /// Returns an error if updating telemetry service fails.
-    pub async fn set_enabled(&self, enabled: bool) -> Result<Option<Self>, Error<B>> {
+    pub async fn set_enabled(&self, enabled: bool) -> Result<ModificationResponse<Self>, Error<B>> {
         let update = TelemetryServiceUpdate::builder()
             .with_service_enabled(enabled)
             .build();
 
-        match self
-            .bmc
+        self.bmc
             .as_ref()
             .update::<_, NavProperty<TelemetryServiceSchema>>(
                 self.data.odata_id(),
@@ -112,16 +118,15 @@ impl<B: Bmc> TelemetryService<B> {
             )
             .await
             .map_err(Error::Bmc)?
-        {
-            ModificationResponse::Entity(nav) => {
+            .try_map_entity_async(|nav| async move {
                 let data = nav.get(self.bmc.as_ref()).await.map_err(Error::Bmc)?;
-                Ok(Some(Self {
+
+                Ok(Self {
                     data,
                     bmc: self.bmc.clone(),
-                }))
-            }
-            ModificationResponse::Task(_) | ModificationResponse::Empty => Ok(None),
-        }
+                })
+            })
+            .await
     }
 
     /// Get `Vec<MetricReportLink>` associated with this telemetry service.
@@ -208,6 +213,13 @@ impl<B: Bmc> TelemetryService<B> {
 
     /// Create a metric definition.
     ///
+    /// Returns one of the following modification outcomes:
+    ///
+    /// - `ModificationResponse::Entity` contains the created metric definition.
+    /// - `ModificationResponse::Task` identifies an asynchronous operation.
+    /// - `ModificationResponse::Empty` reports synchronous success without a
+    ///   response body.
+    ///
     /// # Errors
     ///
     /// Returns an error if:
@@ -216,28 +228,31 @@ impl<B: Bmc> TelemetryService<B> {
     pub async fn create_metric_definition(
         &self,
         create: &MetricDefinitionCreate,
-    ) -> Result<Option<MetricDefinition<B>>, Error<B>> {
+    ) -> Result<ModificationResponse<MetricDefinition<B>>, Error<B>> {
         let collection_ref = self
             .data
             .metric_definitions
             .as_ref()
             .ok_or(Error::MetricDefinitionsNotAvailable)?;
 
-        match self
-            .bmc
+        self.bmc
             .as_ref()
             .create::<_, NavProperty<MetricDefinitionSchema>>(collection_ref.id(), create)
             .await
             .map_err(Error::Bmc)?
-        {
-            ModificationResponse::Entity(nav) => {
-                MetricDefinition::new(&self.bmc, &nav).await.map(Some)
-            }
-            ModificationResponse::Task(_) | ModificationResponse::Empty => Ok(None),
-        }
+            .try_map_entity_async(|nav| async move { MetricDefinition::new(&self.bmc, &nav).await })
+            .await
     }
 
     /// Create a metric report definition.
+    ///
+    /// Returns one of the following modification outcomes:
+    ///
+    /// - `ModificationResponse::Entity` contains the created metric report
+    ///   definition.
+    /// - `ModificationResponse::Task` identifies an asynchronous operation.
+    /// - `ModificationResponse::Empty` reports synchronous success without a
+    ///   response body.
     ///
     /// # Errors
     ///
@@ -247,25 +262,22 @@ impl<B: Bmc> TelemetryService<B> {
     pub async fn create_metric_report_definition(
         &self,
         create: &MetricReportDefinitionCreate,
-    ) -> Result<Option<MetricReportDefinition<B>>, Error<B>> {
+    ) -> Result<ModificationResponse<MetricReportDefinition<B>>, Error<B>> {
         let collection_ref = self
             .data
             .metric_report_definitions
             .as_ref()
             .ok_or(Error::MetricReportDefinitionsNotAvailable)?;
 
-        match self
-            .bmc
+        self.bmc
             .as_ref()
             .create::<_, NavProperty<MetricReportDefinitionSchema>>(collection_ref.id(), create)
             .await
             .map_err(Error::Bmc)?
-        {
-            ModificationResponse::Entity(nav) => {
-                MetricReportDefinition::new(&self.bmc, &nav).await.map(Some)
-            }
-            ModificationResponse::Task(_) | ModificationResponse::Empty => Ok(None),
-        }
+            .try_map_entity_async(|nav| async move {
+                MetricReportDefinition::new(&self.bmc, &nav).await
+            })
+            .await
     }
 }
 

--- a/redfish/src/update_service/mod.rs
+++ b/redfish/src/update_service/mod.rs
@@ -279,8 +279,7 @@ impl<B: Bmc> UpdateService<B> {
         &self,
         update: &UpdateServiceUpdate,
     ) -> Result<ModificationResponse<Self>, Error<B>> {
-        let response = self
-            .bmc
+        self.bmc
             .as_ref()
             .update::<_, NavProperty<UpdateServiceSchema>>(
                 self.data.odata_id(),
@@ -288,21 +287,17 @@ impl<B: Bmc> UpdateService<B> {
                 update,
             )
             .await
-            .map_err(Error::Bmc)?;
-
-        match response {
-            ModificationResponse::Entity(nav) => {
+            .map_err(Error::Bmc)?
+            .try_map_entity_async(|nav| async move {
                 let data = nav.get(self.bmc.as_ref()).await.map_err(Error::Bmc)?;
 
-                Ok(ModificationResponse::Entity(Self {
+                Ok(Self {
                     bmc: self.bmc.clone(),
                     data,
                     fw_inventory_read_patch_fn: self.fw_inventory_read_patch_fn.clone(),
-                }))
-            }
-            ModificationResponse::Task(task) => Ok(ModificationResponse::Task(task)),
-            ModificationResponse::Empty => Ok(ModificationResponse::Empty),
-        }
+                })
+            })
+            .await
     }
 
     /// Upload a raw binary stream using this service's deprecated `HttpPushUri`.

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -42,6 +42,7 @@ nv-redfish = { workspace = true, features = [
     "sensors",
     "session-service",
     "task-service",
+    "telemetry-service",
     "update-service",
 ] }
 serde = { workspace = true, features = ["derive"] }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -32,15 +32,45 @@ pub const ODATA_ID: &str = "@odata.id";
 /// Used in tests for `@odata.type` fields.
 pub const ODATA_TYPE: &str = "@odata.type";
 
+use std::time::Duration;
+
 use error::TestError;
+
 use nv_redfish_bmc_mock::Bmc as MockBmc;
 use nv_redfish_bmc_mock::Expect as MockExpect;
+use nv_redfish_core::AsyncTask;
+use nv_redfish_core::ModificationResponse;
 use nv_redfish_core::ODataId;
+
 use serde_json::json;
 use serde_json::Value;
 
 pub type Bmc = MockBmc<TestError>;
 pub type Expect = MockExpect<TestError>;
+
+pub fn async_task(location: &str, retry_after_secs: u64) -> AsyncTask {
+    AsyncTask {
+        location: ODataId::from(location.to_string()).into(),
+        retry_after: Some(Duration::from_secs(retry_after_secs)),
+    }
+}
+
+pub fn assert_task<T>(response: ModificationResponse<T>, location: &str, retry_after_secs: u64) {
+    let ModificationResponse::Task(task) = response else {
+        panic!("expected an asynchronous task response");
+    };
+
+    assert_eq!(task.location.0.to_string(), location);
+
+    assert_eq!(
+        task.retry_after,
+        Some(Duration::from_secs(retry_after_secs))
+    );
+}
+
+pub fn assert_empty<T>(response: ModificationResponse<T>) {
+    assert!(matches!(response, ModificationResponse::Empty));
+}
 
 /// Build a ServiceRoot payload for AMI Viking (`Vendor=AMI`, `RedfishVersion=1.11.0`)
 /// merged with the provided `fields`.

--- a/tests/tests/test-chassis.rs
+++ b/tests/tests/test-chassis.rs
@@ -14,6 +14,9 @@
 // limitations under the License.
 //! Integration tests for Chassis collection workaround behavior.
 
+use std::error::Error as StdError;
+use std::sync::Arc;
+
 use nv_redfish::chassis::Chassis;
 use nv_redfish::chassis::PowerSupply;
 use nv_redfish::control::ControlUpdate;
@@ -32,10 +35,9 @@ use nv_redfish_tests::Bmc;
 use nv_redfish_tests::Expect;
 use nv_redfish_tests::ODATA_ID;
 use nv_redfish_tests::ODATA_TYPE;
+
 use serde_json::json;
 use serde_json::Value;
-use std::error::Error as StdError;
-use std::sync::Arc;
 use tokio::test;
 
 const CHASSIS_COLLECTION_DATA_TYPE: &str = "#ChassisCollection.ChassisCollection";
@@ -60,10 +62,18 @@ async fn reset_invokes_chassis_reset_action() -> Result<(), Box<dyn StdError>> {
     .await?;
 
     expect_redfish_reset_action(&bmc, &action_target, Some("ForceRestart"));
-    chassis.reset(Some(ResetType::ForceRestart)).await?;
+
+    assert!(matches!(
+        chassis.reset(Some(ResetType::ForceRestart)).await?,
+        ModificationResponse::Entity(())
+    ));
 
     expect_redfish_reset_action(&bmc, &action_target, None);
-    chassis.reset(None).await?;
+
+    assert!(matches!(
+        chassis.reset(None).await?,
+        ModificationResponse::Entity(())
+    ));
 
     Ok(())
 }
@@ -103,10 +113,18 @@ async fn reset_invokes_power_supply_reset_action() -> Result<(), Box<dyn StdErro
     .await?;
 
     expect_redfish_reset_action(&bmc, &action_target, Some("GracefulRestart"));
-    power_supply.reset(Some(ResetType::GracefulRestart)).await?;
+
+    assert!(matches!(
+        power_supply.reset(Some(ResetType::GracefulRestart)).await?,
+        ModificationResponse::Entity(())
+    ));
 
     expect_redfish_reset_action(&bmc, &action_target, None);
-    power_supply.reset(None).await?;
+
+    assert!(matches!(
+        power_supply.reset(None).await?,
+        ModificationResponse::Entity(())
+    ));
 
     Ok(())
 }

--- a/tests/tests/test-computer-system.rs
+++ b/tests/tests/test-computer-system.rs
@@ -14,14 +14,22 @@
 // limitations under the License.
 //! Integration tests for Computer System resources.
 
+use std::error::Error as StdError;
+use std::sync::Arc;
+
+use nv_redfish::computer_system::BootOptionReference;
 use nv_redfish::computer_system::ComputerSystem;
 use nv_redfish::computer_system::SystemCollection;
 use nv_redfish::resource::ResetType;
 use nv_redfish::Resource;
 use nv_redfish::ServiceRoot;
+use nv_redfish_core::ModificationResponse;
 use nv_redfish_core::ODataId;
 use nv_redfish_tests::ami_viking_service_root;
 use nv_redfish_tests::anonymous_1_9_service_root;
+use nv_redfish_tests::assert_empty;
+use nv_redfish_tests::assert_task;
+use nv_redfish_tests::async_task;
 use nv_redfish_tests::expect_redfish_reset_action;
 use nv_redfish_tests::json_merge;
 use nv_redfish_tests::redfish_action_payload;
@@ -30,10 +38,9 @@ use nv_redfish_tests::Bmc;
 use nv_redfish_tests::Expect;
 use nv_redfish_tests::ODATA_ID;
 use nv_redfish_tests::ODATA_TYPE;
+
 use serde_json::json;
 use serde_json::Value;
-use std::error::Error as StdError;
-use std::sync::Arc;
 use tokio::test;
 
 const SERVICE_ROOT_DATA_TYPE: &str = "#ServiceRoot.v1_13_0.ServiceRoot";
@@ -56,10 +63,60 @@ async fn reset_invokes_computer_system_reset_action() -> Result<(), Box<dyn StdE
     .await?;
 
     expect_redfish_reset_action(&bmc, &action_target, Some("GracefulRestart"));
-    system.reset(Some(ResetType::GracefulRestart)).await?;
+
+    assert!(matches!(
+        system.reset(Some(ResetType::GracefulRestart)).await?,
+        ModificationResponse::Entity(())
+    ));
 
     expect_redfish_reset_action(&bmc, &action_target, None);
-    system.reset(None).await?;
+
+    assert!(matches!(
+        system.reset(None).await?,
+        ModificationResponse::Entity(())
+    ));
+
+    Ok(())
+}
+
+#[test]
+async fn set_boot_order_preserves_task_and_empty_responses() -> Result<(), Box<dyn StdError>> {
+    let bmc = Arc::new(Bmc::default());
+    let ids = computer_system_ids();
+
+    let system = get_system(
+        bmc.clone(),
+        &ids,
+        computer_system(&ids, json!({ "Boot": { "BootOrder": ["Boot0001"] } })),
+    )
+    .await?;
+
+    let task_id = "/redfish/v1/TaskService/Tasks/52";
+
+    bmc.expect(Expect::update_task(
+        &ids.system_id,
+        json!({ "Boot": { "BootOrder": ["Boot0002"] } }),
+        async_task(task_id, 7),
+    ));
+
+    assert_task(
+        system
+            .set_boot_order(vec![BootOptionReference::new("Boot0002".into())])
+            .await?,
+        task_id,
+        7,
+    );
+
+    bmc.expect(Expect::update_empty(
+        &ids.system_id,
+        json!({ "Boot": { "BootOrder": ["Boot0003"] } }),
+    ));
+
+    assert_empty(
+        system
+            .set_boot_order(vec![BootOptionReference::new("Boot0003".into())])
+            .await?,
+    );
 
     Ok(())
 }
@@ -412,7 +469,8 @@ fn computer_system(ids: &ComputerSystemIds, fields: Value) -> Value {
         .as_object()
         .and_then(|obj| obj.get(ODATA_ID))
         .and_then(Value::as_str);
-    let system_id = override_id.unwrap_or_else(|| ids.system_id.as_str());
+
+    let system_id = override_id.unwrap_or(ids.system_id.as_str());
     let name = resource_name(system_id);
     let base = json!({
         ODATA_ID: system_id,

--- a/tests/tests/test-manager.rs
+++ b/tests/tests/test-manager.rs
@@ -14,11 +14,15 @@
 // limitations under the License.
 //! Integration tests for Manager collection behavior.
 
+use std::error::Error as StdError;
+use std::sync::Arc;
+
 use nv_redfish::manager::Manager;
 use nv_redfish::manager::ManagerResetToDefaultsType;
 use nv_redfish::resource::ResetType;
 use nv_redfish::Resource;
 use nv_redfish::ServiceRoot;
+use nv_redfish_core::ModificationResponse;
 use nv_redfish_core::ODataId;
 use nv_redfish_tests::ami_viking_service_root;
 use nv_redfish_tests::anonymous_1_9_service_root;
@@ -30,10 +34,9 @@ use nv_redfish_tests::Bmc;
 use nv_redfish_tests::Expect;
 use nv_redfish_tests::ODATA_ID;
 use nv_redfish_tests::ODATA_TYPE;
+
 use serde_json::json;
 use serde_json::Value;
-use std::error::Error as StdError;
-use std::sync::Arc;
 use tokio::test;
 
 const MANAGER_COLLECTION_DATA_TYPE: &str = "#ManagerCollection.ManagerCollection";
@@ -55,10 +58,18 @@ async fn reset_invokes_manager_reset_action() -> Result<(), Box<dyn StdError>> {
     .await?;
 
     expect_redfish_reset_action(&bmc, &action_target, Some("ForceRestart"));
-    manager.reset(Some(ResetType::ForceRestart)).await?;
+
+    assert!(matches!(
+        manager.reset(Some(ResetType::ForceRestart)).await?,
+        ModificationResponse::Entity(())
+    ));
 
     expect_redfish_reset_action(&bmc, &action_target, None);
-    manager.reset(None).await?;
+
+    assert!(matches!(
+        manager.reset(None).await?,
+        ModificationResponse::Entity(())
+    ));
 
     Ok(())
 }
@@ -80,9 +91,13 @@ async fn reset_to_defaults_invokes_manager_reset_to_defaults_action(
     .await?;
 
     expect_redfish_reset_action(&bmc, &action_target, Some("ResetAll"));
-    manager
-        .reset_to_defaults(ManagerResetToDefaultsType::ResetAll)
-        .await?;
+
+    assert!(matches!(
+        manager
+            .reset_to_defaults(ManagerResetToDefaultsType::ResetAll)
+            .await?,
+        ModificationResponse::Entity(())
+    ));
 
     Ok(())
 }

--- a/tests/tests/test-session-service.rs
+++ b/tests/tests/test-session-service.rs
@@ -15,6 +15,9 @@
 
 //! Integration tests of Session Service.
 
+use std::error::Error as StdError;
+use std::sync::Arc;
+
 use nv_redfish::session_service::SessionCollection;
 use nv_redfish::session_service::SessionCreate;
 use nv_redfish::session_service::SessionService;
@@ -22,13 +25,15 @@ use nv_redfish::session_service::SessionTypes;
 use nv_redfish::ServiceRoot;
 use nv_redfish_core::EntityTypeRef as _;
 use nv_redfish_core::ODataId;
+use nv_redfish_tests::assert_empty;
+use nv_redfish_tests::assert_task;
+use nv_redfish_tests::async_task;
 use nv_redfish_tests::Bmc;
 use nv_redfish_tests::Expect;
 use nv_redfish_tests::ODATA_ID;
 use nv_redfish_tests::ODATA_TYPE;
+
 use serde_json::json;
-use std::error::Error as StdError;
-use std::sync::Arc;
 use tokio::test;
 
 const ROOT_DATA_TYPE: &str = "#ServiceRoot.v1_13_0.ServiceRoot";
@@ -144,12 +149,13 @@ async fn delete_created_session_uses_location() -> Result<(), Box<dyn StdError>>
 
     let session = sessions.create_session(&create).await?;
     bmc.expect(Expect::delete(&location_session_id));
-    assert!(session.delete().await?.is_none());
+    assert_empty(session.delete().await?);
+
     Ok(())
 }
 
 #[test]
-async fn delete_session() -> Result<(), Box<dyn StdError>> {
+async fn delete_session_preserves_async_task() -> Result<(), Box<dyn StdError>> {
     let bmc = Arc::new(Bmc::default());
     let root_id = ODataId::service_root();
     let session_service = get_session_service(bmc.clone(), &root_id).await?;
@@ -172,8 +178,12 @@ async fn delete_session() -> Result<(), Box<dyn StdError>> {
     .await?;
 
     let session = sessions.members().await?.into_iter().next().unwrap();
-    bmc.expect(Expect::delete(&session_id));
-    assert!(session.delete().await?.is_none());
+    let task_id = "/redfish/v1/TaskService/Tasks/51";
+
+    bmc.expect(Expect::delete_task(&session_id, async_task(task_id, 6)));
+
+    assert_task(session.delete().await?, task_id, 6);
+
     Ok(())
 }
 

--- a/tests/tests/test-telemetry-service.rs
+++ b/tests/tests/test-telemetry-service.rs
@@ -1,0 +1,317 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Integration tests for Telemetry Service resources.
+
+use std::error::Error as StdError;
+use std::sync::Arc;
+
+use nv_redfish::telemetry_service::MetricDefinition;
+use nv_redfish::telemetry_service::MetricDefinitionCreate;
+use nv_redfish::telemetry_service::MetricDefinitionUpdate;
+use nv_redfish::telemetry_service::MetricReportDefinition;
+use nv_redfish::telemetry_service::MetricReportDefinitionCreate;
+use nv_redfish::telemetry_service::MetricReportDefinitionUpdate;
+use nv_redfish::telemetry_service::TelemetryService;
+use nv_redfish::ServiceRoot;
+use nv_redfish_core::ODataId;
+use nv_redfish_tests::assert_empty;
+use nv_redfish_tests::assert_task;
+use nv_redfish_tests::async_task;
+use nv_redfish_tests::Bmc;
+use nv_redfish_tests::Expect;
+use nv_redfish_tests::ODATA_ID;
+use nv_redfish_tests::ODATA_TYPE;
+
+use serde_json::json;
+use serde_json::Value;
+use tokio::test;
+
+const ROOT_DATA_TYPE: &str = "#ServiceRoot.v1_13_0.ServiceRoot";
+const TELEMETRY_SERVICE_DATA_TYPE: &str = "#TelemetryService.v1_4_1.TelemetryService";
+const METRIC_DEFINITION_COLLECTION_DATA_TYPE: &str =
+    "#MetricDefinitionCollection.MetricDefinitionCollection";
+
+const METRIC_DEFINITION_DATA_TYPE: &str = "#MetricDefinition.v1_3_5.MetricDefinition";
+const METRIC_REPORT_DEFINITION_COLLECTION_DATA_TYPE: &str =
+    "#MetricReportDefinitionCollection.MetricReportDefinitionCollection";
+
+const METRIC_REPORT_DEFINITION_DATA_TYPE: &str =
+    "#MetricReportDefinition.v1_4_7.MetricReportDefinition";
+
+struct TelemetryIds {
+    root: ODataId,
+    service: String,
+    metric_definitions: String,
+    metric_definition: String,
+    metric_report_definitions: String,
+    metric_report_definition: String,
+}
+
+fn telemetry_ids() -> TelemetryIds {
+    let root = ODataId::service_root();
+    let service = format!("{root}/TelemetryService");
+    let metric_definitions = format!("{service}/MetricDefinitions");
+    let metric_definition = format!("{metric_definitions}/Temperature");
+    let metric_report_definitions = format!("{service}/MetricReportDefinitions");
+    let metric_report_definition = format!("{metric_report_definitions}/ThermalReport");
+
+    TelemetryIds {
+        root,
+        service,
+        metric_definitions,
+        metric_definition,
+        metric_report_definitions,
+        metric_report_definition,
+    }
+}
+
+fn single_member_collection(
+    collection_id: &str,
+    collection_type: &str,
+    member_id: &str,
+    member_type: &str,
+    member_name: &str,
+) -> Value {
+    json!({
+        ODATA_ID: collection_id,
+        ODATA_TYPE: collection_type,
+        "Name": member_name,
+        "Members": [{
+            ODATA_ID: member_id,
+            ODATA_TYPE: member_type,
+            "Id": member_name,
+            "Name": member_name,
+        }]
+    })
+}
+
+fn service_root_payload(ids: &TelemetryIds) -> Value {
+    json!({
+        ODATA_ID: &ids.root,
+        ODATA_TYPE: ROOT_DATA_TYPE,
+        "Id": "RootService",
+        "Name": "Root Service",
+        "ProtocolFeaturesSupported": {
+            "ExpandQuery": {
+                "NoLinks": true
+            }
+        },
+        "TelemetryService": {
+            ODATA_ID: &ids.service
+        },
+        "Links": {
+            "Sessions": {
+                ODATA_ID: format!("{}/SessionService/Sessions", ids.root)
+            }
+        }
+    })
+}
+
+#[test]
+async fn set_enabled_preserves_task_and_empty_responses() -> Result<(), Box<dyn StdError>> {
+    let bmc = Arc::new(Bmc::default());
+    let ids = telemetry_ids();
+    let service = get_telemetry_service(bmc.clone(), &ids).await?;
+    let task_id = "/redfish/v1/TaskService/Tasks/61";
+
+    bmc.expect(Expect::update_task(
+        &ids.service,
+        json!({ "ServiceEnabled": false }),
+        async_task(task_id, 4),
+    ));
+
+    assert_task(service.set_enabled(false).await?, task_id, 4);
+
+    bmc.expect(Expect::update_empty(
+        &ids.service,
+        json!({ "ServiceEnabled": true }),
+    ));
+
+    assert_empty(service.set_enabled(true).await?);
+
+    Ok(())
+}
+
+#[test]
+async fn create_definitions_preserves_task_and_empty_responses() -> Result<(), Box<dyn StdError>> {
+    let bmc = Arc::new(Bmc::default());
+    let ids = telemetry_ids();
+    let service = get_telemetry_service(bmc.clone(), &ids).await?;
+    let metric_create = MetricDefinitionCreate::builder().build();
+    let metric_report_create = MetricReportDefinitionCreate::builder().build();
+    let metric_task_id = "/redfish/v1/TaskService/Tasks/62";
+
+    bmc.expect(Expect::create_task(
+        &ids.metric_definitions,
+        json!({}),
+        async_task(metric_task_id, 5),
+    ));
+
+    assert_task(
+        service.create_metric_definition(&metric_create).await?,
+        metric_task_id,
+        5,
+    );
+
+    bmc.expect(Expect::create_empty(
+        &ids.metric_report_definitions,
+        json!({}),
+    ));
+
+    assert_empty(
+        service
+            .create_metric_report_definition(&metric_report_create)
+            .await?,
+    );
+
+    Ok(())
+}
+
+#[test]
+async fn update_and_delete_definitions_preserve_task_and_empty_responses(
+) -> Result<(), Box<dyn StdError>> {
+    let bmc = Arc::new(Bmc::default());
+    let ids = telemetry_ids();
+    let service = get_telemetry_service(bmc.clone(), &ids).await?;
+    let metric_definition = get_metric_definition(&bmc, &service, &ids).await?;
+    let metric_report_definition = get_metric_report_definition(&bmc, &service, &ids).await?;
+    let metric_update = MetricDefinitionUpdate::builder().build();
+    let metric_report_update = MetricReportDefinitionUpdate::builder().build();
+    let metric_update_task_id = "/redfish/v1/TaskService/Tasks/64";
+
+    bmc.expect(Expect::update_task(
+        &ids.metric_definition,
+        json!({}),
+        async_task(metric_update_task_id, 7),
+    ));
+
+    assert_task(
+        metric_definition.update(&metric_update).await?,
+        metric_update_task_id,
+        7,
+    );
+
+    bmc.expect(Expect::delete(&ids.metric_definition));
+    assert_empty(metric_definition.delete().await?);
+
+    let metric_report_update_task_id = "/redfish/v1/TaskService/Tasks/66";
+
+    bmc.expect(Expect::update_task(
+        &ids.metric_report_definition,
+        json!({}),
+        async_task(metric_report_update_task_id, 9),
+    ));
+
+    assert_task(
+        metric_report_definition
+            .update(&metric_report_update)
+            .await?,
+        metric_report_update_task_id,
+        9,
+    );
+
+    bmc.expect(Expect::update_empty(
+        &ids.metric_report_definition,
+        json!({}),
+    ));
+
+    assert_empty(
+        metric_report_definition
+            .update(&metric_report_update)
+            .await?,
+    );
+
+    bmc.expect(Expect::delete(&ids.metric_report_definition));
+    assert_empty(metric_report_definition.delete().await?);
+
+    Ok(())
+}
+
+async fn get_telemetry_service(
+    bmc: Arc<Bmc>,
+    ids: &TelemetryIds,
+) -> Result<TelemetryService<Bmc>, Box<dyn StdError>> {
+    bmc.expect(Expect::get(&ids.root, service_root_payload(ids)));
+
+    let root = ServiceRoot::new(bmc.clone()).await?;
+
+    bmc.expect(Expect::get(
+        &ids.service,
+        json!({
+            ODATA_ID: &ids.service,
+            ODATA_TYPE: TELEMETRY_SERVICE_DATA_TYPE,
+            "Id": "TelemetryService",
+            "Name": "Telemetry Service",
+            "ServiceEnabled": true,
+            "MetricDefinitions": {
+                ODATA_ID: &ids.metric_definitions
+            },
+            "MetricReportDefinitions": {
+                ODATA_ID: &ids.metric_report_definitions
+            }
+        }),
+    ));
+
+    root.telemetry_service()
+        .await?
+        .ok_or_else(|| std::io::Error::other("missing telemetry service").into())
+}
+
+async fn get_metric_definition(
+    bmc: &Arc<Bmc>,
+    service: &TelemetryService<Bmc>,
+    ids: &TelemetryIds,
+) -> Result<MetricDefinition<Bmc>, Box<dyn StdError>> {
+    bmc.expect(Expect::expand(
+        &ids.metric_definitions,
+        single_member_collection(
+            &ids.metric_definitions,
+            METRIC_DEFINITION_COLLECTION_DATA_TYPE,
+            &ids.metric_definition,
+            METRIC_DEFINITION_DATA_TYPE,
+            "Temperature",
+        ),
+    ));
+
+    service
+        .metric_definitions()
+        .await?
+        .and_then(|mut definitions| definitions.pop())
+        .ok_or_else(|| std::io::Error::other("missing metric definition").into())
+}
+
+async fn get_metric_report_definition(
+    bmc: &Arc<Bmc>,
+    service: &TelemetryService<Bmc>,
+    ids: &TelemetryIds,
+) -> Result<MetricReportDefinition<Bmc>, Box<dyn StdError>> {
+    bmc.expect(Expect::expand(
+        &ids.metric_report_definitions,
+        single_member_collection(
+            &ids.metric_report_definitions,
+            METRIC_REPORT_DEFINITION_COLLECTION_DATA_TYPE,
+            &ids.metric_report_definition,
+            METRIC_REPORT_DEFINITION_DATA_TYPE,
+            "ThermalReport",
+        ),
+    ));
+
+    service
+        .metric_report_definitions()
+        .await?
+        .and_then(|mut definitions| definitions.pop())
+        .ok_or_else(|| std::io::Error::other("missing metric report definition").into())
+}

--- a/tests/tests/tests-base-operations.rs
+++ b/tests/tests/tests-base-operations.rs
@@ -325,9 +325,10 @@ async fn update_property_test() -> Result<(), Error> {
     bmc.expect(Expect::update(
         root_id.clone(),
         json!({ write_only_name: &value }),
-        &json_merge([&root_json, &json!({})]),
+        json_merge([&root_json, &json!({})]),
     ));
-    service_root
+
+    let response = service_root
         .update(
             &bmc,
             &ServiceRootUpdate {
@@ -340,6 +341,9 @@ async fn update_property_test() -> Result<(), Error> {
         )
         .await
         .map_err(Error::Bmc)?;
+
+    assert!(matches!(response, ModificationResponse::Entity(_)));
+
     Ok(())
 }
 
@@ -433,7 +437,7 @@ async fn update_rigid_array_property_test() -> Result<(), Error> {
 
     // Ensure field is omitted when not set in update struct.
     bmc.expect(Expect::update(root_id.clone(), json!({}), &root_json));
-    service_root
+    let response = service_root
         .update(
             &bmc,
             &ServiceRootUpdate {
@@ -446,6 +450,8 @@ async fn update_rigid_array_property_test() -> Result<(), Error> {
         )
         .await
         .map_err(Error::Bmc)?;
+
+    assert!(matches!(response, ModificationResponse::Entity(_)));
 
     // Refresh keeps null element in rigid array payload.
     bmc.expect(Expect::get(
@@ -611,15 +617,19 @@ async fn action_method_test() -> Result<(), Error> {
 
     bmc.expect(Expect::action(
         &action_target,
-        &json!({
+        json!({
             "ActionType": "Option1"
         }),
         &json!(null),
     ));
-    service_actions
-        .test_action(&bmc, Some(ActionType::Option1))
-        .await
-        .map_err(Error::Bmc)?;
+
+    assert!(matches!(
+        service_actions
+            .test_action(&bmc, Some(ActionType::Option1))
+            .await
+            .map_err(Error::Bmc)?,
+        ModificationResponse::Entity(())
+    ));
 
     Ok(())
 }


### PR DESCRIPTION
### Why

To make the rest of data modification requests consistent with what has been implemented in https://github.com/NVIDIA/nv-redfish/pull/127 for spec compliance and expanded compatibility.

### What

Return `ModificationResponse` from _remaining_ mutating helpers that previously collapsed `Task` and `Empty` into `None`. This keeps async task handles observable so callers can poll completion and surface task failures.

Add entity-specific mapping helpers to transform Entity values while preserving Task and Empty outcomes.

### BREAKING CHANGE

Session delete, computer-system boot-order updates, and telemetry create/update/delete helpers now return `ModificationResponse<T>` instead of `Option<T>`. `ModificationResponse::map` is renamed to `map_entity`.
