### PR TITLE
feat(csdl-compiler): map Edm.Double to f64

### DIFF
--- a/csdl-compiler/src/generator/rust/mod.rs
+++ b/csdl-compiler/src/generator/rust/mod.rs
@@ -200,6 +200,8 @@ impl<'a> RustGenerator<'a> {
                 pub type DateTimeOffset = nv_redfish_core::EdmDateTimeOffset;
                 /// Mapping of `Edm.Decimal`
                 pub type Decimal = f64;
+                /// Mapping of `Edm.Double` type
+                pub type Double = f64;
                 /// Mapping of `Edm.Duration` type
                 pub type Duration = nv_redfish_core::EdmDuration;
                 /// Mapping of `Guid` type


### PR DESCRIPTION
Adds the `Edm.Double → f64` alias to the generated `edm` module. NVIDIA port-metrics schemas use `Edm.Double` (bit-error rates); it was the only EDM primitive missing from the hardcoded mapping. Only change to the standard corpus is this one alias.