### PR TITLE
fix(csdl-compiler): resolve duplicate CLI short option

### DIFF
--- a/csdl-compiler/src/commands.rs
+++ b/csdl-compiler/src/commands.rs
@@ -91,7 +91,7 @@ pub enum Commands {
         /// Pattern is a wildcard over the qualified name.
         /// Examples:
         /// `EthernetInterface.*.EthernetInterface/StaticNameServers` - matches `StaticNameServers` property of `EthernetInterface`
-        #[arg(short = 'r', long = "rigid-arrays")]
+        #[arg(short = 'a', long = "rigid-arrays")]
         rigid_array_patterns: Vec<PropertyPattern>,
     },
     /// Compile OEM CSDL schemas.
@@ -121,7 +121,7 @@ pub enum Commands {
         /// Pattern is a wildcard over the qualified name.
         /// Examples:
         /// `EthernetInterface.*.EthernetInterface/StaticNameServers` - matches `StaticNameServers` property of `EthernetInterface`
-        #[arg(short = 'r', long = "rigid-arrays")]
+        #[arg(short = 'a', long = "rigid-arrays")]
         rigid_array_patterns: Vec<PropertyPattern>,
     },
 }

--- a/csdl-compiler/src/main.rs
+++ b/csdl-compiler/src/main.rs
@@ -35,3 +35,14 @@ fn main() -> Result<(), Error> {
         .map(|msg| println!("{msg}"));
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Cli;
+    use clap::CommandFactory as _;
+
+    #[test]
+    fn cli_definition_is_valid() {
+        Cli::command().debug_assert();
+    }
+}


### PR DESCRIPTION
Fixes a startup panic in the nv-redfish-csdl-compiler compile subcommand caused by duplicate -r short options.

- Preserves -r for --root.
- Changes the short option for --rigid-arrays to -a in both compile and compile-oem.
- Adds a Clap debug_assert() regression test to detect future CLI option conflicts.

The long option --rigid-arrays remains unchanged.
