### PR TITLE
fix(csdl-compiler): reject cyclic type inheritance

### DIFF
--- a/csdl-compiler/src/compiler/error.rs
+++ b/csdl-compiler/src/compiler/error.rs
@@ -36,6 +36,8 @@ pub enum Error<'a> {
     EntityTypeNotFound(QualifiedName<'a>),
     /// Complex type was not found.
     ComplexTypeNotFound(QualifiedName<'a>),
+    /// A cycle was found in type inheritance.
+    CyclicType(Vec<QualifiedName<'a>>),
     /// Settings.Settings type was not found.
     SettingsTypeNotFound,
     /// Settings.PreferredApplyTime type was not found.
@@ -74,6 +76,15 @@ impl Display for Error<'_> {
             Self::Unimplemented => write!(f, "unimplemented"),
             Self::EntityTypeNotFound(v) => write!(f, "entity type not found: {v}"),
             Self::ComplexTypeNotFound(v) => write!(f, "complex type not found: {v}"),
+            Self::CyclicType(types) => {
+                write!(f, "cyclic type inheritance detected: ")?;
+                types.iter().enumerate().try_for_each(|(index, qtype)| {
+                    if index > 0 {
+                        write!(f, " -> ")?;
+                    }
+                    write!(f, "{qtype}")
+                })
+            }
             Self::SettingsTypeNotFound => write!(
                 f,
                 "cannot find type for Redfish settings (Settings.Settings)"

--- a/csdl-compiler/src/compiler/mod.rs
+++ b/csdl-compiler/src/compiler/mod.rs
@@ -223,7 +223,7 @@ impl SchemaBundle {
         root_patterns: &EntityTypeFilter,
         config: Config,
     ) -> Result<Compiled<'_>, Error<'_>> {
-        let schema_index = SchemaIndex::build(&self.edmx_docs);
+        let schema_index = SchemaIndex::build(&self.edmx_docs)?;
         let root_set = self.root_set_from_singletons(&schema_index, singletons, root_patterns)?;
         let ctx = Context {
             schema_index,
@@ -243,7 +243,7 @@ impl SchemaBundle {
     pub fn compile_all(&self, config: Config) -> Result<Compiled<'_>, Error<'_>> {
         let root_set = self.root_set_all();
         let ctx = Context {
-            schema_index: SchemaIndex::build(&self.edmx_docs),
+            schema_index: SchemaIndex::build(&self.edmx_docs)?,
             config,
             root_set_entities: root_set.entity_types.iter().copied().collect(),
         };
@@ -504,6 +504,32 @@ mod test {
     use super::*;
     use crate::edmx::Edmx;
     use crate::edmx::QualifiedTypeName;
+
+    #[test]
+    fn compile_all_propagates_cyclic_type_error() {
+        let schema = r#"<edmx:Edmx Version="4.0">
+             <edmx:DataServices>
+               <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Cycle">
+                 <EntityType Name="A" BaseType="Cycle.B"/>
+                 <EntityType Name="B" BaseType="Cycle.A"/>
+               </Schema>
+             </edmx:DataServices>
+           </edmx:Edmx>"#;
+        let bundle = SchemaBundle {
+            edmx_docs: vec![Edmx::parse(schema).expect("entity cycle schema must be valid")],
+            root_set_threshold: None,
+        };
+
+        let result = bundle.compile_all(Config::default());
+        assert!(
+            matches!(
+                result,
+                Err(Error::CyclicType(cycle))
+                    if cycle.len() >= 2 && cycle.first() == cycle.last()
+            ),
+            "compile_all must propagate the closed inheritance cycle"
+        );
+    }
 
     #[test]
     fn schema_test() {

--- a/csdl-compiler/src/compiler/namespace.rs
+++ b/csdl-compiler/src/compiler/namespace.rs
@@ -15,6 +15,7 @@
 
 use crate::edmx::Namespace as EdmxNamespace;
 use crate::edmx::SimpleIdentifier;
+use std::cmp::Ordering;
 use std::fmt::Debug;
 use std::fmt::Display;
 use std::fmt::Formatter;
@@ -84,6 +85,18 @@ impl PartialEq for Namespace<'_> {
 }
 
 impl Eq for Namespace<'_> {}
+
+impl PartialOrd for Namespace<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Namespace<'_> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.edmx_ns.ids[..self.len].cmp(&other.edmx_ns.ids[..other.len])
+    }
+}
 
 impl Hash for Namespace<'_> {
     fn hash<H: Hasher>(&self, state: &mut H) {

--- a/csdl-compiler/src/compiler/qualified_name.rs
+++ b/csdl-compiler/src/compiler/qualified_name.rs
@@ -22,7 +22,7 @@ use std::fmt::Formatter;
 use std::fmt::Result as FmtResult;
 
 /// Qualified (namespace + identifier) name used during compilation.
-#[derive(PartialEq, Eq, Hash, Clone, Copy, Debug)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Debug)]
 pub struct QualifiedName<'a> {
     /// Namespace of the type.
     pub namespace: Namespace<'a>,

--- a/csdl-compiler/src/compiler/schema_index.rs
+++ b/csdl-compiler/src/compiler/schema_index.rs
@@ -24,6 +24,7 @@ use crate::edmx::Schema;
 use crate::edmx::SimpleIdentifier;
 use crate::edmx::Type;
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::convert::identity;
 
 /// Index over schemas spanning multiple documents.
@@ -36,20 +37,27 @@ pub struct SchemaIndex<'a> {
 
 impl<'a> SchemaIndex<'a> {
     /// Build an index from the provided documents.
-    #[must_use]
-    pub fn build(edmx_docs: &'a [Edmx]) -> Self {
-        Self {
-            index: edmx_docs
-                .iter()
-                .flat_map(|v| {
-                    v.data_services
-                        .schemas
-                        .iter()
-                        .map(|s| (Namespace::new(&s.namespace), s))
-                })
-                .collect(),
-            child_map: edmx_docs.iter().fold(HashMap::new(), |map, doc| {
-                doc.data_services.schemas.iter().fold(map, |map, s| {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if entity or complex type inheritance contains a cycle.
+    pub fn build(edmx_docs: &'a [Edmx]) -> Result<Self, Error<'a>> {
+        let index = edmx_docs
+            .iter()
+            .flat_map(|v| {
+                v.data_services
+                    .schemas
+                    .iter()
+                    .map(|s| (Namespace::new(&s.namespace), s))
+            })
+            .collect();
+        let (child_map, base_map) = edmx_docs.iter().fold(
+            (
+                HashMap::<QualifiedName<'a>, Vec<QualifiedName<'a>>>::new(),
+                HashMap::<QualifiedName<'a>, QualifiedName<'a>>::new(),
+            ),
+            |maps, doc| {
+                doc.data_services.schemas.iter().fold(maps, |map, s| {
                     let entity_types = s
                         .entity_types
                         .values()
@@ -61,19 +69,25 @@ impl<'a> SchemaIndex<'a> {
                             None
                         }
                     });
-                    entity_types
-                        .chain(complex_types)
-                        .fold(map, |mut map, (name, base)| {
+                    entity_types.chain(complex_types).fold(
+                        map,
+                        |(mut child_map, mut base_map), (name, base)| {
                             let qname = QualifiedName::new(&s.namespace, name.inner());
                             let base_type: QualifiedName = base.into();
-                            map.entry(base_type)
+                            child_map
+                                .entry(base_type)
                                 .and_modify(|e| e.push(qname))
                                 .or_insert_with(|| vec![qname]);
-                            map
-                        })
+                            base_map.insert(qname, base_type);
+                            (child_map, base_map)
+                        },
+                    )
                 })
-            }),
-        }
+            },
+        );
+        find_inheritance_cycle(&base_map).map_or(Ok(Self { index, child_map }), |cycle| {
+            Err(Error::CyclicType(cycle))
+        })
     }
 
     /// Find schema by namespace.
@@ -305,10 +319,136 @@ impl<'a> SchemaIndex<'a> {
     }
 }
 
+/// Find a cycle in the `derived type -> base type` inheritance map.
+///
+/// Every type has at most one base, so the graph can be checked by walking
+/// each inheritance chain. `positions` records where a type first appeared in
+/// the current chain; seeing it again identifies the cyclic suffix. `visited`
+/// contains chains already proven acyclic, preventing repeated work. The walk
+/// is iterative so a deeply nested, valid hierarchy cannot overflow the stack.
+/// Starting types are sorted, and the cycle is rotated to its smallest member,
+/// making the reported path deterministic.
+fn find_inheritance_cycle<'a>(
+    base_map: &HashMap<QualifiedName<'a>, QualifiedName<'a>>,
+) -> Option<Vec<QualifiedName<'a>>> {
+    let mut visited = HashSet::new();
+    let mut starts = base_map.keys().copied().collect::<Vec<_>>();
+    starts.sort_unstable();
+    for start in starts {
+        if visited.contains(&start) {
+            continue;
+        }
+        let mut path = Vec::<QualifiedName<'a>>::new();
+        let mut positions = HashMap::new();
+        let mut current = start;
+        loop {
+            // This chain joined one that was already checked successfully.
+            if visited.contains(&current) {
+                break;
+            }
+            if let Some(position) = positions.get(&current).copied() {
+                let mut cycle = path[position..].to_vec();
+                let canonical_start = cycle
+                    .iter()
+                    .enumerate()
+                    .min_by(|(_, left), (_, right)| left.cmp(right))
+                    .map_or(0, |(index, _)| index);
+                cycle.rotate_left(canonical_start);
+                // Repeat the first cyclic type to return a closed cycle path.
+                if let Some(first) = cycle.first().copied() {
+                    cycle.push(first);
+                }
+                return Some(cycle);
+            }
+            positions.insert(current, path.len());
+            path.push(current);
+            if let Some(base) = base_map.get(&current) {
+                current = *base;
+            } else {
+                break;
+            }
+        }
+        visited.extend(path);
+    }
+    None
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
     use crate::edmx::Edmx;
+
+    fn schema_with_types(types: &str) -> Vec<Edmx> {
+        let schema = format!(
+            r#"<edmx:Edmx Version="4.0">
+                 <edmx:DataServices>
+                   <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Cycle">
+                     {types}
+                   </Schema>
+                 </edmx:DataServices>
+               </edmx:Edmx>"#
+        );
+        vec![Edmx::parse(&schema).expect("cycle test schema must be valid")]
+    }
+
+    fn assert_cycle(result: Result<SchemaIndex<'_>, Error<'_>>, expected: &[&str]) {
+        assert!(matches!(result, Err(Error::CyclicType(_))));
+        if let Err(Error::CyclicType(cycle)) = result {
+            assert_eq!(
+                cycle.iter().map(ToString::to_string).collect::<Vec<_>>(),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_cyclic_entity_type_inheritance() {
+        let schemas = schema_with_types(
+            r#"<EntityType Name="B" BaseType="Cycle.A"/>
+               <EntityType Name="A" BaseType="Cycle.B"/>"#,
+        );
+
+        assert_cycle(
+            SchemaIndex::build(&schemas),
+            &["Cycle.A", "Cycle.B", "Cycle.A"],
+        );
+    }
+
+    #[test]
+    fn rejects_cyclic_complex_type_inheritance() {
+        let schemas = schema_with_types(
+            r#"<ComplexType Name="C" BaseType="Cycle.B"/>
+               <ComplexType Name="B" BaseType="Cycle.C"/>
+               <ComplexType Name="A" BaseType="Cycle.C"/>"#,
+        );
+
+        assert_cycle(
+            SchemaIndex::build(&schemas),
+            &["Cycle.B", "Cycle.C", "Cycle.B"],
+        );
+    }
+
+    #[test]
+    fn rejects_self_inheritance() {
+        let schemas = schema_with_types(r#"<ComplexType Name="A" BaseType="Cycle.A"/>"#);
+
+        assert_cycle(SchemaIndex::build(&schemas), &["Cycle.A", "Cycle.A"]);
+    }
+
+    #[test]
+    fn reports_first_cycle_deterministically() {
+        let schemas = schema_with_types(
+            r#"<EntityType Name="D" BaseType="Cycle.C"/>
+               <EntityType Name="C" BaseType="Cycle.D"/>
+               <EntityType Name="B" BaseType="Cycle.A"/>
+               <EntityType Name="A" BaseType="Cycle.B"/>"#,
+        );
+
+        assert_cycle(
+            SchemaIndex::build(&schemas),
+            &["Cycle.A", "Cycle.B", "Cycle.A"],
+        );
+    }
 
     #[test]
     fn schema_index_test() {
@@ -331,7 +471,7 @@ mod test {
         .collect::<Result<Vec<_>, _>>()
         .unwrap();
 
-        let index = SchemaIndex::build(&schemas);
+        let index = SchemaIndex::build(&schemas).expect("acyclic schemas must be indexed");
         assert!(index
             .get(&Namespace::new(&"Schema.v1_1_0".parse().unwrap()))
             .is_some());


### PR DESCRIPTION
## Summary

Reject cyclic BaseType inheritance while building the schema index. This prevents malformed CSDL from causing a stack overflow or hanging later compiler passes.

## What changed

  - SchemaIndex::build now returns an error when entity or complex type inheritance contains a cycle.
  - Added Error::CyclicType with a deterministic cycle path, for example:

cyclic type inheritance detected: Cycle.A -> Cycle.B -> Cycle.A

  - Propagated the error through compile and compile_all.
  - Added tests for entity cycles, complex type cycles, self-inheritance, multiple cycles, and compile_all error propagation.

## Design choice

The issue is handled at schema-index construction, where the complete inheritance graph is available.

We intentionally did not add duplicate checks to the compiler and optimizer. Those stages only operate on schemas that have already passed index validation, so they can rely on the inheritance graph being acyclic. This also avoids complicating those passes or accidentally treating valid navigation references as inheritance cycles.

## Testing

The nv-redfish-csdl-compiler test suite passes, along with formatting and diff checks.


Fixes: #137 