### PR TITLE
fix(csdl-compiler)!: prevent sensitive request data in Debug output

### DIFF
--- a/core/src/action.rs
+++ b/core/src/action.rs
@@ -49,6 +49,7 @@
 
 use crate::Bmc;
 use crate::ModificationResponse;
+use core::fmt::Debug;
 use core::fmt::Display;
 use core::fmt::Formatter;
 use core::fmt::Result as FmtResult;
@@ -80,7 +81,7 @@ impl ActionTarget {
 
 impl Display for ActionTarget {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        self.0.fmt(f)
+        Display::fmt(&self.0, f)
     }
 }
 
@@ -89,7 +90,7 @@ impl Display for ActionTarget {
 ///
 /// `T` is the type for parameters.
 /// `R` is the type for the return value.
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize)]
 pub struct Action<T, R> {
     /// URI reference used to trigger the action.
     #[serde(rename = "target")]
@@ -101,6 +102,14 @@ pub struct Action<T, R> {
     /// Establishes a dependency on the `R` (return value) type.
     #[serde(skip_deserializing)]
     _marker_retval: PhantomData<R>,
+}
+
+impl<T, R> Debug for Action<T, R> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        f.debug_struct("Action")
+            .field("target", &self.target)
+            .finish()
+    }
 }
 
 /// Action error trait. Needed in generated code when an action function
@@ -126,5 +135,28 @@ impl<T: Send + Sync + Serialize, R: Send + Sync + Sized + for<'de> Deserialize<'
         params: &T,
     ) -> Result<ModificationResponse<R>, B::Error> {
         bmc.action::<T, R>(self, params).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Action;
+    use super::ActionTarget;
+    use std::marker::PhantomData;
+
+    struct NotDebug;
+
+    #[test]
+    fn debug_does_not_require_parameter_or_result_debug() {
+        let action: Action<NotDebug, NotDebug> = Action {
+            target: ActionTarget::new("/redfish/v1/Actions/Test".into()),
+            _marker: PhantomData,
+            _marker_retval: PhantomData,
+        };
+
+        assert_eq!(
+            format!("{action:?}"),
+            "Action { target: ActionTarget(\"/redfish/v1/Actions/Test\") }"
+        );
     }
 }

--- a/csdl-compiler/src/generator/rust/struct_def.rs
+++ b/csdl-compiler/src/generator/rust/struct_def.rs
@@ -82,11 +82,18 @@ enum ImplType {
     None,
 }
 
+#[derive(Clone, Copy)]
+enum SerializableStructKind {
+    Create,
+    Update,
+}
+
 struct SerializableProperty<'a> {
     rename: Literal,
     name: StructFieldName<'a>,
     prop_type: TokenStream,
     required_on_create: bool,
+    write_only: bool,
 }
 
 // Action request fields are generated as two coordinated token streams. Keeping
@@ -359,8 +366,9 @@ impl<'a> StructDef<'a> {
 
         let properties = self.serializable_properties(config);
 
-        let additional_properties = if self.odata.additional_properties.is_some_and(|v| *v.inner())
-        {
+        let has_additional_properties =
+            self.odata.additional_properties.is_some_and(|v| *v.inner());
+        let additional_properties = if has_additional_properties {
             let top = &config.top_module_alias;
             // If additional_properties are explicitly set then we add
             // placeholder with serde_json::Value to
@@ -387,9 +395,17 @@ impl<'a> StructDef<'a> {
         content.extend(properties_content);
         let comment = format!(" Update struct corresponding to `{}`", self.name);
         let name = self.name.for_update(None);
+        let (debug_derive, debug_impl) = Self::debug_serializable(
+            &name,
+            &properties,
+            SerializableStructKind::Update,
+            self.base.is_some(),
+            has_additional_properties,
+        );
         tokens.extend(quote! {
             #[doc = #comment]
-            #[derive(Serialize, Default, Debug)]
+            #[derive(Serialize, Default)]
+            #debug_derive
             pub struct #name { #base #content #additional_properties }
         });
 
@@ -413,6 +429,7 @@ impl<'a> StructDef<'a> {
                 #base_impl
                 #content
             }
+            #debug_impl
         });
     }
 
@@ -441,9 +458,17 @@ impl<'a> StructDef<'a> {
         content.extend(properties_content);
         let comment = format!(" Create struct corresponding to `{}`", self.name);
         let name = self.name.for_create();
+        let (debug_derive, debug_impl) = Self::debug_serializable(
+            &name,
+            &properties,
+            SerializableStructKind::Create,
+            false,
+            false,
+        );
         tokens.extend([quote! {
             #[doc = #comment]
-            #[derive(Serialize, Debug)]
+            #[derive(Serialize)]
+            #debug_derive
             pub struct #name { #content }
         }]);
 
@@ -487,6 +512,7 @@ impl<'a> StructDef<'a> {
                 }
                 #prop_fn_content
             }
+            #debug_impl
         }]);
     }
 
@@ -519,9 +545,62 @@ impl<'a> StructDef<'a> {
                     name: StructFieldName::new_property(p.name),
                     prop_type,
                     required_on_create: p.redfish.is_required_on_create.into_inner(),
+                    write_only: p.odata.permissions_is_write_only(),
                 })
             })
             .collect()
+    }
+
+    fn debug_serializable<N: ToTokens>(
+        name: N,
+        properties: &[SerializableProperty<'a>],
+        kind: SerializableStructKind,
+        has_base: bool,
+        has_additional_properties: bool,
+    ) -> (TokenStream, TokenStream) {
+        if properties.iter().any(|p| p.write_only) || has_additional_properties {
+            let mut fields = TokenStream::new();
+            for p in properties {
+                let name = p.name;
+                let debug_name = Literal::string(&name.to_string());
+                if p.write_only {
+                    let optional =
+                        matches!(kind, SerializableStructKind::Update) || !p.required_on_create;
+                    if optional {
+                        // Preserve whether an optional value was supplied while replacing the
+                        // sensitive value itself with a redaction marker.
+                        fields.extend(quote! {
+                            .field(#debug_name, &self.#name.as_ref().map(|_| "<redacted>"))
+                        });
+                    } else {
+                        fields.extend(quote! { .field(#debug_name, &"<redacted>") });
+                    }
+                } else {
+                    fields.extend(quote! { .field(#debug_name, &self.#name) });
+                }
+            }
+            let base = has_base.then(|| quote! { .field("base", &self.base) });
+            // Additional properties are arbitrary OEM-provided request values with no schema
+            // metadata that can identify sensitive entries, so never expose their contents.
+            let additional_properties = has_additional_properties
+                .then(|| quote! { .field("additional_properties", &"<redacted>") });
+            (
+                quote! {},
+                quote! {
+                    impl core::fmt::Debug for #name {
+                        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                            f.debug_struct(stringify!(#name))
+                                #base
+                                #fields
+                                #additional_properties
+                                .finish()
+                        }
+                    }
+                },
+            )
+        } else {
+            (quote! { #[derive(Debug)] }, quote! {})
+        }
     }
 
     fn generate_optional_property_setter(p: &SerializableProperty<'_>) -> TokenStream {
@@ -548,8 +627,12 @@ impl<'a> StructDef<'a> {
         let name = self.name;
         tokens.extend([
             doc_format_and_generate(self.name, &self.odata),
+            // Action parameters can contain sensitive values such as passwords, keys, or
+            // tokens. Redfish CSDL schemas do not reliably identify which action parameters
+            // are sensitive, so generating a safe Debug implementation requires explicit
+            // sensitivity metadata. Do not derive Debug until those fields can be redacted.
             quote! {
-                #[derive(Serialize, Debug)]
+                #[derive(Serialize)]
                 pub struct #name { #content }
             },
         ]);

--- a/tests/tests/compile-fails/no-debug-for-action-parameters.rs
+++ b/tests/tests/compile-fails/no-debug-for-action-parameters.rs
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use nv_redfish_tests::base::redfish::service_root::TestActionsServiceTestSerializationActionAction;
+use std::fmt::Debug;
+
+// This is intentionally a compile-fail test. Action parameters can contain passwords, keys,
+// tokens, or other sensitive values, but the schema compiler cannot currently identify which
+// parameters need redaction. Requiring Debug here must therefore fail, protecting the generated
+// action parameter type from accidentally gaining an unsafe derived Debug implementation.
+fn require_debug<T: Debug>() {}
+
+fn main() {
+    // If this starts compiling, action parameters could be written to logs without redaction.
+    // Debug support should only be enabled after sensitive parameters are explicitly identified.
+    require_debug::<TestActionsServiceTestSerializationActionAction>();
+}

--- a/tests/tests/compile-fails/no-debug-for-action-parameters.stderr
+++ b/tests/tests/compile-fails/no-debug-for-action-parameters.stderr
@@ -1,0 +1,11 @@
+error[E0277]: `TestActionsServiceTestSerializationActionAction` doesn't implement `Debug`
+  --> tests/compile-fails/no-debug-for-action-parameters.rs:28:21
+   |
+28 |     require_debug::<TestActionsServiceTestSerializationActionAction>();
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Debug` is not implemented for `TestActionsServiceTestSerializationActionAction`
+   |
+note: required by a bound in `require_debug`
+  --> tests/compile-fails/no-debug-for-action-parameters.rs:23:21
+   |
+23 | fn require_debug<T: Debug>() {}
+   |                     ^^^^^ required by this bound in `require_debug`

--- a/tests/tests/tests-account-service.rs
+++ b/tests/tests/tests-account-service.rs
@@ -46,6 +46,57 @@ const MANAGER_ACCOUNT_DATA_TYPE: &str = "#ManagerAccount.v1_3_0.ManagerAccount";
 type TestResult<T> = Result<T, Box<dyn StdError>>;
 
 #[test]
+async fn account_request_debug_redacts_passwords() {
+    const SECRET: &str = "debug-secret-sentinel";
+
+    let create =
+        ManagerAccountCreate::builder(SECRET.into(), "debug-user".into(), "Operator".into())
+            .build();
+    let create_debug = format!("{create:?}");
+    assert!(!create_debug.contains(SECRET));
+    assert!(create_debug.contains("password: \"<redacted>\""));
+    assert!(create_debug.contains("user_name: \"debug-user\""));
+    assert_eq!(
+        serde_json::to_value(&create).expect("create request must serialize")["Password"],
+        SECRET
+    );
+
+    let update = ManagerAccountUpdate::builder()
+        .with_password(SECRET.into())
+        .with_user_name("debug-user".into())
+        .build();
+    let update_debug = format!("{update:?}");
+    assert!(!update_debug.contains(SECRET));
+    assert!(update_debug.contains("base: None"));
+    assert!(update_debug.contains("password: Some(\"<redacted>\")"));
+    assert!(update_debug.contains("user_name: Some(\"debug-user\")"));
+    assert_eq!(
+        serde_json::to_value(&update).expect("update request must serialize")["Password"],
+        SECRET
+    );
+
+    // An unset optional write-only field remains None, while a supplied value is redacted above.
+    let unset_update_debug = format!("{:?}", ManagerAccountUpdate::builder().build());
+    assert!(unset_update_debug.contains("password: None"));
+}
+
+#[test]
+async fn additional_properties_debug_is_fully_redacted() {
+    const SECRET: &str = "oem-debug-secret-sentinel";
+
+    let update = nv_redfish::schema::resource::OemUpdate {
+        additional_properties: json!({ "Secret": SECRET }),
+    };
+    let debug = format!("{update:?}");
+    assert!(!debug.contains(SECRET));
+    assert!(debug.contains("additional_properties: \"<redacted>\""));
+    assert_eq!(
+        serde_json::to_value(&update).expect("OEM update must serialize")["Secret"],
+        SECRET
+    );
+}
+
+#[test]
 async fn list_accounts() -> Result<(), Box<dyn StdError>> {
     let bmc = Arc::new(Bmc::default());
     let root_id = ODataId::service_root();

--- a/tests/tests/tests-base-operations.rs
+++ b/tests/tests/tests-base-operations.rs
@@ -474,6 +474,14 @@ async fn no_write_only_in_read_struct() {
     t.compile_fail("tests/compile-fails/no-write-only-in-read.rs");
 }
 
+// Action parameters can contain sensitive information and must not implement Debug until the
+// schema compiler can explicitly identify and redact sensitive fields.
+#[test]
+async fn no_debug_for_action_parameters() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/compile-fails/no-debug-for-action-parameters.rs");
+}
+
 // Check that collection provides create method.
 #[test]
 async fn create_collection_member_test() -> Result<(), Error> {


### PR DESCRIPTION
Redact write-only and additional properties in generated request types. Remove Debug from action parameter structs and relax Action's Debug bounds. Add regression tests for secret redaction and action parameters.

Fixes: #142 