### PR TITLE
CAR Cache correctness and performance improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,17 +61,25 @@ jobs:
           fi
           echo "baseline commit: $BASE"
           git checkout --recurse-submodules "$BASE"
-          HAS_BENCH=$(cargo metadata --format-version=1 --no-deps \
-            | jq '[.packages[] | select(.name == "nv-redfish-dispatcher")
-                   | .targets[] | select(.kind == ["bench"] and .name == "scheduler")] | length')
-          if [ "$HAS_BENCH" = "0" ]; then
-            echo "no scheduler bench at merge-base; head run records the initial baseline"
+          VERSION=$(cargo metadata --format-version=1 \
+            | jq -r '[.packages[] | select(.name == "gungraun") | .version] | first // empty')
+          if [ -z "$VERSION" ]; then
+            echo "no gungraun at merge-base; head run records the initial baselines"
           else
-            VERSION=$(cargo metadata --format-version=1 \
-              | jq -r '[.packages[] | select(.name == "gungraun") | .version] | first')
             echo "base gungraun $VERSION"
             cargo install gungraun-runner --version "$VERSION" --locked
-            cargo bench -p nv-redfish-dispatcher --bench scheduler -- --save-baseline=base
+            for entry in "nv-redfish-dispatcher scheduler" "nv-redfish-bmc-http cache"; do
+              set -- $entry
+              HAS_BENCH=$(cargo metadata --format-version=1 --no-deps \
+                | jq --arg p "$1" --arg b "$2" \
+                  '[.packages[] | select(.name == $p)
+                    | .targets[] | select(.kind == ["bench"] and .name == $b)] | length')
+              if [ "$HAS_BENCH" = "0" ]; then
+                echo "no $2 bench in $1 at merge-base; head run records its baseline"
+              else
+                cargo bench -p "$1" --bench "$2" -- --save-baseline=base
+              fi
+            done
           fi
           git checkout --recurse-submodules -f -
 
@@ -85,6 +93,9 @@ jobs:
             | jq -r '[.packages[] | select(.name == "gungraun") | .version] | first')
           echo "head gungraun $VERSION"
           cargo install gungraun-runner --version "$VERSION" --locked
-          cargo bench -p nv-redfish-dispatcher --bench scheduler -- \
-            --baseline=base \
-            --callgrind-limits='ir=2%'
+          for entry in "nv-redfish-dispatcher scheduler" "nv-redfish-bmc-http cache"; do
+            set -- $entry
+            cargo bench -p "$1" --bench "$2" -- \
+              --baseline=base \
+              --callgrind-limits='ir=2%'
+          done

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ define build-and-test
 	cargo build -p update-multipart --features update-service-deprecated
 	cargo clippy $1
 	cargo clippy -p nv-redfish-dispatcher --all-targets
+	cargo clippy -p nv-redfish-bmc-http --bench cache
 	cargo build  $1
 	cargo build -p nv-redfish --features computer-systems,bios,boot-options,storages,memory,processors
 	cargo build -p nv-redfish --features oem-hpe,accounts

--- a/bmc-http/Cargo.toml
+++ b/bmc-http/Cargo.toml
@@ -47,3 +47,12 @@ nv-redfish-schema = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt"] }
 tokio-test = { workspace = true }
 wiremock = { workspace = true }
+
+# Compiles only on unix: the runner library it pulls in uses
+# std::os::unix and nix unconditionally.
+[target.'cfg(unix)'.dev-dependencies]
+gungraun = { workspace = true }
+
+[[bench]]
+name = "cache"
+harness = false

--- a/bmc-http/benches/cache.rs
+++ b/bmc-http/benches/cache.rs
@@ -1,0 +1,148 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Instruction-count benchmarks for the CAR cache (gungraun / Valgrind
+//! Callgrind).
+//!
+//! Keys are `Url`s like production (`HttpBmc` keys its response cache by
+//! request URL), so key hashing costs are realistic; values are plain
+//! `u64` to isolate the algorithm from the `Box<dyn Any>` type erasure.
+//! Caches are built in setup (excluded from measurement) and returned
+//! from the benchmark so their drop stays outside it. Valgrind is
+//! unix-only, so the whole benchmark is `cfg(unix)`.
+//!
+//! Slot storage allocates lazily on first use, so benchmarks that
+//! perform a cache's first eviction (insert_with_headroom,
+//! evict_first_probe, evict_full_clock_sweep) include that one-time
+//! allocation; steady-state evictions cost less by that share.
+
+#[cfg(unix)]
+mod unix {
+    use std::hint::black_box;
+
+    use gungraun::library_benchmark;
+    use nv_redfish_bmc_http::cache::CarCache;
+    use url::Url;
+
+    const CAPACITY: usize = 1024;
+
+    type Cache = CarCache<Url, u64>;
+
+    fn key(i: usize) -> Url {
+        let url = format!("https://bmc.local/redfish/v1/Systems/{i}/Sensors/{i}");
+        Url::parse(&url).expect("static test URL parses")
+    }
+
+    /// Cache filled to capacity; every entry in T1 with a clear
+    /// reference bit, so eviction finds a victim on the first probe.
+    fn full(c: usize) -> Cache {
+        let mut cache = Cache::new(c);
+        for i in 0..c {
+            cache.put(key(i), i as u64);
+        }
+        cache
+    }
+
+    /// Like [`full`], but every entry's reference bit is set: eviction
+    /// must sweep the whole clock once, demoting entries to T2.
+    fn full_referenced(c: usize) -> Cache {
+        let mut cache = full(c);
+        for i in 0..c {
+            black_box(cache.get(&key(i)));
+        }
+        cache
+    }
+
+    /// Full cache whose ghost list B1 deterministically holds evicted
+    /// keys: the referenced half of the population recirculates to T2
+    /// during evictions, so the unreferenced half demotes to B1 and
+    /// survives (T2 keeps |T1| + |B1| below the discard threshold).
+    /// Returns the cache and a key proven to be a B1 ghost.
+    fn ghost_input(c: usize) -> (Cache, Url) {
+        let build = || {
+            let mut cache = full(c);
+            for i in 0..c / 2 {
+                black_box(cache.get(&key(i)));
+            }
+            for i in c..c + c / 2 {
+                cache.put(key(i), i as u64);
+            }
+            cache
+        };
+        // Prove the measured put takes the B1 adaptation path: a B1
+        // hit must raise the adaptation parameter.
+        let ghost = key(c - 1);
+        let mut probe = build();
+        let p_before = probe.adaptation_parameter();
+        probe.put(ghost.clone(), 0);
+        assert!(
+            probe.adaptation_parameter() > p_before,
+            "setup must produce a B1 ghost hit"
+        );
+        (build(), ghost)
+    }
+
+    #[library_benchmark]
+    #[bench::hit((full(CAPACITY), key(0)))]
+    #[bench::miss((full(CAPACITY), key(CAPACITY + 1)))]
+    fn get((mut cache, k): (Cache, Url)) -> (Cache, Option<u64>) {
+        let value = cache.get(&k).copied();
+        (cache, black_box(value))
+    }
+
+    #[library_benchmark]
+    #[bench::update_existing((full(CAPACITY), key(0)))]
+    #[bench::insert_with_headroom((full(CAPACITY / 2), key(CAPACITY)))]
+    #[bench::evict_first_probe((full(CAPACITY), key(CAPACITY + 1)))]
+    #[bench::evict_full_clock_sweep((full_referenced(CAPACITY), key(CAPACITY + 1)))]
+    #[bench::ghost_hit(ghost_input(CAPACITY))]
+    fn put((mut cache, k): (Cache, Url)) -> Cache {
+        black_box(cache.put(k, 7));
+        cache
+    }
+
+    fn scan_input(c: usize) -> (Cache, Vec<Url>) {
+        let keys = (0..256).map(|i| key(2 * c + i)).collect();
+        (full_referenced(c), keys)
+    }
+
+    // Workload-shaped batch: a scan of 256 never-before-seen keys
+    // through a full, referenced cache (the pattern a Redfish resource
+    // walk produces). Keys are pre-built in setup so only cache
+    // operations are measured.
+    #[library_benchmark]
+    #[bench::n_256(scan_input(CAPACITY))]
+    fn scan((mut cache, keys): (Cache, Vec<Url>)) -> Cache {
+        for (i, k) in keys.into_iter().enumerate() {
+            black_box(cache.put(k, i as u64));
+        }
+        cache
+    }
+}
+
+#[cfg(unix)]
+use unix::{get, put, scan};
+
+#[cfg(unix)]
+gungraun::library_benchmark_group!(
+    name = cache;
+    benchmarks = get, put, scan
+);
+
+#[cfg(unix)]
+gungraun::main!(library_benchmark_groups = cache);
+
+#[cfg(not(unix))]
+fn main() {}

--- a/bmc-http/benches/cache.rs
+++ b/bmc-http/benches/cache.rs
@@ -24,9 +24,9 @@
 //! unix-only, so the whole benchmark is `cfg(unix)`.
 //!
 //! Slot storage allocates lazily on first use, so benchmarks that
-//! perform a cache's first eviction (insert_with_headroom,
-//! evict_first_probe, evict_full_clock_sweep) include that one-time
-//! allocation; steady-state evictions cost less by that share.
+//! perform a cache's first eviction (evict_first_probe,
+//! evict_full_clock_sweep) include that one-time allocation;
+//! steady-state evictions cost less by that share.
 
 #[cfg(unix)]
 mod unix {
@@ -50,6 +50,18 @@ mod unix {
     fn full(c: usize) -> Cache {
         let mut cache = Cache::new(c);
         for i in 0..c {
+            cache.put(key(i), i as u64);
+        }
+        cache
+    }
+
+    /// Cache filled to half its capacity, so insertion takes the
+    /// no-eviction path. Fills one entry past c/2 so the measured
+    /// insert doesn't land on the slot vector's doubling boundary
+    /// and pay its reallocation.
+    fn half_full(c: usize) -> Cache {
+        let mut cache = Cache::new(c);
+        for i in 0..=c / 2 {
             cache.put(key(i), i as u64);
         }
         cache
@@ -104,7 +116,7 @@ mod unix {
 
     #[library_benchmark]
     #[bench::update_existing((full(CAPACITY), key(0)))]
-    #[bench::insert_with_headroom((full(CAPACITY / 2), key(CAPACITY)))]
+    #[bench::insert_with_headroom((half_full(CAPACITY), key(CAPACITY)))]
     #[bench::evict_first_probe((full(CAPACITY), key(CAPACITY + 1)))]
     #[bench::evict_full_clock_sweep((full_referenced(CAPACITY), key(CAPACITY + 1)))]
     #[bench::ghost_hit(ghost_input(CAPACITY))]

--- a/bmc-http/src/cache.rs
+++ b/bmc-http/src/cache.rs
@@ -18,7 +18,11 @@
 //! Based on "CAR: Clock with Adaptive Replacement" by Bansal & Modha
 //! USENIX Conference on File and Storage Technologies, 2004
 //!
-//! This implementation follows the exact pseudocode from the [paper](https://www.usenix.org/legacy/publications/library/proceedings/fast04/tech/full_papers/bansal/bansal.pdf).
+//! This implementation follows the pseudocode from the [paper](https://www.usenix.org/legacy/publications/library/proceedings/fast04/tech/full_papers/bansal/bansal.pdf),
+//! with one clock-native reading: "make it the tail page in T2"
+//! (line 36) is realized by clearing the reference bit and advancing
+//! the hand — in a circular list that leaves the page as the last one
+//! the hand revisits.
 
 use std::any::Any;
 use std::collections::HashMap;
@@ -64,7 +68,7 @@ impl<K, V> CacheEntry<K, V> {
 }
 
 /// Node in the ghost list doubly-linked structure
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 struct GhostNode<K> {
     key: K,
     prev: Option<usize>,
@@ -74,7 +78,10 @@ struct GhostNode<K> {
 /// Intrusive doubly linked list for ghost entries (B1, B2)
 #[derive(Debug)]
 struct GhostList<K> {
+    /// Grows on demand up to `capacity`, so an idle cache holds no
+    /// slot storage.
     entries: Vec<Option<GhostNode<K>>>,
+    capacity: usize,
     head: Option<usize>, // LRU end
     tail: Option<usize>, // MRU end
     free_slots: Vec<usize>,
@@ -82,13 +89,26 @@ struct GhostList<K> {
 }
 
 impl<K: Clone> GhostList<K> {
-    fn new(capacity: usize) -> Self {
+    const fn new(capacity: usize) -> Self {
         Self {
-            entries: vec![None; capacity],
+            entries: Vec::new(),
+            capacity,
             head: None,
             tail: None,
-            free_slots: (0..capacity).rev().collect(),
+            free_slots: Vec::new(),
             size: 0,
+        }
+    }
+
+    fn acquire_slot(&mut self) -> Option<usize> {
+        if let Some(slot) = self.free_slots.pop() {
+            return Some(slot);
+        }
+        if self.entries.len() < self.capacity {
+            self.entries.push(None);
+            Some(self.entries.len() - 1)
+        } else {
+            None
         }
     }
 
@@ -96,13 +116,13 @@ impl<K: Clone> GhostList<K> {
     /// Returns `(slot, evicted_key)` where `evicted_key` is Some if an item was evicted
     fn insert_at_tail(&mut self, key: K) -> Option<(usize, Option<K>)> {
         // If we're at capacity, remove LRU first
-        let evicted_key = if self.free_slots.is_empty() {
+        let evicted_key = if self.size == self.capacity {
             self.remove_lru()
         } else {
             None
         };
 
-        let slot = self.free_slots.pop()?;
+        let slot = self.acquire_slot()?;
         let new_node = GhostNode {
             key,
             prev: self.tail,
@@ -185,74 +205,136 @@ impl<K: Clone> GhostList<K> {
     }
 }
 
-/// Clock-based list for T1 and T2
+/// Node in the clock's circular intrusive list
+#[derive(Debug)]
+struct ClockNode<K, V> {
+    entry: CacheEntry<K, V>,
+    prev: usize,
+    next: usize,
+}
+
+/// Clock-based list for T1 and T2.
+///
+/// Occupied slots form a circular doubly-linked ring in insertion
+/// order; the hand points at the head (next victim candidate), so head
+/// access, removal and hand advancement are O(1) regardless of how
+/// sparsely the slot vector is populated.
 #[derive(Debug)]
 struct ClockList<K, V> {
-    entries: Vec<Option<CacheEntry<K, V>>>,
-    hand: usize, // Clock hand position
+    /// Grows on demand up to `capacity`, so an idle cache holds no
+    /// slot storage.
+    nodes: Vec<Option<ClockNode<K, V>>>,
+    capacity: usize,
+    /// Clock hand: slot of the current head, `None` when empty
+    hand: Option<usize>,
     free_slots: Vec<usize>,
     size: usize,
 }
 
 impl<K: Clone, V> ClockList<K, V> {
-    fn new(capacity: usize) -> Self {
-        let mut entries = Vec::with_capacity(capacity);
-        for _ in 0..capacity {
-            entries.push(None);
-        }
+    const fn new(capacity: usize) -> Self {
         Self {
-            entries,
-            hand: 0,
-            free_slots: (0..capacity).rev().collect(),
+            nodes: Vec::new(),
+            capacity,
+            hand: None,
+            free_slots: Vec::new(),
             size: 0,
         }
     }
 
-    /// Insert at tail (any available slot)
-    fn insert_at_tail(&mut self, key: K, value: V) -> Option<usize> {
-        let slot = self.free_slots.pop()?;
-        self.entries[slot] = Some(CacheEntry::new(key, value));
-        self.size += 1;
-        Some(slot)
+    fn acquire_slot(&mut self) -> Option<usize> {
+        if let Some(slot) = self.free_slots.pop() {
+            return Some(slot);
+        }
+        if self.nodes.len() < self.capacity {
+            self.nodes.push(None);
+            Some(self.nodes.len() - 1)
+        } else {
+            None
+        }
     }
 
-    /// Get head page for clock algorithm
+    /// Insert at tail — immediately behind the hand, so the new entry
+    /// is the last the clock visits — O(1). On failure (list full, or
+    /// a broken hand invariant) the pair is handed back untouched.
+    fn insert_at_tail(&mut self, key: K, value: V) -> Result<usize, (K, V)> {
+        let links = match self.hand {
+            Some(hand) => match self.nodes.get(hand).and_then(Option::as_ref) {
+                Some(node) => Some((node.prev, hand)),
+                None => return Err((key, value)),
+            },
+            None => None,
+        };
+        let Some(slot) = self.acquire_slot() else {
+            return Err((key, value));
+        };
+        let (prev, next) = links.unwrap_or((slot, slot));
+        self.nodes[slot] = Some(ClockNode {
+            entry: CacheEntry::new(key, value),
+            prev,
+            next,
+        });
+        if links.is_some() {
+            if let Some(prev_node) = self.nodes.get_mut(prev).and_then(Option::as_mut) {
+                prev_node.next = slot;
+            }
+            if let Some(next_node) = self.nodes.get_mut(next).and_then(Option::as_mut) {
+                next_node.prev = slot;
+            }
+        } else {
+            self.hand = Some(slot);
+        }
+        self.size += 1;
+        Ok(slot)
+    }
+
+    /// Get head page for clock algorithm - O(1)
     fn get_head_page(&mut self) -> Option<&mut CacheEntry<K, V>> {
-        // Find the entry at the current hand position
-        let start_hand = self.hand;
-        loop {
-            if self.size == 0 {
-                return None;
+        let hand = self.hand?;
+        self.nodes
+            .get_mut(hand)?
+            .as_mut()
+            .map(|node| &mut node.entry)
+    }
+
+    /// Remove head page (at the hand) - O(1)
+    fn remove_head_page(&mut self) -> Option<CacheEntry<K, V>> {
+        let hand = self.hand?;
+        let node = self.nodes.get_mut(hand)?.take()?;
+        self.free_slots.push(hand);
+        self.size -= 1;
+        if self.size == 0 {
+            self.hand = None;
+        } else {
+            if let Some(prev_node) = self.nodes.get_mut(node.prev).and_then(Option::as_mut) {
+                prev_node.next = node.next;
             }
-
-            if self.entries[self.hand].is_some() {
-                return self.entries[self.hand].as_mut();
+            if let Some(next_node) = self.nodes.get_mut(node.next).and_then(Option::as_mut) {
+                next_node.prev = node.prev;
             }
+            self.hand = Some(node.next);
+        }
+        Some(node.entry)
+    }
 
-            self.advance_hand();
-
-            // Prevent infinite loop
-            if self.hand == start_hand {
-                return None;
+    /// Move the hand past the current head - O(1)
+    fn advance_hand(&mut self) {
+        if let Some(hand) = self.hand {
+            if let Some(node) = self.nodes.get(hand).and_then(Option::as_ref) {
+                self.hand = Some(node.next);
             }
         }
     }
 
-    /// Remove head page (at current hand position)
-    fn remove_head_page(&mut self) -> Option<CacheEntry<K, V>> {
-        let entry = self.entries[self.hand].take()?;
-        self.free_slots.push(self.hand);
-        self.size -= 1;
-        self.advance_hand();
-        Some(entry)
-    }
-
-    const fn advance_hand(&mut self) {
-        self.hand = (self.hand + 1) % self.entries.len();
-    }
-
     fn get_mut(&mut self, slot: usize) -> Option<&mut CacheEntry<K, V>> {
-        self.entries.get_mut(slot)?.as_mut()
+        self.nodes
+            .get_mut(slot)?
+            .as_mut()
+            .map(|node| &mut node.entry)
+    }
+
+    fn get(&self, slot: usize) -> Option<&CacheEntry<K, V>> {
+        self.nodes.get(slot)?.as_ref().map(|node| &node.entry)
     }
 
     const fn len(&self) -> usize {
@@ -368,21 +450,33 @@ where
         }
 
         let mut evicted = None;
+        // The key's post-replace location; when the cache is not full,
+        // invariant I5 guarantees B1 ∪ B2 is empty, so `None` is exact.
+        let mut location = None;
+        debug_assert!(
+            self.t1.len() + self.t2.len() == self.c || self.b1.len() + self.b2.len() == 0,
+            "I5 violated: ghosts exist while the cache is not full"
+        );
         // Line 3: else /* cache miss */
         // Line 4: if (|T1| + |T2| = c) then
         if self.t1.len() + self.t2.len() == self.c {
             // Line 5: replace()
             evicted = self.replace();
 
+            // replace() can discard ghosts, so look the key up after it;
+            // one lookup serves lines 6, 8 and the B1/B2 dispatch below.
+            location = self.index.get(&key).copied();
+            let in_ghosts = matches!(location, Some(Location::B1(_) | Location::B2(_)));
+
             // Line 6: if ((x is not in B1 ∪ B2) and (|T1| + |B1| = c)) then
-            if !self.is_in_b1_or_b2(&key) && (self.t1.len() + self.b1.len() == self.c) {
+            if !in_ghosts && (self.t1.len() + self.b1.len() == self.c) {
                 // Line 7: Discard the LRU page in B1
                 if let Some(discarded_key) = self.b1.remove_lru() {
                     self.index.remove(&discarded_key);
                 }
             }
             // Line 8: elseif ((|T1| + |T2| + |B1| + |B2| = 2c) and (x is not in B1 ∪ B2)) then
-            else if !self.is_in_b1_or_b2(&key)
+            else if !in_ghosts
                 && (self.t1.len() + self.t2.len() + self.b1.len() + self.b2.len() == 2 * self.c)
             {
                 // Line 9: Discard the LRU page in B2
@@ -392,7 +486,7 @@ where
             }
         }
 
-        match self.index.get(&key).copied() {
+        match location {
             Some(Location::B1(slot)) => {
                 // Line 14: elseif (x is in B1) then
                 // Line 15: Adapt: Increase the target size for the list T1 as: p = min {p + max{1, |B2|/|B1|}, c}
@@ -407,10 +501,7 @@ where
                 self.b1.remove(slot);
 
                 // Line 16: Move x at the tail of T2. Set the page reference bit of x to 0.
-                if let Some(t2_slot) = self.t2.insert_at_tail(key.clone(), value) {
-                    self.index.insert(key, Location::T2(t2_slot));
-                    // ref_bit is already 0 from CacheEntry::new()
-                }
+                self.move_to_t2(key, value);
             }
             Some(Location::B2(slot)) => {
                 // Line 17: else /* x must be in B2 */
@@ -426,22 +517,39 @@ where
                 self.b2.remove(slot);
 
                 // Line 19: Move x at the tail of T2. Set the page reference bit of x to 0.
-                if let Some(t2_slot) = self.t2.insert_at_tail(key.clone(), value) {
-                    self.index.insert(key, Location::T2(t2_slot));
-                }
+                self.move_to_t2(key, value);
             }
             None => {
                 // Line 12: if (x is not in B1 ∪ B2) then
                 // Line 13: Insert x at the tail of T1. Set the page reference bit of x to 0.
-                if let Some(t1_slot) = self.t1.insert_at_tail(key.clone(), value) {
+                if let Ok(t1_slot) = self.t1.insert_at_tail(key.clone(), value) {
                     self.index.insert(key, Location::T1(t1_slot));
                 }
             }
-            _ => {
-                // Should not happen - T1/T2 cases handled above
+            Some(Location::T1(_) | Location::T2(_)) => {
+                debug_assert!(false, "T1/T2 hits are handled before the miss path");
             }
         }
         evicted.map(|e| Evicted::new(e.key, e.value))
+    }
+
+    /// Move an already-indexed key to the tail of T2 and repoint its
+    /// index entry, without cloning the key. If T2 cannot take the
+    /// entry the index entry is removed, keeping index and lists
+    /// consistent.
+    fn move_to_t2(&mut self, key: K, value: V) {
+        match self.t2.insert_at_tail(key, value) {
+            Ok(t2_slot) => {
+                if let Some(moved) = self.t2.get(t2_slot) {
+                    if let Some(location) = self.index.get_mut(&moved.key) {
+                        *location = Location::T2(t2_slot);
+                    }
+                }
+            }
+            Err((key, _value)) => {
+                self.index.remove(&key);
+            }
+        }
     }
 
     /// Line 5: `replace()` - exact implementation of pseudocode
@@ -453,12 +561,17 @@ where
                 if let Some(found) = self.try_replace_from_t1() {
                     return Some(found);
                 }
-                self.t1.advance_hand();
+                // No advance here: a T1 pass that found no victim has
+                // recirculated the head to T2, which already moved the
+                // hand to the next page. An extra advance would skip
+                // that page without examining its reference bit.
             } else {
                 // Line 31: else
                 if let Some(found) = self.try_replace_from_t2() {
                     return Some(found);
                 }
+                // A T2 pass that found no victim only cleared the head's
+                // reference bit; move the hand past it.
                 self.t2.advance_hand();
             }
         }
@@ -481,7 +594,11 @@ where
                         if let Some(evicted) = evicted_key {
                             self.index.remove(&evicted);
                         }
-                        self.index.insert(entry.key.clone(), Location::B1(b1_slot));
+                        // The key is already indexed (it was in T1):
+                        // update the location in place.
+                        if let Some(location) = self.index.get_mut(&entry.key) {
+                            *location = Location::B1(b1_slot);
+                        }
                     } else {
                         self.index.remove(&entry.key);
                     }
@@ -491,9 +608,7 @@ where
                 // Line 28-29: else Set the page reference bit of head page in T1 to 0, and make it the tail page in T2
                 head_entry.ref_bit = false; // Line 29: Set the page reference bit of head page in T1 to 0
                 if let Some(entry) = self.t1.remove_head_page() {
-                    if let Some(t2_slot) = self.t2.insert_at_tail(entry.key.clone(), entry.value) {
-                        self.index.insert(entry.key, Location::T2(t2_slot));
-                    }
+                    self.move_to_t2(entry.key, entry.value);
                 }
             }
         }
@@ -516,7 +631,11 @@ where
                         if let Some(evicted) = evicted_key {
                             self.index.remove(&evicted);
                         }
-                        self.index.insert(entry.key.clone(), Location::B2(b2_slot));
+                        // The key is already indexed (it was in T2):
+                        // update the location in place.
+                        if let Some(location) = self.index.get_mut(&entry.key) {
+                            *location = Location::B2(b2_slot);
+                        }
                     } else {
                         self.index.remove(&entry.key);
                     }
@@ -524,20 +643,15 @@ where
                 }
             } else {
                 // Line 35-36: else Set the page reference bit of head page in T2 to 0, and make it the tail page in T2
+                //
+                // In a clock, "make it the tail" is the hand passing
+                // over the page: clear the bit and leave the entry in
+                // its slot; once the caller advances the hand, this
+                // page is the last the hand will revisit.
                 head_entry.ref_bit = false; // Line 36: Set the page reference bit of head page in T2 to 0
-                if let Some(entry) = self.t2.remove_head_page() {
-                    if let Some(t2_slot) = self.t2.insert_at_tail(entry.key.clone(), entry.value) {
-                        self.index.insert(entry.key, Location::T2(t2_slot));
-                    }
-                }
             }
         }
         None
-    }
-
-    /// Helper function to check if key is in B1 or B2
-    fn is_in_b1_or_b2(&self, key: &K) -> bool {
-        matches!(self.index.get(key), Some(Location::B1(_) | Location::B2(_)))
     }
 
     /// Get current cache size (items in T1 + T2)
@@ -825,6 +939,24 @@ mod tests {
     }
 
     #[test]
+    fn test_clock_examines_every_page_during_replacement() {
+        // T1 = [a(ref=1), b, c]: the clock recirculates `a` to T2 and
+        // must then examine `b` — the victim is `b`, not `c`.
+        let mut cache = CarCache::new(3);
+        cache.put("a", 1);
+        cache.put("b", 2);
+        cache.put("c", 3);
+        cache.get(&"a");
+
+        let evicted = cache.put("d", 4).expect("full cache evicts");
+        assert_eq!(evicted.key, "b");
+        assert_eq!(evicted.value, 2);
+        assert_car_invariants(&cache);
+        // `a` survived via recirculation to T2.
+        assert_eq!(cache.get(&"a"), Some(&1));
+    }
+
+    #[test]
     fn test_zero_capacity_cache_is_disabled() {
         let mut cache = CarCache::new(0);
 
@@ -850,9 +982,12 @@ mod tests {
         cache.get(&"a");
 
         cache.put("e", 5);
+        // Fills the cache; the next put replaces: `a` (referenced)
+        // recirculates to T2 and `b` demotes to B1.
         cache.put("f", 6);
 
-        cache.put("c", 10);
+        // B1 hit on `b` adapts p upward.
+        cache.put("b", 10);
 
         assert!(cache.adaptation_parameter() > initial_p);
         assert!(cache.adaptation_parameter() <= cache.capacity());
@@ -865,24 +1000,19 @@ mod tests {
         cache.put("a", 1);
         cache.put("b", 2);
         cache.put("c", 3);
-
         cache.get(&"a");
-
         cache.put("e", 5);
         cache.put("f", 6);
 
+        // Three B1 hits grow p to 3, forcing replacements to come from
+        // T2; `a` (recirculated there with a cleared bit) demotes to B2.
+        cache.put("b", 10);
         cache.put("c", 10);
+        cache.put("e", 10);
 
         let p_before = cache.adaptation_parameter();
 
-        cache.put("f", 6);
-        cache.get(&"f");
-        cache.put("g", 7);
-        cache.get(&"g");
-        cache.put("x", 7);
-        cache.put("y", 7);
-        cache.put("z", 7);
-
+        // B2 hit on `a` adapts p downward.
         cache.put("a", 10);
 
         assert!(cache.adaptation_parameter() < p_before);

--- a/bmc-http/src/cache.rs
+++ b/bmc-http/src/cache.rs
@@ -113,15 +113,10 @@ impl<K: Clone> GhostList<K> {
     }
 
     /// Insert at tail (MRU position) - O(1)
-    /// Returns `(slot, evicted_key)` where `evicted_key` is Some if an item was evicted
-    fn insert_at_tail(&mut self, key: K) -> Option<(usize, Option<K>)> {
-        // If we're at capacity, remove LRU first
-        let evicted_key = if self.size == self.capacity {
-            self.remove_lru()
-        } else {
-            None
-        };
-
+    /// Returns the slot the key was stored in. Callers must keep the
+    /// list below capacity; see [`CarCache::new`] for the sizing.
+    fn insert_at_tail(&mut self, key: K) -> Option<usize> {
+        debug_assert!(self.size < self.capacity, "insert into a full ghost list");
         let slot = self.acquire_slot()?;
         let new_node = GhostNode {
             key,
@@ -141,7 +136,7 @@ impl<K: Clone> GhostList<K> {
         self.entries[slot] = Some(new_node);
         self.size += 1;
 
-        Some((slot, evicted_key))
+        Some(slot)
     }
 
     /// Remove LRU (head) entry - O(1)
@@ -385,8 +380,14 @@ where
             p: 0,
             t1: ClockList::new(capacity),
             t2: ClockList::new(capacity),
-            b1: GhostList::new(capacity),
-            b2: GhostList::new(capacity),
+            // One slack slot: a put demotes at most one page into a
+            // ghost list and ends with both lists at or below c (the
+            // guarded discards, lines 6-9, or the requested ghost's
+            // own removal restore the bound). Only B2 can transiently
+            // reach c+1, keeping the requested key's ghost alive for
+            // its adaptation hit; B1 peaks at c and is sized alike.
+            b1: GhostList::new(capacity.saturating_add(1)),
+            b2: GhostList::new(capacity.saturating_add(1)),
             index: HashMap::new(),
         }
     }
@@ -426,27 +427,18 @@ where
         }
 
         // Check if it's a cache hit first
-        if let Some(location) = self.index.get(&key).copied() {
-            match location {
-                Location::T1(slot) | Location::T2(slot) => {
-                    // Cache hit - update value and set reference bit
-                    let entry = if matches!(location, Location::T1(_)) {
-                        self.t1.get_mut(slot)
-                    } else {
-                        self.t2.get_mut(slot)
-                    };
-
-                    if let Some(entry) = entry {
-                        entry.value = value;
-                    }
-
-                    // We are not removed anything, as we just updated value
-                    return None;
-                }
-                _ => {
-                    // Will handle B1/B2 hits below
-                }
-            }
+        let hit = match self.index.get(&key).copied() {
+            Some(Location::T1(slot)) => self.t1.get_mut(slot),
+            Some(Location::T2(slot)) => self.t2.get_mut(slot),
+            // B1/B2 hits are handled in the miss path below.
+            _ => None,
+        };
+        if let Some(entry) = hit {
+            // Line 2: a hit sets the page reference bit, whether the
+            // request reads or refreshes.
+            entry.ref_bit = true;
+            entry.value = value;
+            return None;
         }
 
         let mut evicted = None;
@@ -588,12 +580,7 @@ where
                 // Line 26: found = 1;
                 // Line 27: Demote the head page in T1 and make it the MRU page in B1
                 if let Some(entry) = self.t1.remove_head_page() {
-                    if let Some((b1_slot, evicted_key)) = self.b1.insert_at_tail(entry.key.clone())
-                    {
-                        // Clean up evicted key from index if any
-                        if let Some(evicted) = evicted_key {
-                            self.index.remove(&evicted);
-                        }
+                    if let Some(b1_slot) = self.b1.insert_at_tail(entry.key.clone()) {
                         // The key is already indexed (it was in T1):
                         // update the location in place.
                         if let Some(location) = self.index.get_mut(&entry.key) {
@@ -625,12 +612,7 @@ where
                 // Line 33: found = 1;
                 // Line 34: Demote the head page in T2 and make it the MRU page in B2
                 if let Some(entry) = self.t2.remove_head_page() {
-                    if let Some((b2_slot, evicted_key)) = self.b2.insert_at_tail(entry.key.clone())
-                    {
-                        // Clean up evicted key from index if any
-                        if let Some(evicted) = evicted_key {
-                            self.index.remove(&evicted);
-                        }
+                    if let Some(b2_slot) = self.b2.insert_at_tail(entry.key.clone()) {
                         // The key is already indexed (it was in T2):
                         // update the location in place.
                         if let Some(location) = self.index.get_mut(&entry.key) {
@@ -905,10 +887,10 @@ mod tests {
         assert_eq!(ghost_list.len(), 0);
         assert_eq!(ghost_list.remove_lru(), None);
 
-        let (_slot1, _) = ghost_list.insert_at_tail("a").unwrap();
+        let _slot1 = ghost_list.insert_at_tail("a").unwrap();
         assert_eq!(ghost_list.len(), 1);
 
-        let (slot2, _) = ghost_list.insert_at_tail("b").unwrap();
+        let slot2 = ghost_list.insert_at_tail("b").unwrap();
         assert_eq!(ghost_list.len(), 2);
 
         assert_eq!(ghost_list.remove_lru(), Some("a"));
@@ -954,6 +936,56 @@ mod tests {
         assert_car_invariants(&cache);
         // `a` survived via recirculation to T2.
         assert_eq!(cache.get(&"a"), Some(&1));
+    }
+
+    #[test]
+    fn test_put_hit_sets_reference_bit() {
+        // A refresh is a request for x (paper line 2): the refreshed
+        // entry must survive the next replacement via recirculation.
+        let mut cache = CarCache::new(3);
+        cache.put("a", 1);
+        cache.put("b", 2);
+        cache.put("c", 3);
+        cache.put("a", 10);
+
+        let evicted = cache.put("d", 4).expect("full cache evicts");
+        assert_eq!(evicted.key, "b");
+        assert_car_invariants(&cache);
+        assert_eq!(cache.get(&"a"), Some(&10));
+    }
+
+    #[test]
+    fn test_mid_put_demotion_spares_requested_ghost() {
+        // Build |B2| = c with the requested key as B2's LRU (forcing
+        // B1 empty and a full 2c directory), so replace()'s demotion
+        // inside the same put pushes B2 to c+1 before the hit is
+        // processed — the case the ghost lists' slack slot absorbs.
+        let mut cache = CarCache::new(2);
+        cache.put("a", 1);
+        cache.put("b", 2);
+        cache.get(&"a");
+        cache.put("c", 3); // a recirculates to T2; b demotes to B1
+        cache.put("b", 20); // B1 hit: c demotes to B1, b joins T2, p = 1
+        cache.put("d", 4); // a demotes to B2
+        cache.put("c", 30); // B1 hit: d demotes to B1, c joins T2, p = 2
+        cache.put("e", 5); // b demotes to B2; line 8 discards ghost a
+        cache.put("d", 40); // B1 hit: c demotes to B2, d joins T2
+        assert_eq!(cache.b1.len(), 0);
+        assert_eq!(cache.b2.len(), cache.capacity());
+        assert!(matches!(cache.index.get(&"b"), Some(Location::B2(_))));
+
+        // replace() demotes T2's head (d) into the full B2 first; b's
+        // own ghost must survive it for the adaptation hit to land.
+        let p_before = cache.adaptation_parameter();
+        cache.put("b", 100);
+        assert!(
+            cache.adaptation_parameter() < p_before,
+            "B2 hit must adapt p downward"
+        );
+        // Line 19: a ghost hit promotes to T2, not T1.
+        assert!(matches!(cache.index.get(&"b"), Some(Location::T2(_))));
+        assert_eq!(cache.get(&"b"), Some(&100));
+        assert_car_invariants(&cache);
     }
 
     #[test]
@@ -1016,6 +1048,58 @@ mod tests {
         cache.put("a", 10);
 
         assert!(cache.adaptation_parameter() < p_before);
+    }
+
+    /// Full capacity-8 cache with T1 = {5..8}, T2 = {0..3} and `4` in
+    /// B1: fill, reference the first half, then evict once.
+    fn cache_with_mixed_directory() -> CarCache<i32, i32> {
+        let mut cache = CarCache::new(8);
+        for i in 0..8 {
+            cache.put(i, i);
+        }
+        for i in 0..4 {
+            cache.get(&i);
+        }
+        cache.put(8, 8); // 0-3 recirculate to T2; 4 demotes to B1
+        cache
+    }
+
+    #[test]
+    fn test_b1_adaptation_delta_scales_with_ghost_ratio() {
+        // Line 15: delta = max(1, |B2|/|B1|). Plant a B2-heavy ghost
+        // directory and pin the exact jump.
+        let mut cache = cache_with_mixed_directory();
+        for k in 200..204 {
+            let slot = cache.b2.insert_at_tail(k).expect("planted ghost fits");
+            cache.index.insert(k, Location::B2(slot));
+        }
+        assert_car_invariants(&cache);
+
+        // replace() demotes T1's head into B1 first, so at line 15
+        // |B1| = 2 and |B2| = 4: p jumps by 4/2 = 2, not by 1.
+        cache.put(4, 40);
+        assert_eq!(cache.adaptation_parameter(), 2);
+        assert_car_invariants(&cache);
+    }
+
+    #[test]
+    fn test_b2_adaptation_delta_scales_with_ghost_ratio() {
+        // Line 18: delta = max(1, |B1|/|B2|), saturating at zero.
+        let mut cache = cache_with_mixed_directory();
+        for k in 100..103 {
+            let slot = cache.b1.insert_at_tail(k).expect("planted ghost fits");
+            cache.index.insert(k, Location::B1(slot));
+        }
+        let slot = cache.b2.insert_at_tail(200).expect("planted ghost fits");
+        cache.index.insert(200, Location::B2(slot));
+        cache.p = 4;
+        assert_car_invariants(&cache);
+
+        // replace() demotes T1's head into B1 first (|T1| = 4 >= p),
+        // so at line 18 |B1| = 5 and |B2| = 1: p drops by 5, not 1.
+        cache.put(200, 0);
+        assert_eq!(cache.adaptation_parameter(), 0);
+        assert_car_invariants(&cache);
     }
 
     #[test]
@@ -1175,7 +1259,16 @@ mod tests {
             "NOTE: Adaptation parameter remained at {} (may need different workload)",
             p_values[0]
         );
-        assert_eq!(cache.adaptation_parameter(), 5);
+        // The workload drives p across its full range: B1 hits push it
+        // to the capacity clamp, B2 hits pull it back down.
+        let peak = p_values
+            .iter()
+            .position(|&p| p == cache.capacity())
+            .expect("B1 hits must push p to the capacity clamp");
+        assert!(
+            p_values[peak..].iter().any(|&p| p < cache.capacity()),
+            "B2 hits must pull p back down from the clamp"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## CAR cache: performance, paper conformance, and benchmarks

With help of Claude Fable and GPT-5.6sol. Added gungraun perf benchmark and walked through instruction set. Main change is to make ClockList intrusive, which leads to good performance improvements on scans.

Also found various small (non-critical bugs), AI description bellow goes through them.

## AI Generated description bellow 

Reworked the `bmc-http` CAR cache hot paths and cross-checked the
implementation against the CAR paper (Bansal & Modha, FAST'04), fixing three
conformance bugs.

- **Perf**: `ClockList` is now an intrusive circular ring (O(1) head ops),
  index updates are clone-free, slot storage allocates lazily. Full-clock
  sweep −22% instructions, 256-key scan −83%.
- **Conformance**: fixed a T1 double hand-advance that skipped pages during
  replacement; write hits now set the reference bit (paper line 2); ghost
  discards happen only via the guarded directory rules — ghost lists carry
  one slack slot instead of auto-evicting, which could drop the requested
  key's own ghost mid-put and lose its adaptation hit.
- **Tests**: behavioral test for the slack slot (fails on old code), exact
  pins for both adaptation deltas, trajectory-shape asserts instead of
  brittle endpoint pins. Verified additionally by a 24M-op randomized fuzz.
- **Benchmarks/CI**: new gungraun cache bench suite; fixed
  `insert_with_headroom` (was measuring an eviction on a full half-size
  cache); CI regression job now gates both dispatcher and cache benches at
  `ir=2%`.

