### PR TITLE
ci(speed): add `--no-deps` to disable dependency doc gen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ define build-and-test
 	cargo build -p nv-redfish --features managers,oem-dell-attributes
 	$(foreach f,$(std-standalone-features),$(call compile-one-feature,$f))
 	cargo build -p nv-redfish --features ""
-	cargo doc $1
+	cargo doc --no-deps $1
 	cargo build
 
 endef


### PR DESCRIPTION
Reduce CI time by running rustdoc with `--no-deps`. This skips HTML documentation generation for third-party dependencies while still validating `nv-redfish` workspace documentation.

## Why

`cargo doc` builds documentation for dependencies by default. That work is expensive and outside the scope of `nv-redfish`'s CI contract: third-party crates own their own docs, and dependency documentation failures do not affect `nv-redfish` publish-ability.

Example in other projects:

- tokio: <https://github.com/tokio-rs/tokio/blob/c637f6e73d06f36d933cc3edaf45111c06b79c18/.github/workflows/ci.yml#L875>
- axum: <https://github.com/tokio-rs/axum/blob/b90b8e02d0f761ce36a13610acd2afa60984a5e2/.github/workflows/CI.yml#L34>