### PR TITLE
Dispatcher Graceful Shutdown and Leaf/Bucket Schedulers

### DIFF
--- a/dispatcher/examples/composable_tree.rs
+++ b/dispatcher/examples/composable_tree.rs
@@ -44,9 +44,14 @@
 //! added through the branch's own API, reached by downcasting the root to
 //! its concrete type.
 //!
-//! NOTE: the dispatcher is currently a scaffold. `Runtime::new`, `next`, and
-//! `with_root_mut` panic with `unimplemented!`; the example illustrates the
-//! API shape and will run unchanged once the runtime body lands.
+//! The `RoundRobin` and `PollLeaf` here are hand-rolled to show how to
+//! write custom nodes; production trees can compose the built-ins from
+//! `nv_redfish_dispatcher::schedulers` instead.
+//!
+//! A background task calls `graceful_shutdown` after a few seconds; the
+//! driver drains, prints runtime stats, and exits. The driver honors
+//! `SleepUntil` with a plain sleep, so a shutdown issued mid-sleep is
+//! observed at the next `next()` call (see `RuntimeOutput::SleepUntil`).
 
 use core::marker::PhantomData;
 use core::time::Duration;
@@ -254,7 +259,15 @@ async fn main() {
         })
         .expect("downcast failed");
 
-    // 4. Drive the runtime. `next()` is the single ordered output stream.
+    // 4. Shut down from the outside after a few seconds. In-flight work
+    //    still drains; `next()` then emits a sticky `Shutdown`.
+    let shutdown_handle = handle.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(6)).await;
+        shutdown_handle.graceful_shutdown();
+    });
+
+    // 5. Drive the runtime. `next()` is the single ordered output stream.
     let start = Instant::now();
     loop {
         match runtime.next().await {
@@ -277,4 +290,11 @@ async fn main() {
             RuntimeOutput::Shutdown => break,
         }
     }
+
+    let stats = handle.stats();
+    println!(
+        "shut down after {:?}: {} items dispatched",
+        Instant::now().duration_since(start),
+        stats.dispatched
+    );
 }

--- a/dispatcher/src/lib.rs
+++ b/dispatcher/src/lib.rs
@@ -46,8 +46,9 @@
 //! - [`Runtime`] + [`RuntimeConfig`], [`RuntimeHandle`] (with
 //!   [`RuntimeHandle::with_root`] / [`with_root_mut`][`RuntimeHandle::with_root_mut`]),
 //!   [`RuntimeOutput`], the [`FutureWork`] payload alias,
-//! - the [`schedulers`] module with the seven built-in branch primitives
-//!   ([`RoundRobin`], [`BoundedConcurrency`], [`CircuitBreaker`]),
+//! - the [`schedulers`] module with the built-in policy primitives
+//!   ([`RoundRobin`], [`StrictPriority`], [`BoundedConcurrency`],
+//!   [`CircuitBreaker`], [`TokenBucket`], [`FixedCost`], [`PeriodicLeaf`]),
 //! - optional out-of-band [`RuntimeEventType`].
 //!
 //! The runtime does *not* enumerate the scheduler tree, and exposes no
@@ -78,9 +79,6 @@
 // Module-name repetition is intentional for this crate's public types
 // (RuntimeOutput, RuntimeEvent, RuntimeStats, etc.) which are re-exported.
 #![allow(clippy::module_name_repetitions)]
-// Scaffold-only relaxations on the runtime surface that still has stubs.
-#![allow(clippy::unimplemented)]
-#![allow(dead_code)]
 
 pub mod event;
 pub mod runtime;
@@ -137,5 +135,6 @@ pub use work::WorkMeta;
 
 #[doc(inline)]
 pub use schedulers::{
-    BoundedConcurrency, BreakerState, CircuitBreaker, CircuitBreakerConfig, RoundRobin,
+    BoundedConcurrency, BreakerState, CircuitBreaker, CircuitBreakerConfig, FixedCost,
+    PeriodicLeaf, RemovedChild, RoundRobin, StrictPriority, TokenBucket, TokenBucketConfig,
 };

--- a/dispatcher/src/runtime.rs
+++ b/dispatcher/src/runtime.rs
@@ -404,6 +404,7 @@ where
     ///
     /// Can panic if the runtime mutex is poisoned, which only happens if
     /// a closure passed to [`Self::with_root_mut`] panicked.
+    #[allow(clippy::unwrap_in_result)]
     pub fn with_root<S, R>(&self, f: impl FnOnce(&S) -> R) -> Option<R>
     where
         S: 'static,

--- a/dispatcher/src/runtime.rs
+++ b/dispatcher/src/runtime.rs
@@ -591,7 +591,7 @@ mod tests {
     #![allow(clippy::expect_used)]
 
     use core::time::Duration;
-    use std::num::NonZeroUsize;
+    use std::{num::NonZeroUsize, time::Instant};
 
     use futures_util::future::poll_immediate;
 
@@ -610,7 +610,7 @@ mod tests {
 
     fn firing_root() -> TestRoot {
         let mut root = TestRoot::new();
-        root.add_child(PeriodicLeaf::new(Duration::ZERO, || {
+        root.add_child(PeriodicLeaf::new(Instant::now(), Duration::ZERO, || {
             Box::pin(async { Ok(vec![7_u64]) }) as TestWork
         }));
         root
@@ -689,9 +689,11 @@ mod tests {
 
         let id = handle
             .with_root_mut::<TestRoot, _>(|root| {
-                root.add_child(PeriodicLeaf::new(Duration::from_secs(9999), || {
-                    Box::pin(async { Ok(vec![9_u64]) }) as TestWork
-                }))
+                root.add_child(PeriodicLeaf::new(
+                    Instant::now(),
+                    Duration::from_secs(9999),
+                    || Box::pin(async { Ok(vec![9_u64]) }) as TestWork,
+                ))
             })
             .expect("root downcasts");
         assert_eq!(handle.with_root::<TestRoot, _>(TestRoot::len), Some(2));

--- a/dispatcher/src/runtime.rs
+++ b/dispatcher/src/runtime.rs
@@ -32,6 +32,7 @@
 
 use crate::scheduler::private::SchedulerObj;
 use crate::scheduler::Scheduler;
+use crate::stats::OutputQueueStats;
 use crate::stats::RuntimeStats;
 use crate::work::WorkMeta;
 use crate::Completion;
@@ -42,6 +43,9 @@ use crate::ScheduledWork;
 use core::future::Future;
 use core::marker::PhantomData;
 use core::pin::Pin;
+use core::sync::atomic::AtomicU64;
+use core::sync::atomic::AtomicUsize;
+use core::sync::atomic::Ordering;
 use core::task::Context;
 use core::task::Poll;
 use core::time::Duration;
@@ -83,6 +87,7 @@ pub struct Runtime<Ev, Err, M: WorkMeta> {
     completion: Vec<Completion<M>>,
     output: VecDeque<RuntimeOutput<Ev, Err>>,
     shared: Arc<Mutex<Shared<Ev, Err, M>>>,
+    stats: Arc<StatsCells>,
     _phantom: RuntimePhantom<Ev, Err, M>,
 }
 
@@ -122,9 +127,11 @@ where
             shared: Mutex::new(Shared {
                 root: Box::new(root),
                 waker: None,
+                shutdown: false,
                 _phantom: PhantomData,
             })
             .into(),
+            stats: Arc::new(StatsCells::default()),
             _phantom: PhantomData,
         }
     }
@@ -134,7 +141,43 @@ where
     pub fn handle(&self) -> RuntimeHandle<Ev, Err, M> {
         RuntimeHandle {
             shared: self.shared.clone(),
+            stats: self.stats.clone(),
         }
+    }
+
+    /// Poll the in-flight set, converting finished payloads into pending
+    /// completions and `Work` outputs. Returns `true` if anything
+    /// finished.
+    fn drain_completed(
+        &mut self,
+        in_flight: &mut FuturesUnordered<InFlight<Ev, Err, M>>,
+        cx: &mut Context<'_>,
+        now: Instant,
+    ) -> bool {
+        let mut progress = false;
+        while let Poll::Ready(Some(completed)) = Pin::new(&mut *in_flight).poll_next(cx) {
+            let CompletedWork {
+                start,
+                meta,
+                result,
+                routing,
+            } = completed;
+            let latency = now.duration_since(start);
+            progress = true;
+            self.completion.push(Completion {
+                latency,
+                meta,
+                routing,
+                outcome: if result.is_ok() {
+                    CompletionOutcome::Succeeded
+                } else {
+                    CompletionOutcome::Failed
+                },
+            });
+            self.output
+                .push_back(RuntimeOutput::Work { result, latency });
+        }
+        progress
     }
 
     /// Advance until an output is available or no progress is possible.
@@ -187,6 +230,10 @@ where
                 }
             }
             if let Some(output) = self.runtime.output.pop_front() {
+                self.runtime
+                    .stats
+                    .output_queued
+                    .store(self.runtime.output.len(), Ordering::Relaxed);
                 return Poll::Ready(output);
             }
             progress = false;
@@ -194,15 +241,21 @@ where
             let now = self.runtime.clock.now();
             let mut in_flight = mem::take(&mut self.runtime.in_flight);
             let global_max_in_flight = self.runtime.config.global_max_in_flight;
+            let mut shutdown = false;
             if in_flight.len() < global_max_in_flight.into() {
                 let mut shared = self
                     .runtime
                     .shared
                     .lock()
                     .expect("dispatcher runtime mutex is poisoned");
-                while in_flight.len() < global_max_in_flight.into() {
+                shutdown = shared.shutdown;
+                while !shutdown && in_flight.len() < global_max_in_flight.into() {
                     match shared.next(now) {
                         SharedNextResult::Work(work) => {
+                            self.runtime
+                                .stats
+                                .dispatched
+                                .fetch_add(1, Ordering::Relaxed);
                             in_flight.push(InFlight {
                                 start: now,
                                 work: Some(work),
@@ -225,31 +278,30 @@ where
                     shared.maybe_setup_waker(cx);
                 }
             }
+            self.runtime
+                .stats
+                .in_flight
+                .store(in_flight.len() as u64, Ordering::Relaxed);
 
-            while let Poll::Ready(Some(completed)) = Pin::new(&mut in_flight).poll_next(cx) {
-                let CompletedWork {
-                    start,
-                    meta,
-                    result,
-                    routing,
-                } = completed;
-                let latency = now.duration_since(start);
-                progress = true;
-                self.runtime.completion.push(Completion {
-                    latency,
-                    meta,
-                    routing,
-                    outcome: if result.is_ok() {
-                        CompletionOutcome::Succeeded
-                    } else {
-                        CompletionOutcome::Failed
-                    },
-                });
-                self.runtime
-                    .output
-                    .push_back(RuntimeOutput::Work { result, latency });
-            }
+            progress |= self.runtime.drain_completed(&mut in_flight, cx, now);
+            self.runtime
+                .stats
+                .in_flight
+                .store(in_flight.len() as u64, Ordering::Relaxed);
+            self.runtime
+                .stats
+                .output_queued
+                .store(self.runtime.output.len(), Ordering::Relaxed);
             self.runtime.in_flight = in_flight;
+
+            // Shutdown is emitted only once everything has drained.
+            if shutdown
+                && self.runtime.in_flight.is_empty()
+                && self.runtime.output.is_empty()
+                && self.runtime.completion.is_empty()
+            {
+                return Poll::Ready(RuntimeOutput::Shutdown);
+            }
         }
         Poll::Pending
     }
@@ -284,12 +336,14 @@ pub enum ClockConfig {
 /// itself is not `Clone`.
 pub struct RuntimeHandle<Ev, Err, M: WorkMeta> {
     shared: Arc<Mutex<Shared<Ev, Err, M>>>,
+    stats: Arc<StatsCells>,
 }
 
 impl<Ev, Err, M: WorkMeta> Clone for RuntimeHandle<Ev, Err, M> {
     fn clone(&self) -> Self {
         Self {
             shared: self.shared.clone(),
+            stats: self.stats.clone(),
         }
     }
 }
@@ -303,26 +357,62 @@ where
     /// Begin graceful shutdown. Idempotent. In-flight items still complete,
     /// queued outputs still drain, then [`Runtime::next`] emits a sticky
     /// shutdown.
+    ///
+    /// Wakes a driver parked inside [`Runtime::next`]; a driver sleeping
+    /// on a [`RuntimeOutput::SleepUntil`] hint observes the shutdown at
+    /// its next `next()` call.
+    ///
+    /// # Panics
+    ///
+    /// Can panic if the runtime mutex is poisoned, which only happens if
+    /// a closure passed to [`Self::with_root_mut`] panicked.
     pub fn graceful_shutdown(&self) {
-        unimplemented!("scaffold")
+        let mut guard = self
+            .shared
+            .lock()
+            .expect("dispatcher runtime mutex is poisoned");
+        guard.shutdown = true;
+        let waker = guard.waker.take();
+        drop(guard);
+        if let Some(waker) = waker {
+            waker.wake();
+        }
     }
 
-    /// Snapshot of runtime statistics.
+    /// Snapshot of runtime statistics. Lock-free; values are relaxed
+    /// snapshots and may trail the driver by one step.
     #[must_use]
     pub fn stats(&self) -> RuntimeStats {
-        unimplemented!("scaffold")
+        RuntimeStats {
+            in_flight: self.stats.in_flight.load(Ordering::Relaxed),
+            dispatched: self.stats.dispatched.load(Ordering::Relaxed),
+            output_queue: OutputQueueStats {
+                queued: self.stats.output_queued.load(Ordering::Relaxed),
+                capacity: None,
+                dropped: 0,
+            },
+        }
     }
 
     /// Run `f` with shared access to the root downcast to `S`. `None` if
     /// the downcast fails.
     ///
     /// Holds the root lock for the duration of `f`; keep it short and do
-    /// not re-enter the runtime from inside.
-    pub fn with_root<S, R>(&self, _f: impl FnOnce(&S) -> R) -> Option<R>
+    /// not re-enter the runtime from inside (it will deadlock).
+    ///
+    /// # Panics
+    ///
+    /// Can panic if the runtime mutex is poisoned, which only happens if
+    /// a closure passed to [`Self::with_root_mut`] panicked.
+    pub fn with_root<S, R>(&self, f: impl FnOnce(&S) -> R) -> Option<R>
     where
         S: 'static,
     {
-        unimplemented!("scaffold")
+        let guard = self
+            .shared
+            .lock()
+            .expect("dispatcher runtime mutex is poisoned");
+        guard.root.as_any().downcast_ref::<S>().map(f)
     }
 
     /// Run `f` with exclusive access to the root downcast to `S`. `None`
@@ -369,10 +459,14 @@ pub enum RuntimeOutput<Ev, Err, R = RuntimeEventType> {
     },
     /// Out-of-band runtime event (only when `runtime-events` is enabled).
     Runtime(R),
-    /// Runtime requested to sleep specified duration. In tokio it is
-    /// expected that caller will call
-    /// tokio::time::sleep(v.duration_since(now)).await before calling
-    /// next() next time.
+    /// Runtime requested to sleep until the given instant before the
+    /// next `next()` call (e.g. `tokio::time::sleep`); calling earlier
+    /// is always safe.
+    ///
+    /// Control-plane changes ([`RuntimeHandle::graceful_shutdown`],
+    /// [`RuntimeHandle::with_root_mut`]) are only observed at the next
+    /// `next()` call. Drivers needing a prompt reaction should race the
+    /// sleep against their own wake signal (e.g. `tokio::select!`).
     SleepUntil(Instant),
     /// Sticky terminal output after graceful shutdown drains. Subsequent
     /// `next()` calls return this immediately.
@@ -396,9 +490,19 @@ impl RuntimeClock {
     }
 }
 
+/// Runtime-wide counters shared lock-free between the driver and
+/// [`RuntimeHandle::stats`].
+#[derive(Default)]
+struct StatsCells {
+    dispatched: AtomicU64,
+    in_flight: AtomicU64,
+    output_queued: AtomicUsize,
+}
+
 struct Shared<Ev, Err, M> {
     waker: Option<Waker>,
     root: Box<dyn SchedulerObj<FutureWork<Ev, Err>, M>>,
+    shutdown: bool,
     _phantom: PhantomData<(Ev, Err)>,
 }
 
@@ -479,4 +583,123 @@ struct CompletedWork<Ev, Err, M> {
     meta: M,
     result: Result<Vec<Ev>, Err>,
     routing: RoutingPath,
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used)]
+
+    use core::time::Duration;
+    use std::num::NonZeroUsize;
+
+    use futures_util::future::poll_immediate;
+
+    use super::{ClockConfig, FutureWork, Runtime, RuntimeConfig, RuntimeOutput};
+    use crate::schedulers::{PeriodicLeaf, RoundRobin};
+
+    type TestWork = FutureWork<u64, String>;
+    type TestRoot = RoundRobin<TestWork, ()>;
+
+    fn config() -> RuntimeConfig {
+        RuntimeConfig {
+            global_max_in_flight: NonZeroUsize::new(2).expect("non-zero"),
+            clock: ClockConfig::Wallclock,
+        }
+    }
+
+    fn firing_root() -> TestRoot {
+        let mut root = TestRoot::new();
+        root.add_child(PeriodicLeaf::new(Duration::ZERO, || {
+            Box::pin(async { Ok(vec![7_u64]) }) as TestWork
+        }));
+        root
+    }
+
+    #[tokio::test]
+    async fn graceful_shutdown_drains_then_is_sticky() {
+        let mut rt: Runtime<u64, String, ()> = Runtime::new(config(), firing_root());
+        let handle = rt.handle();
+
+        let mut works = 0_u64;
+        while works < 3 {
+            if let RuntimeOutput::Work { result, .. } = rt.next().await {
+                assert_eq!(result.expect("payload succeeds"), vec![7]);
+                works += 1;
+            }
+        }
+
+        handle.graceful_shutdown();
+        // Anything already in flight still drains as Work outputs, then
+        // the terminal Shutdown arrives.
+        loop {
+            match rt.next().await {
+                RuntimeOutput::Work { .. } => works += 1,
+                RuntimeOutput::Shutdown => break,
+                RuntimeOutput::SleepUntil(_) | RuntimeOutput::Runtime(_) => {}
+            }
+        }
+        // Sticky: every subsequent call returns Shutdown immediately.
+        assert!(matches!(rt.next().await, RuntimeOutput::Shutdown));
+        assert!(matches!(rt.next().await, RuntimeOutput::Shutdown));
+
+        let stats = handle.stats();
+        assert_eq!(stats.dispatched, works, "every dispatch was drained");
+        assert_eq!(stats.in_flight, 0);
+        assert_eq!(stats.output_queue.queued, 0);
+    }
+
+    #[tokio::test]
+    async fn graceful_shutdown_wakes_a_parked_driver() {
+        // An empty root reports not-ready with no hint: the driver parks.
+        let mut rt: Runtime<u64, String, ()> = Runtime::new(config(), TestRoot::new());
+        let handle = rt.handle();
+
+        let mut fut = rt.next();
+        assert!(
+            poll_immediate(&mut fut).await.is_none(),
+            "nothing to do: the driver must park"
+        );
+        handle.graceful_shutdown();
+        assert!(matches!(fut.await, RuntimeOutput::Shutdown));
+    }
+
+    #[tokio::test]
+    async fn stats_count_dispatches() {
+        let mut rt: Runtime<u64, String, ()> = Runtime::new(config(), firing_root());
+        let handle = rt.handle();
+        assert_eq!(handle.stats().dispatched, 0);
+
+        let mut works = 0_u64;
+        while works < 5 {
+            if let RuntimeOutput::Work { .. } = rt.next().await {
+                works += 1;
+            }
+        }
+        assert!(handle.stats().dispatched >= 5);
+    }
+
+    #[tokio::test]
+    async fn with_root_reads_and_with_root_mut_mutates() {
+        let rt: Runtime<u64, String, ()> = Runtime::new(config(), firing_root());
+        let handle = rt.handle();
+
+        assert_eq!(handle.with_root::<TestRoot, _>(TestRoot::len), Some(1));
+        assert_eq!(handle.with_root::<u32, _>(|_| ()), None, "wrong type");
+
+        let id = handle
+            .with_root_mut::<TestRoot, _>(|root| {
+                root.add_child(PeriodicLeaf::new(Duration::from_hours(1), || {
+                    Box::pin(async { Ok(vec![9_u64]) }) as TestWork
+                }))
+            })
+            .expect("root downcasts");
+        assert_eq!(handle.with_root::<TestRoot, _>(TestRoot::len), Some(2));
+
+        handle
+            .with_root_mut::<TestRoot, _>(|root| {
+                root.remove_child(id).expect("child exists");
+            })
+            .expect("root downcasts");
+        assert_eq!(handle.with_root::<TestRoot, _>(TestRoot::len), Some(1));
+    }
 }

--- a/dispatcher/src/runtime.rs
+++ b/dispatcher/src/runtime.rs
@@ -688,7 +688,7 @@ mod tests {
 
         let id = handle
             .with_root_mut::<TestRoot, _>(|root| {
-                root.add_child(PeriodicLeaf::new(Duration::from_hours(1), || {
+                root.add_child(PeriodicLeaf::new(Duration::from_secs(9999), || {
                     Box::pin(async { Ok(vec![9_u64]) }) as TestWork
                 }))
             })

--- a/dispatcher/src/schedulers/bounded_concurrency.rs
+++ b/dispatcher/src/schedulers/bounded_concurrency.rs
@@ -106,7 +106,7 @@ mod tests {
 
     #[test]
     fn under_cap_passes_work_through() {
-        let leaf = MockLeaf::ready_firing(0, 7);
+        let leaf = MockLeaf::ready_firing(7);
         let handle = leaf.handle();
         let mut bc: BoundedConcurrency<TestPayload, MockLeaf<()>> =
             BoundedConcurrency::new(cap(2), leaf);
@@ -130,8 +130,8 @@ mod tests {
     #[test]
     fn cap_blocks_further_dispatch_until_completion() {
         let mut rr: RoundRobin<TestPayload, ()> = RoundRobin::new();
-        for label in 0..3 {
-            rr.add_child(MockLeaf::ready_firing(label, u64::from(label)));
+        for id in 0..3 {
+            rr.add_child(MockLeaf::ready_firing(id));
         }
         let mut bc: BoundedConcurrency<TestPayload, RoundRobin<TestPayload, ()>> =
             BoundedConcurrency::new(cap(2), rr);
@@ -175,7 +175,7 @@ mod tests {
 
     #[test]
     fn passes_meta_and_routing_unmodified() {
-        let leaf = MockLeaf::ready_firing(0, 99);
+        let leaf = MockLeaf::ready_firing(99);
         let handle = leaf.handle();
         let mut bc: BoundedConcurrency<TestPayload, MockLeaf<()>> =
             BoundedConcurrency::new(cap(1), leaf);

--- a/dispatcher/src/schedulers/circuit_breaker.rs
+++ b/dispatcher/src/schedulers/circuit_breaker.rs
@@ -268,7 +268,7 @@ mod tests {
 
     #[test]
     fn closed_passes_through_until_failure_threshold() {
-        let leaf = MockLeaf::ready_firing(0, 1);
+        let leaf = MockLeaf::ready_firing(1);
         let mut cb = CircuitBreaker::new(cfg(Duration::from_millis(100)), leaf);
         let t0 = Instant::now();
 
@@ -289,7 +289,7 @@ mod tests {
 
     #[test]
     fn cool_down_promotes_to_half_open() {
-        let leaf = MockLeaf::ready_firing(0, 1);
+        let leaf = MockLeaf::ready_firing(1);
         let cool_down = Duration::from_millis(50);
         let mut cb = CircuitBreaker::new(cfg(cool_down), leaf);
         let t0 = Instant::now();
@@ -308,7 +308,7 @@ mod tests {
 
     #[test]
     fn half_open_success_closes_breaker() {
-        let leaf = MockLeaf::ready_firing(0, 1);
+        let leaf = MockLeaf::ready_firing(1);
         let cool_down = Duration::from_millis(50);
         let mut cb = CircuitBreaker::new(cfg(cool_down), leaf);
         let t0 = Instant::now();
@@ -323,7 +323,7 @@ mod tests {
 
     #[test]
     fn half_open_failure_re_opens_with_fresh_cool_down() {
-        let leaf = MockLeaf::ready_firing(0, 1);
+        let leaf = MockLeaf::ready_firing(1);
         let cool_down = Duration::from_millis(50);
         let mut cb = CircuitBreaker::new(cfg(cool_down), leaf);
         let t0 = Instant::now();
@@ -345,7 +345,7 @@ mod tests {
     fn half_open_caps_concurrent_probes() {
         // half_open_max_probes = 1: once a probe is in-flight, the
         // breaker reports not-ready until that probe completes.
-        let leaf = MockLeaf::ready_firing(0, 1);
+        let leaf = MockLeaf::ready_firing(1);
         let cool_down = Duration::from_millis(10);
         let mut cb = CircuitBreaker::new(cfg(cool_down), leaf);
         let t0 = Instant::now();

--- a/dispatcher/src/schedulers/fixed_cost.rs
+++ b/dispatcher/src/schedulers/fixed_cost.rs
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Cost-stamping decorator.
+//!
+//! Adapts a cost-naive child for cost-aware branches like
+//! [`crate::schedulers::TokenBucket`]: every item pulled from the child
+//! gets its meta wrapped in [`WithCost`] carrying this node's current
+//! cost, and readiness reports the same value as `next_cost`. The cost
+//! is mutable at runtime via [`FixedCost::set_cost`].
+
+use core::marker::PhantomData;
+use std::time::Instant;
+
+use crate::scheduler::{ScheduledWork, Scheduler};
+use crate::work::{Completion, CostUnits, Readiness, WithCost};
+
+/// Stamps a fixed [`CostUnits`] onto every item pulled from `inner`.
+pub struct FixedCost<T, C: Scheduler<T>> {
+    inner: C,
+    cost: CostUnits,
+    _t: PhantomData<fn() -> T>,
+}
+
+impl<T, C: Scheduler<T>> FixedCost<T, C> {
+    /// Wrap `child`, stamping `cost` on everything it produces.
+    #[must_use]
+    pub const fn new(cost: CostUnits, child: C) -> Self {
+        Self {
+            inner: child,
+            cost,
+            _t: PhantomData,
+        }
+    }
+
+    /// Cost currently stamped on produced items.
+    #[must_use]
+    pub const fn cost(&self) -> CostUnits {
+        self.cost
+    }
+
+    /// Update the stamped cost. Items already dispatched keep the cost
+    /// they were stamped with.
+    pub const fn set_cost(&mut self, cost: CostUnits) {
+        self.cost = cost;
+    }
+}
+
+impl<T, C> Scheduler<T> for FixedCost<T, C>
+where
+    T: Send + 'static,
+    C: Scheduler<T>,
+{
+    type Meta = WithCost<C::Meta>;
+
+    fn update_ready(&mut self, now: Instant) -> Readiness {
+        let r = self.inner.update_ready(now);
+        Readiness {
+            next_cost: r.ready.then_some(self.cost),
+            ..r
+        }
+    }
+
+    fn take_next(&mut self) -> Option<ScheduledWork<T, Self::Meta>> {
+        let work = self.inner.take_next()?;
+        Some(ScheduledWork {
+            meta: WithCost::new(work.meta, self.cost),
+            routing: work.routing,
+            payload: work.payload,
+        })
+    }
+
+    fn on_complete(&mut self, completion: Completion<Self::Meta>) {
+        self.inner.on_complete(Completion {
+            outcome: completion.outcome,
+            latency: completion.latency,
+            meta: completion.meta.inner,
+            routing: completion.routing,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used)]
+
+    use core::time::Duration;
+    use std::time::Instant;
+
+    use super::FixedCost;
+    use crate::scheduler::Scheduler as _;
+    use crate::schedulers::tests::MockLeaf;
+    use crate::work::{Completion, CompletionOutcome, CostUnits, HasCost as _};
+
+    #[test]
+    fn stamps_cost_on_items_and_readiness() {
+        let leaf = MockLeaf::ready_firing(7);
+        let handle = leaf.handle();
+        let mut fc = FixedCost::new(CostUnits::new(3), leaf);
+
+        let r = fc.update_ready(Instant::now());
+        assert!(r.ready);
+        assert_eq!(r.next_cost, Some(CostUnits::new(3)));
+
+        let work = fc.take_next().expect("leaf fires");
+        assert_eq!(work.meta.cost(), CostUnits::new(3));
+
+        // Completion unwraps back to the child's meta.
+        fc.on_complete(Completion {
+            outcome: CompletionOutcome::Succeeded,
+            latency: Duration::ZERO,
+            meta: work.meta,
+            routing: work.routing,
+        });
+        assert_eq!(handle.completion_count(), 1);
+    }
+
+    #[test]
+    fn set_cost_applies_to_subsequent_items() {
+        let leaf = MockLeaf::ready_firing(7);
+        let mut fc = FixedCost::new(CostUnits::new(1), leaf);
+        fc.set_cost(CostUnits::new(9));
+        let work = fc.take_next().expect("leaf fires");
+        assert_eq!(work.meta.cost(), CostUnits::new(9));
+    }
+
+    #[test]
+    fn not_ready_reports_no_cost() {
+        let leaf = MockLeaf::not_ready(None);
+        let mut fc = FixedCost::new(CostUnits::new(3), leaf);
+        let r = fc.update_ready(Instant::now());
+        assert!(!r.ready);
+        assert_eq!(r.next_cost, None);
+    }
+}

--- a/dispatcher/src/schedulers/mod.rs
+++ b/dispatcher/src/schedulers/mod.rs
@@ -37,6 +37,8 @@ pub use token_bucket::{TokenBucket, TokenBucketConfig};
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::unwrap_in_result)]
+
     use core::sync::atomic::{AtomicU32, Ordering};
     use core::time::Duration;
     use std::sync::{Arc, Mutex};

--- a/dispatcher/src/schedulers/mod.rs
+++ b/dispatcher/src/schedulers/mod.rs
@@ -21,17 +21,22 @@
 
 mod bounded_concurrency;
 mod circuit_breaker;
+mod fixed_cost;
+mod periodic_leaf;
 mod round_robin;
 mod strict_priority;
+mod token_bucket;
 
 pub use bounded_concurrency::BoundedConcurrency;
 pub use circuit_breaker::{BreakerState, CircuitBreaker, CircuitBreakerConfig};
-pub use round_robin::RoundRobin;
+pub use fixed_cost::FixedCost;
+pub use periodic_leaf::PeriodicLeaf;
+pub use round_robin::{RemovedChild, RoundRobin};
 pub use strict_priority::StrictPriority;
+pub use token_bucket::{TokenBucket, TokenBucketConfig};
 
 #[cfg(test)]
 mod tests {
-
     use core::sync::atomic::{AtomicU32, Ordering};
     use core::time::Duration;
     use std::sync::{Arc, Mutex};
@@ -85,34 +90,17 @@ mod tests {
                 .last()
                 .map(|c| c.outcome)
         }
-
-        pub fn set_ready(&self, readiness: Readiness) {
-            *self.readiness.lock().expect("MockLeaf state poisoned") = readiness;
-        }
-
-        pub fn set_fire(&self, payload: Option<TestPayload>) {
-            *self.fire.lock().expect("MockLeaf state poisoned") = payload;
-        }
-
-        pub fn clear_completions(&self) {
-            self.completions
-                .lock()
-                .expect("MockLeaf completions log poisoned")
-                .clear();
-        }
     }
 
     /// Scriptable leaf used to exercise branch policies in isolation.
     pub struct MockLeaf<M: WorkMeta + Clone> {
-        label: u32,
         meta: M,
         handle: MockLeafHandle<M>,
     }
 
     impl<M: WorkMeta + Clone> MockLeaf<M> {
-        pub fn new(label: u32, meta: M, readiness: Readiness, fire: Option<TestPayload>) -> Self {
+        pub fn new(meta: M, readiness: Readiness, fire: Option<TestPayload>) -> Self {
             Self {
-                label,
                 meta,
                 handle: MockLeafHandle {
                     readiness: Arc::new(Mutex::new(readiness)),
@@ -126,26 +114,22 @@ mod tests {
         pub fn handle(&self) -> MockLeafHandle<M> {
             self.handle.clone()
         }
-
-        pub const fn label(&self) -> u32 {
-            self.label
-        }
     }
 
     impl MockLeaf<()> {
         /// Always-ready leaf that produces `payload` on every call.
-        pub fn ready_firing(label: u32, payload: TestPayload) -> Self {
-            Self::new(label, (), Readiness::ready(None), Some(payload))
+        pub fn ready_firing(payload: TestPayload) -> Self {
+            Self::new((), Readiness::ready(None), Some(payload))
         }
 
         /// Always-ready leaf with no payload to fire.
-        pub fn ready_idle(label: u32) -> Self {
-            Self::new(label, (), Readiness::ready(None), None)
+        pub fn ready_idle() -> Self {
+            Self::new((), Readiness::ready(None), None)
         }
 
         /// Not-ready leaf with an optional `next_update_at` hint.
-        pub fn not_ready(label: u32, next_update_at: Option<Instant>) -> Self {
-            Self::new(label, (), Readiness::not_ready(next_update_at), None)
+        pub fn not_ready(next_update_at: Option<Instant>) -> Self {
+            Self::new((), Readiness::not_ready(next_update_at), None)
         }
     }
 

--- a/dispatcher/src/schedulers/periodic_leaf.rs
+++ b/dispatcher/src/schedulers/periodic_leaf.rs
@@ -1,0 +1,233 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Interval-driven work leaf.
+//!
+//! Fires one payload from a factory closure each time its interval
+//! elapses, replacing hand-rolled poll loops. The next tick is scheduled
+//! from *dispatch* time (fixed delay), so a leaf held back by upstream
+//! policy — a token bucket, a tripped circuit breaker — does not burst to
+//! catch up once released. While waiting, `update_ready` reports the due
+//! instant so the runtime can sleep precisely.
+//!
+//! Dispatching does not wait for the previous item to complete: a payload
+//! that runs longer than the interval overlaps the next one. Wrap the
+//! leaf in [`crate::schedulers::BoundedConcurrency`] with a cap of 1 to
+//! serialize iterations.
+
+use core::marker::PhantomData;
+use core::time::Duration;
+use std::time::Instant;
+
+use crate::scheduler::{ScheduledWork, Scheduler};
+use crate::work::{Completion, Readiness};
+
+/// When the next item becomes due.
+enum Due {
+    /// Due immediately (initial state: nothing dispatched yet).
+    Now,
+    /// Due at the given instant.
+    At(Instant),
+    /// Never due again
+    Never,
+}
+
+/// Leaf that produces `make()` every `interval`. Meta is `()`; compose
+/// with [`crate::schedulers::FixedCost`] to sit under cost-aware
+/// branches.
+pub struct PeriodicLeaf<T, F> {
+    interval: Duration,
+    next_due: Due,
+    last_now: Instant,
+    make: F,
+    _t: PhantomData<fn() -> T>,
+}
+
+impl<T, F> PeriodicLeaf<T, F>
+where
+    F: FnMut() -> T + Send + 'static,
+{
+    /// Leaf firing `make()` every `interval`, starting immediately.
+    ///
+    /// An `interval` too large for `Instant` arithmetic (e.g.
+    /// [`Duration::MAX`]) fires the first item and then never again.
+    #[must_use]
+    pub fn new(interval: Duration, make: F) -> Self {
+        Self {
+            interval,
+            next_due: Due::Now,
+            last_now: Instant::now(),
+            make,
+            _t: PhantomData,
+        }
+    }
+
+    /// Leaf whose first item is due at `first_due` instead of
+    /// immediately. Use to stagger a fleet of leaves sharing an interval.
+    #[must_use]
+    pub fn starting_at(first_due: Instant, interval: Duration, make: F) -> Self {
+        Self {
+            interval,
+            next_due: Due::At(first_due),
+            last_now: Instant::now(),
+            make,
+            _t: PhantomData,
+        }
+    }
+
+    /// Configured interval.
+    #[must_use]
+    pub const fn interval(&self) -> Duration {
+        self.interval
+    }
+
+    /// Change the interval. Takes effect when the next item is
+    /// dispatched; an already-scheduled due time is left as is.
+    pub const fn set_interval(&mut self, interval: Duration) {
+        self.interval = interval;
+    }
+
+    fn due(&self, now: Instant) -> bool {
+        match self.next_due {
+            Due::Now => true,
+            Due::At(d) => now >= d,
+            Due::Never => false,
+        }
+    }
+}
+
+impl<T, F> Scheduler<T> for PeriodicLeaf<T, F>
+where
+    T: Send + 'static,
+    F: FnMut() -> T + Send + 'static,
+{
+    type Meta = ();
+
+    fn update_ready(&mut self, now: Instant) -> Readiness {
+        self.last_now = now;
+        if self.due(now) {
+            Readiness::ready(None)
+        } else {
+            let hint = match self.next_due {
+                Due::At(d) => Some(d),
+                Due::Now | Due::Never => None,
+            };
+            Readiness::not_ready(hint)
+        }
+    }
+
+    fn take_next(&mut self) -> Option<ScheduledWork<T, ()>> {
+        if !self.due(self.last_now) {
+            return None;
+        }
+
+        self.next_due = self
+            .last_now
+            .checked_add(self.interval)
+            .map_or(Due::Never, Due::At);
+        Some(ScheduledWork::new((), (self.make)()))
+    }
+
+    fn on_complete(&mut self, _completion: Completion<()>) {}
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used)]
+
+    use core::time::Duration;
+    use std::time::Instant;
+
+    use super::PeriodicLeaf;
+    use crate::scheduler::Scheduler as _;
+
+    #[test]
+    fn fires_immediately_then_respects_interval() {
+        let interval = Duration::from_secs(5);
+        let mut leaf = PeriodicLeaf::new(interval, || 42_u64);
+        let t0 = Instant::now();
+
+        assert!(leaf.update_ready(t0).ready);
+        let work = leaf.take_next().expect("due immediately");
+        assert_eq!(work.payload, 42);
+
+        // Not due again until one interval after dispatch.
+        let r = leaf.update_ready(t0);
+        assert!(!r.ready);
+        assert_eq!(r.next_update_at, Some(t0 + interval));
+        assert!(leaf.take_next().is_none());
+
+        assert!(leaf.update_ready(t0 + interval).ready);
+        assert!(leaf.take_next().is_some());
+    }
+
+    #[test]
+    fn no_catch_up_burst_after_a_long_stall() {
+        let interval = Duration::from_secs(1);
+        let mut leaf = PeriodicLeaf::new(interval, || 1_u64);
+        let t0 = Instant::now();
+        leaf.update_ready(t0);
+        leaf.take_next().expect("first tick");
+
+        // 10 intervals pass unserved; exactly one item is due, and the
+        // next is a full interval after that dispatch.
+        let t1 = t0 + Duration::from_secs(10);
+        assert!(leaf.update_ready(t1).ready);
+        leaf.take_next().expect("one catch-up item only");
+        let r = leaf.update_ready(t1);
+        assert!(!r.ready);
+        assert_eq!(r.next_update_at, Some(t1 + interval));
+    }
+
+    #[test]
+    fn take_next_without_due_tick_yields_nothing() {
+        let mut leaf = PeriodicLeaf::new(Duration::from_secs(1), || 1_u64);
+        let t0 = Instant::now();
+        leaf.update_ready(t0);
+        assert!(leaf.take_next().is_some());
+        // A branch probing again in the same pass gets nothing.
+        assert!(leaf.take_next().is_none());
+    }
+
+    #[test]
+    fn overflowing_interval_fires_once_then_never_without_panicking() {
+        let mut leaf = PeriodicLeaf::new(Duration::MAX, || 1_u64);
+        let t0 = Instant::now();
+        assert!(leaf.update_ready(t0).ready);
+        assert!(leaf.take_next().is_some(), "first tick fires");
+
+        // Instant + Duration::MAX overflows: the leaf must go dormant
+        // (not-ready, no hint) instead of panicking in the runtime.
+        let r = leaf.update_ready(t0 + Duration::from_secs(1));
+        assert!(!r.ready);
+        assert!(r.next_update_at.is_none());
+        assert!(leaf.take_next().is_none());
+    }
+
+    #[test]
+    fn starting_at_delays_the_first_item() {
+        let interval = Duration::from_secs(1);
+        let t0 = Instant::now();
+        let first = t0 + Duration::from_millis(300);
+        let mut leaf = PeriodicLeaf::starting_at(first, interval, || 1_u64);
+
+        let r = leaf.update_ready(t0);
+        assert!(!r.ready);
+        assert_eq!(r.next_update_at, Some(first));
+
+        assert!(leaf.update_ready(first).ready);
+        assert!(leaf.take_next().is_some());
+    }
+}

--- a/dispatcher/src/schedulers/periodic_leaf.rs
+++ b/dispatcher/src/schedulers/periodic_leaf.rs
@@ -60,15 +60,17 @@ where
     F: FnMut() -> T + Send + 'static,
 {
     /// Leaf firing `make()` every `interval`, starting immediately.
+    /// `now` is the scheduling epoch — pass the driving clock's current
+    /// time.
     ///
     /// An `interval` too large for `Instant` arithmetic (e.g.
     /// [`Duration::MAX`]) fires the first item and then never again.
     #[must_use]
-    pub fn new(interval: Duration, make: F) -> Self {
+    pub fn new(now: Instant, interval: Duration, make: F) -> Self {
         Self {
             interval,
             next_due: Due::Now,
-            last_now: Instant::now(),
+            last_now: now,
             make,
             _t: PhantomData,
         }
@@ -77,11 +79,11 @@ where
     /// Leaf whose first item is due at `first_due` instead of
     /// immediately. Use to stagger a fleet of leaves sharing an interval.
     #[must_use]
-    pub fn starting_at(first_due: Instant, interval: Duration, make: F) -> Self {
+    pub fn starting_at(now: Instant, first_due: Instant, interval: Duration, make: F) -> Self {
         Self {
             interval,
             next_due: Due::At(first_due),
-            last_now: Instant::now(),
+            last_now: now,
             make,
             _t: PhantomData,
         }
@@ -156,8 +158,8 @@ mod tests {
     #[test]
     fn fires_immediately_then_respects_interval() {
         let interval = Duration::from_secs(5);
-        let mut leaf = PeriodicLeaf::new(interval, || 42_u64);
         let t0 = Instant::now();
+        let mut leaf = PeriodicLeaf::new(t0, interval, || 42_u64);
 
         assert!(leaf.update_ready(t0).ready);
         let work = leaf.take_next().expect("due immediately");
@@ -176,8 +178,8 @@ mod tests {
     #[test]
     fn no_catch_up_burst_after_a_long_stall() {
         let interval = Duration::from_secs(1);
-        let mut leaf = PeriodicLeaf::new(interval, || 1_u64);
         let t0 = Instant::now();
+        let mut leaf = PeriodicLeaf::new(t0, interval, || 1_u64);
         leaf.update_ready(t0);
         leaf.take_next().expect("first tick");
 
@@ -193,8 +195,8 @@ mod tests {
 
     #[test]
     fn take_next_without_due_tick_yields_nothing() {
-        let mut leaf = PeriodicLeaf::new(Duration::from_secs(1), || 1_u64);
         let t0 = Instant::now();
+        let mut leaf = PeriodicLeaf::new(t0, Duration::from_secs(1), || 1_u64);
         leaf.update_ready(t0);
         assert!(leaf.take_next().is_some());
         // A branch probing again in the same pass gets nothing.
@@ -203,8 +205,8 @@ mod tests {
 
     #[test]
     fn overflowing_interval_fires_once_then_never_without_panicking() {
-        let mut leaf = PeriodicLeaf::new(Duration::MAX, || 1_u64);
         let t0 = Instant::now();
+        let mut leaf = PeriodicLeaf::new(t0, Duration::MAX, || 1_u64);
         assert!(leaf.update_ready(t0).ready);
         assert!(leaf.take_next().is_some(), "first tick fires");
 
@@ -221,7 +223,7 @@ mod tests {
         let interval = Duration::from_secs(1);
         let t0 = Instant::now();
         let first = t0 + Duration::from_millis(300);
-        let mut leaf = PeriodicLeaf::starting_at(first, interval, || 1_u64);
+        let mut leaf = PeriodicLeaf::starting_at(t0, first, interval, || 1_u64);
 
         let r = leaf.update_ready(t0);
         assert!(!r.ready);

--- a/dispatcher/src/schedulers/round_robin.rs
+++ b/dispatcher/src/schedulers/round_robin.rs
@@ -13,26 +13,56 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Plain round-robin branch.
+//! Plain round-robin branch with dynamic membership.
 //!
-//! Children are stored in a `Vec` (stable indices used as the routing
-//! tag). Iteration order is a `VecDeque<u32>` of indices: `take_next`
-//! pops the front, asks that child, pushes the index back regardless of
-//! result, and stops on the first `Some`. New children appended mid-scan
-//! land at the back of the queue and are visited within one cycle.
+//! Children are stored in a map keyed by a `u32` id (the routing tag).
+//! Iteration order is a `VecDeque<u32>` of ids: `take_next` pops the
+//! front, asks that child, pushes the id back, and stops on the first
+//! `Some`. Children appended mid-scan are visited within one cycle.
+//!
+//! Children can be removed at any time. A child with nothing in flight
+//! is handed back ([`RemovedChild::Detached`]); one with items
+//! outstanding is quarantined out of rotation, keeps receiving its
+//! completions, and is dropped once drained ([`RemovedChild::Draining`]).
+//! Ids are recycled only after the drain, so id consumption is bounded
+//! by concurrent children and a late completion is never misrouted to a
+//! child that inherited the id.
 
-use core::convert::TryFrom as _;
 use core::marker::PhantomData;
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::time::Instant;
 
 use crate::scheduler::{ScheduledWork, Scheduler};
 use crate::work::{Completion, Readiness, WorkMeta};
 
+/// A live child plus the number of its items currently in flight.
+struct Slot<T, M: WorkMeta> {
+    sched: Box<dyn Scheduler<T, Meta = M>>,
+    in_flight: u32,
+}
+
+/// Outcome of [`RoundRobin::remove_child`].
+pub enum RemovedChild<T, M: WorkMeta> {
+    /// Nothing was in flight: the subtree is handed back fully drained
+    /// and safe to reuse.
+    Detached(Box<dyn Scheduler<T, Meta = M>>),
+    /// Items were still in flight: the subtree stays quarantined inside
+    /// the branch, receives its remaining completions, and is dropped
+    /// once drained.
+    Draining,
+}
+
 /// Round robing over boxed children
 pub struct RoundRobin<T, M: WorkMeta> {
-    children: Vec<Box<dyn Scheduler<T, Meta = M>>>,
+    children: HashMap<u32, Slot<T, M>>,
+    /// Removed children still owed completions: out of rotation, but
+    /// completions are forwarded until `in_flight` drains to zero, then
+    /// the subtree is dropped and the id moves to `free`.
+    draining: HashMap<u32, Slot<T, M>>,
+    /// Ids safe to hand out again.
+    free: Vec<u32>,
     queue: VecDeque<u32>,
+    next_id: u32,
     _t: PhantomData<fn() -> T>,
 }
 
@@ -45,40 +75,83 @@ impl<T, M: WorkMeta> Default for RoundRobin<T, M> {
 impl<T, M: WorkMeta> RoundRobin<T, M> {
     /// Empty round-robin branch.
     #[must_use]
-    pub const fn new() -> Self {
+    pub fn new() -> Self {
         Self {
-            children: Vec::new(),
+            children: HashMap::new(),
+            draining: HashMap::new(),
+            free: Vec::new(),
             queue: VecDeque::new(),
+            next_id: 0,
             _t: PhantomData,
         }
     }
 
-    /// Append `child` and return its stable index (the routing tag).
+    /// Append `child` and return its id (the routing tag). Ids of
+    /// removed children are recycled: a cached id is invalidated by
+    /// [`Self::remove_child`] and may later address a different child —
+    /// do not hold ids across a removal you don't control.
     ///
     /// # Panics
     ///
-    /// Panics if more than `u32::MAX` children are added (which the
-    /// [`RoutingPath`](crate::RoutingPath) tag width does not support).
+    /// Panics if more than `u32::MAX` children are held *concurrently*
+    /// (live plus removed-but-draining), which the
+    /// [`RoutingPath`](crate::RoutingPath) tag width does not support.
     pub fn add_child<S>(&mut self, child: S) -> u32
     where
         S: Scheduler<T, Meta = M>,
     {
-        let id = u32::try_from(self.children.len())
-            .expect("RoundRobin supports up to u32::MAX children");
-        self.children.push(Box::new(child));
+        let id = if let Some(id) = self.free.pop() {
+            id
+        } else {
+            let id = self.next_id;
+            self.next_id = self
+                .next_id
+                .checked_add(1)
+                .expect("RoundRobin supports up to u32::MAX concurrent children");
+            id
+        };
+        self.children.insert(
+            id,
+            Slot {
+                sched: Box::new(child),
+                in_flight: 0,
+            },
+        );
         self.queue.push_back(id);
         id
     }
 
+    /// Remove the child with the given id, or `None` if no such child
+    /// exists.
+    ///
+    /// With nothing in flight the subtree is returned
+    /// ([`RemovedChild::Detached`]); otherwise it stays quarantined —
+    /// out of rotation, still receiving its remaining completions — and
+    /// is dropped once drained ([`RemovedChild::Draining`]). The id is
+    /// reusable by [`Self::add_child`] only after the drain finishes.
+    pub fn remove_child(&mut self, id: u32) -> Option<RemovedChild<T, M>> {
+        let slot = self.children.remove(&id)?;
+        // Purge eagerly: a recycled id must not still sit in the queue
+        // when add_child pushes it again.
+        self.queue.retain(|&queued| queued != id);
+        if slot.in_flight > 0 {
+            self.draining.insert(id, slot);
+            Some(RemovedChild::Draining)
+        } else {
+            self.free.push(id);
+            Some(RemovedChild::Detached(slot.sched))
+        }
+    }
+
     /// Number of children currently held by this branch.
     #[must_use]
-    pub const fn len(&self) -> usize {
+    pub fn len(&self) -> usize {
         self.children.len()
     }
 
-    /// `true` when no children have been added yet.
+    /// `true` when the branch currently holds no children.
     #[must_use]
-    pub const fn is_empty(&self) -> bool {
+    pub fn is_empty(&self) -> bool {
         self.children.is_empty()
     }
 }
@@ -93,8 +166,8 @@ where
     fn update_ready(&mut self, now: Instant) -> Readiness {
         let mut ready = false;
         let mut next_at: Option<Instant> = None;
-        for child in &mut self.children {
-            let r = child.update_ready(now);
+        for slot in self.children.values_mut() {
+            let r = slot.sched.update_ready(now);
             ready |= r.ready;
             next_at = match (next_at, r.next_update_at) {
                 (Some(a), Some(b)) => Some(a.min(b)),
@@ -112,9 +185,13 @@ where
         let n = self.queue.len();
         for _ in 0..n {
             let id = self.queue.pop_front()?;
+            let Some(slot) = self.children.get_mut(&id) else {
+                // Defensive: remove_child purges the queue eagerly.
+                continue;
+            };
             self.queue.push_back(id);
-            let idx = usize::try_from(id).ok()?;
-            if let Some(mut work) = self.children[idx].take_next() {
+            if let Some(mut work) = slot.sched.take_next() {
+                slot.in_flight = slot.in_flight.saturating_add(1);
                 work.routing.push(id);
                 return Some(work);
             }
@@ -126,9 +203,18 @@ where
         let Some(id) = completion.routing.pop() else {
             return;
         };
-        let idx = usize::try_from(id).expect("u32 stable index fits in usize");
-        if let Some(child) = self.children.get_mut(idx) {
-            child.on_complete(completion);
+        if let Some(slot) = self.children.get_mut(&id) {
+            slot.in_flight = slot.in_flight.saturating_sub(1);
+            slot.sched.on_complete(completion);
+        } else if let Some(slot) = self.draining.get_mut(&id) {
+            // Forward to the quarantined child; recycle the id and drop
+            // the subtree once drained.
+            slot.in_flight = slot.in_flight.saturating_sub(1);
+            slot.sched.on_complete(completion);
+            if slot.in_flight == 0 {
+                self.draining.remove(&id);
+                self.free.push(id);
+            }
         }
     }
 }
@@ -140,10 +226,10 @@ mod tests {
     use core::time::Duration;
     use std::time::Instant;
 
-    use super::RoundRobin;
+    use super::{RemovedChild, RoundRobin};
     use crate::scheduler::Scheduler as _;
     use crate::schedulers::tests::{dispatch_and_complete, MockLeaf};
-    use crate::work::CompletionOutcome;
+    use crate::work::{Completion, CompletionOutcome};
 
     #[test]
     fn empty_branch_is_not_ready_and_yields_nothing() {
@@ -156,7 +242,7 @@ mod tests {
 
     #[test]
     fn single_child_round_trip() {
-        let leaf = MockLeaf::ready_firing(0, 11);
+        let leaf = MockLeaf::ready_firing(11);
         let handle = leaf.handle();
         let mut rr: RoundRobin<u64, ()> = RoundRobin::new();
         let id = rr.add_child(leaf);
@@ -175,9 +261,9 @@ mod tests {
 
     #[test]
     fn three_children_rotate_evenly() {
-        let l0 = MockLeaf::ready_firing(0, 100);
-        let l1 = MockLeaf::ready_firing(1, 200);
-        let l2 = MockLeaf::ready_firing(2, 300);
+        let l0 = MockLeaf::ready_firing(100);
+        let l1 = MockLeaf::ready_firing(200);
+        let l2 = MockLeaf::ready_firing(300);
         let h0 = l0.handle();
         let h1 = l1.handle();
         let h2 = l2.handle();
@@ -199,9 +285,9 @@ mod tests {
 
     #[test]
     fn skips_not_ready_children() {
-        let l0 = MockLeaf::ready_firing(0, 1);
-        let l1 = MockLeaf::ready_idle(1); // ready=true but no payload
-        let l2 = MockLeaf::ready_firing(2, 3);
+        let l0 = MockLeaf::ready_firing(1);
+        let l1 = MockLeaf::ready_idle();
+        let l2 = MockLeaf::ready_firing(3);
         let h0 = l0.handle();
         let h1 = l1.handle();
         let h2 = l2.handle();
@@ -223,8 +309,8 @@ mod tests {
 
     #[test]
     fn add_child_mid_scan_is_visited_within_one_cycle() {
-        let l0 = MockLeaf::ready_firing(0, 1);
-        let l1 = MockLeaf::ready_firing(1, 2);
+        let l0 = MockLeaf::ready_firing(1);
+        let l1 = MockLeaf::ready_firing(2);
         let h0 = l0.handle();
         let h1 = l1.handle();
 
@@ -236,7 +322,7 @@ mod tests {
         dispatch_and_complete(&mut rr, CompletionOutcome::Succeeded, Duration::ZERO).expect("ok");
 
         // Add a third child mid-stream.
-        let l2 = MockLeaf::ready_firing(2, 3);
+        let l2 = MockLeaf::ready_firing(3);
         let h2 = l2.handle();
         rr.add_child(l2);
 
@@ -252,9 +338,99 @@ mod tests {
     }
 
     #[test]
+    fn removed_child_is_no_longer_scheduled() {
+        let l0 = MockLeaf::ready_firing(1);
+        let l1 = MockLeaf::ready_firing(2);
+        let h0 = l0.handle();
+        let h1 = l1.handle();
+
+        let mut rr: RoundRobin<u64, ()> = RoundRobin::new();
+        let id0 = rr.add_child(l0);
+        rr.add_child(l1);
+        assert_eq!(rr.len(), 2);
+
+        assert!(rr.remove_child(id0).is_some());
+        assert!(rr.remove_child(id0).is_none(), "second removal is a miss");
+        assert_eq!(rr.len(), 1);
+
+        for _ in 0..4 {
+            dispatch_and_complete(&mut rr, CompletionOutcome::Succeeded, Duration::ZERO)
+                .expect("remaining leaf fires");
+        }
+        assert_eq!(h0.completion_count(), 0);
+        assert_eq!(h1.completion_count(), 4);
+    }
+
+    #[test]
+    fn in_flight_removal_quarantines_and_forwards_the_late_completion() {
+        let l0 = MockLeaf::ready_firing(1);
+        let h0 = l0.handle();
+        let mut rr: RoundRobin<u64, ()> = RoundRobin::new();
+        let id0 = rr.add_child(l0);
+
+        // Dispatch, then remove the child while the item is in flight:
+        // the subtree is quarantined, not handed back.
+        let work = rr.take_next().expect("leaf fires");
+        assert!(matches!(rr.remove_child(id0), Some(RemovedChild::Draining)));
+
+        // A replacement child must get a fresh id while the old id is
+        // owed a completion, so the completion cannot alias onto it.
+        let l1 = MockLeaf::ready_firing(2);
+        let h1 = l1.handle();
+        let id1 = rr.add_child(l1);
+        assert_ne!(id0, id1);
+
+        rr.on_complete(Completion {
+            outcome: CompletionOutcome::Succeeded,
+            latency: Duration::ZERO,
+            meta: work.meta,
+            routing: work.routing,
+        });
+        assert_eq!(h1.completion_count(), 0, "not misrouted to the new child");
+        assert_eq!(
+            h0.completion_count(),
+            1,
+            "forwarded into the quarantined subtree: exactly-once holds"
+        );
+
+        // Fully drained: the id is now recyclable.
+        let id2 = rr.add_child(MockLeaf::ready_firing(3));
+        assert_eq!(id2, id0);
+    }
+
+    #[test]
+    fn idle_removal_detaches_and_recycles_the_id_immediately() {
+        let mut rr: RoundRobin<u64, ()> = RoundRobin::new();
+        let id0 = rr.add_child(MockLeaf::ready_firing(1));
+        // Nothing in flight: the subtree is handed back for reuse and
+        // the id frees at once, so unbounded add/remove churn cannot
+        // exhaust the u32 tag space.
+        assert!(matches!(
+            rr.remove_child(id0),
+            Some(RemovedChild::Detached(_))
+        ));
+        let id1 = rr.add_child(MockLeaf::ready_firing(2));
+        assert_eq!(id1, id0);
+    }
+
+    #[test]
+    fn completion_for_a_live_child_decrements_its_in_flight_count() {
+        // Remove after the completion has already drained: the id must
+        // free immediately (the slot's count went back to zero).
+        let l0 = MockLeaf::ready_firing(1);
+        let mut rr: RoundRobin<u64, ()> = RoundRobin::new();
+        let id0 = rr.add_child(l0);
+        dispatch_and_complete(&mut rr, CompletionOutcome::Succeeded, Duration::ZERO)
+            .expect("leaf fires");
+        assert!(rr.remove_child(id0).is_some());
+        let id1 = rr.add_child(MockLeaf::ready_firing(2));
+        assert_eq!(id1, id0);
+    }
+
+    #[test]
     fn completion_routes_back_to_the_originating_child() {
-        let l0 = MockLeaf::ready_idle(0); // does not fire
-        let l1 = MockLeaf::ready_firing(1, 42); // fires
+        let l0 = MockLeaf::ready_idle(); // does not fire
+        let l1 = MockLeaf::ready_firing(42); // fires
         let h0 = l0.handle();
         let h1 = l1.handle();
 

--- a/dispatcher/src/schedulers/strict_priority.rs
+++ b/dispatcher/src/schedulers/strict_priority.rs
@@ -141,8 +141,8 @@ mod tests {
 
     #[test]
     fn high_priority_preempts_low() {
-        let high = MockLeaf::ready_firing(0, 100);
-        let low = MockLeaf::ready_firing(1, 200);
+        let high = MockLeaf::ready_firing(100);
+        let low = MockLeaf::ready_firing(200);
         let h_high = high.handle();
         let h_low = low.handle();
 
@@ -162,8 +162,8 @@ mod tests {
 
     #[test]
     fn lower_advances_when_higher_is_not_ready() {
-        let high = MockLeaf::ready_idle(0); // ready but no payload
-        let low = MockLeaf::ready_firing(1, 200);
+        let high = MockLeaf::ready_idle();
+        let low = MockLeaf::ready_firing(200);
         let h_high = high.handle();
         let h_low = low.handle();
 
@@ -183,8 +183,8 @@ mod tests {
     #[test]
     fn next_update_at_is_min_across_classes() {
         let now = Instant::now();
-        let early = MockLeaf::not_ready(0, Some(now + Duration::from_millis(100))); // low prio, early
-        let late = MockLeaf::not_ready(1, Some(now + Duration::from_millis(500))); // high prio, late
+        let early = MockLeaf::not_ready(Some(now + Duration::from_millis(100))); // low prio, early
+        let late = MockLeaf::not_ready(Some(now + Duration::from_millis(500))); // high prio, late
 
         let mut sp: StrictPriority<TestPayload, MockLeaf<()>> = StrictPriority::new();
         sp.add_child(early, 1);
@@ -198,9 +198,9 @@ mod tests {
 
     #[test]
     fn completion_routes_to_correct_class_and_child() {
-        let high0 = MockLeaf::ready_firing(0, 1);
-        let high1 = MockLeaf::ready_idle(1);
-        let low0 = MockLeaf::ready_idle(2);
+        let high0 = MockLeaf::ready_firing(1);
+        let high1 = MockLeaf::ready_idle();
+        let low0 = MockLeaf::ready_idle();
         let h_high0 = high0.handle();
         let h_high1 = high1.handle();
         let h_low0 = low0.handle();

--- a/dispatcher/src/schedulers/token_bucket.rs
+++ b/dispatcher/src/schedulers/token_bucket.rs
@@ -1,0 +1,510 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Token-bucket rate-limiting scheduler.
+//!
+//! Wraps a single child whose meta exposes [`HasCost`]. Tokens accrue
+//! continuously at `refill_amount` per `refill_interval` up to
+//! `capacity`. Admission requires the balance to cover the child's
+//! projected next cost ([`Readiness::next_cost`]); without a hint, one
+//! whole token; a cost above `capacity` is gated at a full bucket. On
+//! dispatch the item's *actual* meta cost is charged, which may drive
+//! the balance negative (debt) — the deficit is paid back before the
+//! next admission.
+//!
+//! While the balance is insufficient, `update_ready` reports the
+//! instant at which it will suffice. Accounting is exact integer math,
+//! scaled by `refill_interval` in nanoseconds.
+
+use core::convert::TryFrom as _;
+use core::marker::PhantomData;
+use core::time::Duration;
+use std::time::Instant;
+
+use crate::scheduler::{ScheduledWork, Scheduler};
+use crate::work::{Completion, CostUnits, HasCost as _, Readiness};
+
+/// Configuration for a [`TokenBucket`].
+#[derive(Debug, Clone, Copy)]
+pub struct TokenBucketConfig {
+    /// Maximum stored tokens (the burst size). The bucket starts full.
+    pub capacity: CostUnits,
+    /// Tokens added per `refill_interval`. Zero means the bucket never
+    /// refills: only the initial `capacity` is ever spent.
+    pub refill_amount: CostUnits,
+    /// Period over which `refill_amount` accrues. Accrual is continuous,
+    /// not stepped. A zero interval means an unlimited rate (the bucket
+    /// is always full).
+    pub refill_interval: Duration,
+}
+
+impl Default for TokenBucketConfig {
+    fn default() -> Self {
+        Self {
+            capacity: CostUnits::new(16),
+            refill_amount: CostUnits::new(1),
+            refill_interval: Duration::from_secs(1),
+        }
+    }
+}
+
+/// Token-bucket decorator wrapping a single cost-aware child scheduler.
+///
+/// Children whose meta does not implement [`crate::HasCost`] can be
+/// adapted with [`crate::schedulers::FixedCost`].
+pub struct TokenBucket<T, C: Scheduler<T>> {
+    inner: C,
+    cfg: TokenBucketConfig,
+    /// Balance scaled by `refill_interval` nanoseconds: one token equals
+    /// `refill_interval.as_nanos()` scaled units, so accrual per elapsed
+    /// nanosecond is exactly `refill_amount` scaled units.
+    scaled_balance: i128,
+    last_refill: Instant,
+    last_now: Instant,
+    /// Admission gate captured at `update_ready`, re-checked in
+    /// `take_next` because branches may pull without a fresh readiness
+    /// pass.
+    admission_cost: CostUnits,
+    _t: PhantomData<fn() -> T>,
+}
+
+impl<T, C> TokenBucket<T, C>
+where
+    C: Scheduler<T>,
+    C::Meta: crate::HasCost,
+{
+    /// Create a new [`TokenBucket`] with the given config and child
+    /// scheduler. The bucket starts at full `capacity`.
+    ///
+    /// The child's meta must expose [`crate::HasCost`] so the actual
+    /// cost of each dispatched item can be charged; adapt cost-naive
+    /// children with [`crate::schedulers::FixedCost`].
+    #[must_use]
+    pub fn new(cfg: TokenBucketConfig, child: C) -> Self {
+        let now = Instant::now();
+        Self {
+            inner: child,
+            scaled_balance: Self::scale(&cfg, cfg.capacity),
+            cfg,
+            last_refill: now,
+            last_now: now,
+            admission_cost: CostUnits::new(1),
+            _t: PhantomData,
+        }
+    }
+
+    /// Currently available whole tokens. Negative while the bucket is in
+    /// debt from an item whose actual cost exceeded the admission
+    /// estimate.
+    #[must_use]
+    pub fn available(&self) -> i64 {
+        let interval = i128::from(self.interval_nanos());
+        if interval == 0 {
+            return cost_to_i64(self.cfg.capacity);
+        }
+        tokens_to_i64(self.scaled_balance.div_euclid(interval))
+    }
+
+    /// Replace the bucket parameters, preserving the current balance
+    /// (clamped to the new capacity).
+    pub fn set_config(&mut self, cfg: TokenBucketConfig) {
+        // Convert the balance to the new interval scale before swapping.
+        let old_interval = i128::from(self.interval_nanos());
+        let tokens = if old_interval == 0 {
+            i128::from(cost_to_i64(self.cfg.capacity))
+        } else {
+            self.scaled_balance.div_euclid(old_interval)
+        };
+        self.cfg = cfg;
+        let new_interval = i128::from(self.interval_nanos());
+        let cap = Self::scale(&self.cfg, self.cfg.capacity);
+        self.scaled_balance = (tokens * new_interval).min(cap);
+    }
+
+    /// Current configuration.
+    #[must_use]
+    pub const fn config(&self) -> TokenBucketConfig {
+        self.cfg
+    }
+
+    fn interval_nanos(&self) -> u64 {
+        u64::try_from(self.cfg.refill_interval.as_nanos()).unwrap_or(u64::MAX)
+    }
+
+    fn scale(cfg: &TokenBucketConfig, cost: CostUnits) -> i128 {
+        let interval = u64::try_from(cfg.refill_interval.as_nanos()).unwrap_or(u64::MAX);
+        i128::from(cost.get()) * i128::from(interval)
+    }
+
+    fn refill(&mut self, now: Instant) {
+        let cap = Self::scale(&self.cfg, self.cfg.capacity);
+        if self.interval_nanos() == 0 {
+            // Unlimited rate: always full.
+            self.scaled_balance = cap;
+            self.last_refill = now;
+            return;
+        }
+        let elapsed = now.saturating_duration_since(self.last_refill);
+        self.last_refill = now;
+        let accrued = i128::try_from(elapsed.as_nanos()).unwrap_or(i128::MAX)
+            * i128::from(self.cfg.refill_amount.get());
+        self.scaled_balance = self.scaled_balance.saturating_add(accrued).min(cap);
+    }
+
+    fn covers(&self, cost: CostUnits) -> bool {
+        self.scaled_balance >= Self::scale(&self.cfg, cost)
+    }
+
+    fn spend(&mut self, cost: CostUnits) {
+        self.scaled_balance = self
+            .scaled_balance
+            .saturating_sub(Self::scale(&self.cfg, cost));
+    }
+
+    /// Instant at which the balance will cover `cost`, or `None` when it
+    /// never will (zero refill rate).
+    fn covered_at(&self, cost: CostUnits) -> Option<Instant> {
+        let deficit = Self::scale(&self.cfg, cost) - self.scaled_balance;
+        if deficit <= 0 {
+            return Some(self.last_refill);
+        }
+        let amount = i128::from(self.cfg.refill_amount.get());
+        if amount == 0 || self.interval_nanos() == 0 {
+            return None;
+        }
+
+        let nanos = (deficit + amount - 1) / amount;
+        let nanos = u64::try_from(nanos).unwrap_or(u64::MAX);
+        Some(self.last_refill + Duration::from_nanos(nanos))
+    }
+}
+
+impl<T, C> Scheduler<T> for TokenBucket<T, C>
+where
+    T: Send + 'static,
+    C: Scheduler<T>,
+    C::Meta: crate::HasCost,
+{
+    type Meta = C::Meta;
+
+    fn update_ready(&mut self, now: Instant) -> Readiness {
+        self.last_now = now;
+        self.refill(now);
+        let child = self.inner.update_ready(now);
+        if !child.ready {
+            return child;
+        }
+
+        let cost = child.next_cost.unwrap_or(CostUnits::new(1));
+        // A cost beyond capacity can never be covered (the balance
+        // clamps at capacity): gate it at "bucket full", overshoot
+        // becomes debt.
+        let gate = CostUnits::new(cost.get().min(self.cfg.capacity.get()));
+        self.admission_cost = gate;
+        if self.covers(gate) {
+            Readiness {
+                ready: true,
+                next_update_at: child.next_update_at,
+                next_cost: Some(cost),
+            }
+        } else {
+            Readiness::not_ready(self.covered_at(gate))
+        }
+    }
+
+    fn take_next(&mut self) -> Option<ScheduledWork<T, C::Meta>> {
+        self.refill(self.last_now);
+        if !self.covers(self.admission_cost) {
+            return None;
+        }
+        let work = self.inner.take_next()?;
+        self.spend(work.meta.cost());
+        Some(work)
+    }
+
+    fn on_complete(&mut self, completion: Completion<C::Meta>) {
+        self.inner.on_complete(completion);
+    }
+}
+
+fn cost_to_i64(cost: CostUnits) -> i64 {
+    i64::try_from(cost.get()).unwrap_or(i64::MAX)
+}
+
+/// Clamp an i128 token count to i64, preserving the sign.
+fn tokens_to_i64(tokens: i128) -> i64 {
+    i64::try_from(tokens).unwrap_or(if tokens < 0 { i64::MIN } else { i64::MAX })
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used)]
+
+    use core::time::Duration;
+    use std::time::Instant;
+
+    use super::{TokenBucket, TokenBucketConfig};
+    use crate::scheduler::Scheduler as _;
+    use crate::schedulers::tests::MockLeaf;
+    use crate::work::{Completion, CompletionOutcome, CostUnits, Readiness, WithCost};
+
+    fn costed_leaf(cost: u64) -> MockLeaf<WithCost<()>> {
+        MockLeaf::new(
+            WithCost::new((), CostUnits::new(cost)),
+            Readiness::ready(Some(CostUnits::new(cost))),
+            Some(1),
+        )
+    }
+
+    fn cfg(capacity: u64, amount: u64, interval: Duration) -> TokenBucketConfig {
+        TokenBucketConfig {
+            capacity: CostUnits::new(capacity),
+            refill_amount: CostUnits::new(amount),
+            refill_interval: interval,
+        }
+    }
+
+    fn drain<T, C>(tb: &mut TokenBucket<T, C>)
+    where
+        T: Send + 'static,
+        C: crate::Scheduler<T>,
+        C::Meta: crate::HasCost,
+    {
+        while let Some(work) = tb.take_next() {
+            tb.on_complete(Completion {
+                outcome: CompletionOutcome::Succeeded,
+                latency: Duration::ZERO,
+                meta: work.meta,
+                routing: work.routing,
+            });
+        }
+    }
+
+    #[test]
+    fn burst_up_to_capacity_then_blocks() {
+        let leaf = costed_leaf(1);
+        let handle = leaf.handle();
+        let mut tb = TokenBucket::new(cfg(3, 1, Duration::from_secs(1)), leaf);
+        let t0 = Instant::now();
+
+        assert!(tb.update_ready(t0).ready);
+        drain(&mut tb);
+        assert_eq!(handle.take_next_count(), 3);
+        assert_eq!(tb.available(), 0);
+
+        // Exhausted: not ready, with a refill hint one interval out.
+        let r = tb.update_ready(t0);
+        assert!(!r.ready);
+        let eta = r.next_update_at.expect("refill hint");
+        assert!(eta > t0);
+        assert!(eta <= t0 + Duration::from_secs(1));
+    }
+
+    #[test]
+    fn refills_continuously_over_time() {
+        let leaf = costed_leaf(1);
+        let mut tb = TokenBucket::new(cfg(4, 2, Duration::from_secs(1)), leaf);
+        let t0 = Instant::now();
+        tb.update_ready(t0);
+        drain(&mut tb);
+        assert_eq!(tb.available(), 0);
+
+        // 2 tokens/s: after 1.5s exactly 3 tokens have accrued.
+        let t1 = t0 + Duration::from_millis(1500);
+        assert!(tb.update_ready(t1).ready);
+        assert_eq!(tb.available(), 3);
+        drain(&mut tb);
+        assert_eq!(tb.available(), 0);
+    }
+
+    #[test]
+    fn balance_clamps_at_capacity() {
+        let leaf = costed_leaf(1);
+        let mut tb = TokenBucket::new(cfg(2, 10, Duration::from_secs(1)), leaf);
+        let t0 = Instant::now();
+        tb.update_ready(t0 + Duration::from_mins(1));
+        assert_eq!(tb.available(), 2);
+    }
+
+    #[test]
+    fn actual_cost_above_estimate_creates_debt() {
+        // Admission hint says 1, actual meta cost is 5.
+        let leaf = MockLeaf::new(
+            WithCost::new((), CostUnits::new(5)),
+            Readiness::ready(Some(CostUnits::new(1))),
+            Some(1),
+        );
+        let mut tb = TokenBucket::new(cfg(2, 1, Duration::from_secs(1)), leaf);
+        let t0 = Instant::now();
+        assert!(tb.update_ready(t0).ready);
+        let work = tb.take_next().expect("admitted on the estimate");
+        tb.on_complete(Completion {
+            outcome: CompletionOutcome::Succeeded,
+            latency: Duration::ZERO,
+            meta: work.meta,
+            routing: work.routing,
+        });
+        // 2 - 5 = -3: in debt, and the ETA covers deficit + next cost.
+        assert_eq!(tb.available(), -3);
+        let r = tb.update_ready(t0);
+        assert!(!r.ready);
+        // 3 deficit + 1 admission cost at 1 token/s, minus the sliver of
+        // accrual between construction and t0.
+        let eta = r.next_update_at.expect("refill hint");
+        let wait = eta.duration_since(t0);
+        assert!(wait > Duration::from_secs(3) && wait <= Duration::from_secs(4));
+    }
+
+    #[test]
+    fn no_hint_admits_on_one_token_and_charges_actual_cost() {
+        // Ready with no next_cost hint, but the meta carries cost 5.
+        let leaf = MockLeaf::new(
+            WithCost::new((), CostUnits::new(5)),
+            Readiness::ready(None),
+            Some(1),
+        );
+        let mut tb = TokenBucket::new(cfg(2, 1, Duration::from_secs(1)), leaf);
+        let t0 = Instant::now();
+
+        assert!(tb.update_ready(t0).ready, "one token suffices to admit");
+        let work = tb.take_next().expect("admitted without a hint");
+        tb.on_complete(Completion {
+            outcome: CompletionOutcome::Succeeded,
+            latency: Duration::ZERO,
+            meta: work.meta,
+            routing: work.routing,
+        });
+        // The actual meta cost was charged: 2 - 5 = -3.
+        assert_eq!(tb.available(), -3);
+        assert!(!tb.update_ready(t0).ready, "in debt: blocked");
+    }
+
+    #[test]
+    fn cost_beyond_capacity_admits_at_full_bucket_instead_of_stalling() {
+        // Hinted cost 5 with capacity 2: coverage is unreachable, so the
+        // gate clamps to "bucket full" and the item runs on debt.
+        let leaf = costed_leaf(5);
+        let mut tb = TokenBucket::new(cfg(2, 1, Duration::from_secs(1)), leaf);
+        let t0 = Instant::now();
+
+        assert!(tb.update_ready(t0).ready, "full bucket admits");
+        let work = tb.take_next().expect("dispatched at full burst");
+        tb.on_complete(Completion {
+            outcome: CompletionOutcome::Succeeded,
+            latency: Duration::ZERO,
+            meta: work.meta,
+            routing: work.routing,
+        });
+        assert_eq!(tb.available(), -3, "2 - 5: overshoot became debt");
+
+        // Blocked while paying the debt back, with a *reachable* ETA
+        // (debt 3 + gate 2 at 1 token/s), then admitted again — no
+        // forever-receding ETA livelock.
+        let r = tb.update_ready(t0);
+        assert!(!r.ready);
+        let eta = r.next_update_at.expect("finite refill hint");
+        assert!(eta <= t0 + Duration::from_secs(5));
+        assert!(tb.update_ready(t0 + Duration::from_secs(5)).ready);
+    }
+
+    #[test]
+    fn deep_debt_reports_negative_available() {
+        // A near-max actual cost must read as i64::MIN, not i64::MAX.
+        let leaf = MockLeaf::new(
+            WithCost::new((), CostUnits::new(u64::MAX)),
+            Readiness::ready(None),
+            Some(1),
+        );
+        let mut tb = TokenBucket::new(cfg(2, 1, Duration::from_secs(1)), leaf);
+        let t0 = Instant::now();
+        tb.update_ready(t0);
+        let work = tb.take_next().expect("admitted on the 1-token gate");
+        tb.on_complete(Completion {
+            outcome: CompletionOutcome::Succeeded,
+            latency: Duration::ZERO,
+            meta: work.meta,
+            routing: work.routing,
+        });
+        assert!(tb.available() < 0, "deep debt must not read as positive");
+    }
+
+    #[test]
+    fn take_next_gates_without_fresh_update_ready() {
+        let leaf = costed_leaf(1);
+        let handle = leaf.handle();
+        let mut tb = TokenBucket::new(cfg(1, 1, Duration::from_secs(1)), leaf);
+        let t0 = Instant::now();
+        tb.update_ready(t0);
+        assert!(tb.take_next().is_some());
+        // Second pull without update_ready must be refused, and must not
+        // reach the child.
+        let calls_before = handle.take_next_count();
+        assert!(tb.take_next().is_none());
+        assert_eq!(handle.take_next_count(), calls_before);
+    }
+
+    #[test]
+    fn zero_refill_rate_never_recovers() {
+        let leaf = costed_leaf(1);
+        let mut tb = TokenBucket::new(cfg(1, 0, Duration::from_secs(1)), leaf);
+        let t0 = Instant::now();
+        tb.update_ready(t0);
+        drain(&mut tb);
+        let r = tb.update_ready(t0 + Duration::from_hours(1));
+        assert!(!r.ready);
+        assert!(r.next_update_at.is_none(), "no ETA when rate is zero");
+    }
+
+    #[test]
+    fn zero_interval_is_unlimited() {
+        let leaf = costed_leaf(1);
+        let handle = leaf.handle();
+        let mut tb = TokenBucket::new(cfg(2, 1, Duration::ZERO), leaf);
+        let t0 = Instant::now();
+        for _ in 0..10 {
+            assert!(tb.update_ready(t0).ready);
+            let work = tb.take_next().expect("always admitted");
+            tb.on_complete(Completion {
+                outcome: CompletionOutcome::Succeeded,
+                latency: Duration::ZERO,
+                meta: work.meta,
+                routing: work.routing,
+            });
+        }
+        assert_eq!(handle.take_next_count(), 10);
+    }
+
+    #[test]
+    fn set_config_preserves_balance_and_clamps() {
+        let leaf = costed_leaf(1);
+        let mut tb = TokenBucket::new(cfg(10, 1, Duration::from_secs(1)), leaf);
+        let t0 = Instant::now();
+        tb.update_ready(t0);
+        assert_eq!(tb.available(), 10);
+        tb.set_config(cfg(4, 2, Duration::from_millis(500)));
+        assert_eq!(tb.available(), 4, "clamped to the new capacity");
+    }
+
+    #[test]
+    fn child_not_ready_passes_through() {
+        let leaf: MockLeaf<WithCost<()>> = MockLeaf::new(
+            WithCost::new((), CostUnits::ZERO),
+            Readiness::not_ready(None),
+            None,
+        );
+        let mut tb = TokenBucket::new(cfg(3, 1, Duration::from_secs(1)), leaf);
+        assert!(!tb.update_ready(Instant::now()).ready);
+    }
+}

--- a/dispatcher/src/schedulers/token_bucket.rs
+++ b/dispatcher/src/schedulers/token_bucket.rs
@@ -86,14 +86,15 @@ where
     C::Meta: crate::HasCost,
 {
     /// Create a new [`TokenBucket`] with the given config and child
-    /// scheduler. The bucket starts at full `capacity`.
+    /// scheduler. The bucket starts at full `capacity`; `now` is the
+    /// accounting epoch — pass the driving clock's current time (e.g.
+    /// [`crate::ManualClock::now`] under a manual-clock runtime).
     ///
     /// The child's meta must expose [`crate::HasCost`] so the actual
     /// cost of each dispatched item can be charged; adapt cost-naive
     /// children with [`crate::schedulers::FixedCost`].
     #[must_use]
-    pub fn new(cfg: TokenBucketConfig, child: C) -> Self {
-        let now = Instant::now();
+    pub fn new(now: Instant, cfg: TokenBucketConfig, child: C) -> Self {
         Self {
             inner: child,
             scaled_balance: Self::scale(&cfg, cfg.capacity),
@@ -130,7 +131,7 @@ where
         self.cfg = cfg;
         let new_interval = i128::from(self.interval_nanos());
         let cap = Self::scale(&self.cfg, self.cfg.capacity);
-        self.scaled_balance = (tokens * new_interval).min(cap);
+        self.scaled_balance = tokens.saturating_mul(new_interval).min(cap);
     }
 
     /// Current configuration.
@@ -145,7 +146,7 @@ where
 
     fn scale(cfg: &TokenBucketConfig, cost: CostUnits) -> i128 {
         let interval = u64::try_from(cfg.refill_interval.as_nanos()).unwrap_or(u64::MAX);
-        i128::from(cost.get()) * i128::from(interval)
+        i128::from(cost.get()).saturating_mul(i128::from(interval))
     }
 
     fn refill(&mut self, now: Instant) {
@@ -158,8 +159,9 @@ where
         }
         let elapsed = now.saturating_duration_since(self.last_refill);
         self.last_refill = now;
-        let accrued = i128::try_from(elapsed.as_nanos()).unwrap_or(i128::MAX)
-            * i128::from(self.cfg.refill_amount.get());
+        let accrued = i128::try_from(elapsed.as_nanos())
+            .unwrap_or(i128::MAX)
+            .saturating_mul(i128::from(self.cfg.refill_amount.get()));
         self.scaled_balance = self.scaled_balance.saturating_add(accrued).min(cap);
     }
 
@@ -174,9 +176,9 @@ where
     }
 
     /// Instant at which the balance will cover `cost`, or `None` when it
-    /// never will (zero refill rate).
+    /// never will (zero refill rate, or an ETA beyond `Instant` range).
     fn covered_at(&self, cost: CostUnits) -> Option<Instant> {
-        let deficit = Self::scale(&self.cfg, cost) - self.scaled_balance;
+        let deficit = Self::scale(&self.cfg, cost).saturating_sub(self.scaled_balance);
         if deficit <= 0 {
             return Some(self.last_refill);
         }
@@ -185,9 +187,10 @@ where
             return None;
         }
 
-        let nanos = (deficit + amount - 1) / amount;
+        // Ceiling division; both operands are positive here.
+        let nanos = deficit.saturating_add(amount - 1) / amount;
         let nanos = u64::try_from(nanos).unwrap_or(u64::MAX);
-        Some(self.last_refill + Duration::from_nanos(nanos))
+        self.last_refill.checked_add(Duration::from_nanos(nanos))
     }
 }
 
@@ -296,27 +299,27 @@ mod tests {
     fn burst_up_to_capacity_then_blocks() {
         let leaf = costed_leaf(1);
         let handle = leaf.handle();
-        let mut tb = TokenBucket::new(cfg(3, 1, Duration::from_secs(1)), leaf);
         let t0 = Instant::now();
+        let mut tb = TokenBucket::new(t0, cfg(3, 1, Duration::from_secs(1)), leaf);
 
         assert!(tb.update_ready(t0).ready);
         drain(&mut tb);
         assert_eq!(handle.take_next_count(), 3);
         assert_eq!(tb.available(), 0);
 
-        // Exhausted: not ready, with a refill hint one interval out.
+        // Exhausted: not ready, with a refill hint exactly one interval
+        // out (the accounting epoch is t0, so no sliver of drift).
         let r = tb.update_ready(t0);
         assert!(!r.ready);
         let eta = r.next_update_at.expect("refill hint");
-        assert!(eta > t0);
-        assert!(eta <= t0 + Duration::from_secs(1));
+        assert_eq!(eta, t0 + Duration::from_secs(1));
     }
 
     #[test]
     fn refills_continuously_over_time() {
         let leaf = costed_leaf(1);
-        let mut tb = TokenBucket::new(cfg(4, 2, Duration::from_secs(1)), leaf);
         let t0 = Instant::now();
+        let mut tb = TokenBucket::new(t0, cfg(4, 2, Duration::from_secs(1)), leaf);
         tb.update_ready(t0);
         drain(&mut tb);
         assert_eq!(tb.available(), 0);
@@ -332,8 +335,8 @@ mod tests {
     #[test]
     fn balance_clamps_at_capacity() {
         let leaf = costed_leaf(1);
-        let mut tb = TokenBucket::new(cfg(2, 10, Duration::from_secs(1)), leaf);
         let t0 = Instant::now();
+        let mut tb = TokenBucket::new(t0, cfg(2, 10, Duration::from_secs(1)), leaf);
         tb.update_ready(t0 + Duration::from_secs(100));
         assert_eq!(tb.available(), 2);
     }
@@ -346,8 +349,8 @@ mod tests {
             Readiness::ready(Some(CostUnits::new(1))),
             Some(1),
         );
-        let mut tb = TokenBucket::new(cfg(2, 1, Duration::from_secs(1)), leaf);
         let t0 = Instant::now();
+        let mut tb = TokenBucket::new(t0, cfg(2, 1, Duration::from_secs(1)), leaf);
         assert!(tb.update_ready(t0).ready);
         let work = tb.take_next().expect("admitted on the estimate");
         tb.on_complete(Completion {
@@ -356,15 +359,13 @@ mod tests {
             meta: work.meta,
             routing: work.routing,
         });
-        // 2 - 5 = -3: in debt, and the ETA covers deficit + next cost.
+        // 2 - 5 = -3: in debt, and the ETA covers deficit + next cost:
+        // exactly 3 + 1 at 1 token/s.
         assert_eq!(tb.available(), -3);
         let r = tb.update_ready(t0);
         assert!(!r.ready);
-        // 3 deficit + 1 admission cost at 1 token/s, minus the sliver of
-        // accrual between construction and t0.
         let eta = r.next_update_at.expect("refill hint");
-        let wait = eta.duration_since(t0);
-        assert!(wait > Duration::from_secs(3) && wait <= Duration::from_secs(4));
+        assert_eq!(eta, t0 + Duration::from_secs(4));
     }
 
     #[test]
@@ -375,8 +376,8 @@ mod tests {
             Readiness::ready(None),
             Some(1),
         );
-        let mut tb = TokenBucket::new(cfg(2, 1, Duration::from_secs(1)), leaf);
         let t0 = Instant::now();
+        let mut tb = TokenBucket::new(t0, cfg(2, 1, Duration::from_secs(1)), leaf);
 
         assert!(tb.update_ready(t0).ready, "one token suffices to admit");
         let work = tb.take_next().expect("admitted without a hint");
@@ -396,8 +397,8 @@ mod tests {
         // Hinted cost 5 with capacity 2: coverage is unreachable, so the
         // gate clamps to "bucket full" and the item runs on debt.
         let leaf = costed_leaf(5);
-        let mut tb = TokenBucket::new(cfg(2, 1, Duration::from_secs(1)), leaf);
         let t0 = Instant::now();
+        let mut tb = TokenBucket::new(t0, cfg(2, 1, Duration::from_secs(1)), leaf);
 
         assert!(tb.update_ready(t0).ready, "full bucket admits");
         let work = tb.take_next().expect("dispatched at full burst");
@@ -415,8 +416,8 @@ mod tests {
         let r = tb.update_ready(t0);
         assert!(!r.ready);
         let eta = r.next_update_at.expect("finite refill hint");
-        assert!(eta <= t0 + Duration::from_secs(5));
-        assert!(tb.update_ready(t0 + Duration::from_secs(5)).ready);
+        assert_eq!(eta, t0 + Duration::from_secs(5));
+        assert!(tb.update_ready(eta).ready);
     }
 
     #[test]
@@ -427,8 +428,8 @@ mod tests {
             Readiness::ready(None),
             Some(1),
         );
-        let mut tb = TokenBucket::new(cfg(2, 1, Duration::from_secs(1)), leaf);
         let t0 = Instant::now();
+        let mut tb = TokenBucket::new(t0, cfg(2, 1, Duration::from_secs(1)), leaf);
         tb.update_ready(t0);
         let work = tb.take_next().expect("admitted on the 1-token gate");
         tb.on_complete(Completion {
@@ -444,8 +445,8 @@ mod tests {
     fn take_next_gates_without_fresh_update_ready() {
         let leaf = costed_leaf(1);
         let handle = leaf.handle();
-        let mut tb = TokenBucket::new(cfg(1, 1, Duration::from_secs(1)), leaf);
         let t0 = Instant::now();
+        let mut tb = TokenBucket::new(t0, cfg(1, 1, Duration::from_secs(1)), leaf);
         tb.update_ready(t0);
         assert!(tb.take_next().is_some());
         // Second pull without update_ready must be refused, and must not
@@ -456,10 +457,25 @@ mod tests {
     }
 
     #[test]
+    fn huge_elapsed_and_refill_amount_saturate_instead_of_panicking() {
+        let leaf = costed_leaf(1);
+        let t0 = Instant::now();
+        let mut tb = TokenBucket::new(t0, cfg(3, u64::MAX, Duration::from_secs(1)), leaf);
+        tb.update_ready(t0);
+        drain(&mut tb);
+
+        // ~317k years of accrual at u64::MAX tokens/s: the i128 product
+        // saturates and the balance clamps at capacity.
+        let t1 = t0 + Duration::from_secs(10_000_000_000_000);
+        assert!(tb.update_ready(t1).ready);
+        assert_eq!(tb.available(), 3);
+    }
+
+    #[test]
     fn zero_refill_rate_never_recovers() {
         let leaf = costed_leaf(1);
-        let mut tb = TokenBucket::new(cfg(1, 0, Duration::from_secs(1)), leaf);
         let t0 = Instant::now();
+        let mut tb = TokenBucket::new(t0, cfg(1, 0, Duration::from_secs(1)), leaf);
         tb.update_ready(t0);
         drain(&mut tb);
         let r = tb.update_ready(t0 + Duration::from_secs(9999));
@@ -471,8 +487,8 @@ mod tests {
     fn zero_interval_is_unlimited() {
         let leaf = costed_leaf(1);
         let handle = leaf.handle();
-        let mut tb = TokenBucket::new(cfg(2, 1, Duration::ZERO), leaf);
         let t0 = Instant::now();
+        let mut tb = TokenBucket::new(t0, cfg(2, 1, Duration::ZERO), leaf);
         for _ in 0..10 {
             assert!(tb.update_ready(t0).ready);
             let work = tb.take_next().expect("always admitted");
@@ -489,8 +505,8 @@ mod tests {
     #[test]
     fn set_config_preserves_balance_and_clamps() {
         let leaf = costed_leaf(1);
-        let mut tb = TokenBucket::new(cfg(10, 1, Duration::from_secs(1)), leaf);
         let t0 = Instant::now();
+        let mut tb = TokenBucket::new(t0, cfg(10, 1, Duration::from_secs(1)), leaf);
         tb.update_ready(t0);
         assert_eq!(tb.available(), 10);
         tb.set_config(cfg(4, 2, Duration::from_millis(500)));
@@ -504,7 +520,8 @@ mod tests {
             Readiness::not_ready(None),
             None,
         );
-        let mut tb = TokenBucket::new(cfg(3, 1, Duration::from_secs(1)), leaf);
-        assert!(!tb.update_ready(Instant::now()).ready);
+        let now = Instant::now();
+        let mut tb = TokenBucket::new(now, cfg(3, 1, Duration::from_secs(1)), leaf);
+        assert!(!tb.update_ready(now).ready);
     }
 }

--- a/dispatcher/src/schedulers/token_bucket.rs
+++ b/dispatcher/src/schedulers/token_bucket.rs
@@ -334,7 +334,7 @@ mod tests {
         let leaf = costed_leaf(1);
         let mut tb = TokenBucket::new(cfg(2, 10, Duration::from_secs(1)), leaf);
         let t0 = Instant::now();
-        tb.update_ready(t0 + Duration::from_mins(1));
+        tb.update_ready(t0 + Duration::from_secs(100));
         assert_eq!(tb.available(), 2);
     }
 
@@ -462,7 +462,7 @@ mod tests {
         let t0 = Instant::now();
         tb.update_ready(t0);
         drain(&mut tb);
-        let r = tb.update_ready(t0 + Duration::from_hours(1));
+        let r = tb.update_ready(t0 + Duration::from_secs(9999));
         assert!(!r.ready);
         assert!(r.next_update_at.is_none(), "no ETA when rate is zero");
     }


### PR DESCRIPTION
Added graceful shutdown hanlding to dispatcher, as well as two new schdulers:

- FixedLeaf
- TokenBucket

Added ability to remove nodes from RoundRobin scheduler.