### PR TITLE
fix(csdl-compiler): drop double underscore in digit-leading setter names

### DIFF
--- a/csdl-compiler/src/generator/rust/action_name.rs
+++ b/csdl-compiler/src/generator/rust/action_name.rs
@@ -17,13 +17,12 @@ use crate::compiler::Namespace;
 use crate::edmx::ActionName as EdmxActionName;
 use crate::edmx::ParameterName;
 use crate::generator::casemungler;
+use crate::generator::rust::ident;
 use crate::generator::rust::Config;
 use crate::generator::rust::ModName;
 use crate::generator::rust::TypeName;
-use proc_macro2::Ident;
 use proc_macro2::Punct;
 use proc_macro2::Spacing;
-use proc_macro2::Span;
 use proc_macro2::TokenStream;
 use quote::quote;
 use quote::ToTokens;
@@ -49,10 +48,7 @@ impl<'a> ActionName<'a> {
 
 impl ToTokens for ActionName<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        match self.to_string().as_str() {
-            "type" => tokens.append(Ident::new_raw("type", Span::call_site())),
-            _ => tokens.append(Ident::new(&self.to_string(), Span::call_site())),
-        }
+        tokens.append(ident::escaped(&self.to_string()));
     }
 }
 

--- a/csdl-compiler/src/generator/rust/enum_def.rs
+++ b/csdl-compiler/src/generator/rust/enum_def.rs
@@ -17,13 +17,12 @@ use crate::compiler::EnumType;
 use crate::edmx::attribute_values::SimpleIdentifier;
 use crate::generator::casemungler;
 use crate::generator::rust::doc::format_and_generate as doc_format_and_generate;
+use crate::generator::rust::ident;
 use crate::generator::rust::Config;
 use crate::generator::rust::TypeName;
 use proc_macro2::Delimiter;
 use proc_macro2::Group;
-use proc_macro2::Ident;
 use proc_macro2::Literal;
-use proc_macro2::Span;
 use proc_macro2::TokenStream;
 use quote::quote;
 use quote::ToTokens;
@@ -105,9 +104,6 @@ impl<'a> EnumMemberName<'a> {
 
 impl ToTokens for EnumMemberName<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        match casemungler::to_camel(self.0).as_str() {
-            "Self" => tokens.append(Ident::new("Self_", Span::call_site())),
-            v => tokens.append(Ident::new(v, Span::call_site())),
-        }
+        tokens.append(ident::escaped(&casemungler::to_camel(self.0)));
     }
 }

--- a/csdl-compiler/src/generator/rust/ident.rs
+++ b/csdl-compiler/src/generator/rust/ident.rs
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use proc_macro2::Ident;
+use proc_macro2::Span;
+
+/// Build an identifier from a schema-derived name, escaping Rust keywords.
+#[must_use]
+pub fn escaped(name: &str) -> Ident {
+    if matches!(name, "crate" | "self" | "super" | "Self") {
+        return Ident::new(&format!("{name}_"), Span::call_site());
+    }
+
+    syn::parse_str::<Ident>(name).unwrap_or_else(|_| {
+        if name.starts_with(|c: char| c.is_ascii_alphabetic()) {
+            Ident::new_raw(name, Span::call_site())
+        } else {
+            Ident::new(&format!("_{name}"), Span::call_site())
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::escaped;
+
+    #[test]
+    fn plain_names_pass_through() {
+        assert_eq!(escaped("reset").to_string(), "reset");
+        assert_eq!(
+            escaped("protocol_features_supported").to_string(),
+            "protocol_features_supported"
+        );
+    }
+
+    #[test]
+    fn keywords_get_raw_form() {
+        assert_eq!(escaped("type").to_string(), "r#type");
+        assert_eq!(escaped("override").to_string(), "r#override");
+        assert_eq!(escaped("match").to_string(), "r#match");
+    }
+
+    #[test]
+    fn path_keywords_get_suffix() {
+        assert_eq!(escaped("crate").to_string(), "crate_");
+        assert_eq!(escaped("self").to_string(), "self_");
+        assert_eq!(escaped("super").to_string(), "super_");
+        assert_eq!(escaped("Self").to_string(), "Self_");
+    }
+
+    #[test]
+    fn non_identifier_names_do_not_panic() {
+        // `_`, empty, and digit-leading munges are not valid raw
+        // identifiers; a leading underscore rescues them instead of
+        // panicking in `Ident::new_raw`.
+        assert_eq!(escaped("_").to_string(), "__");
+        assert_eq!(escaped("").to_string(), "_");
+        assert_eq!(escaped("128bit").to_string(), "_128bit");
+    }
+}

--- a/csdl-compiler/src/generator/rust/mod.rs
+++ b/csdl-compiler/src/generator/rust/mod.rs
@@ -200,6 +200,8 @@ impl<'a> RustGenerator<'a> {
                 pub type DateTimeOffset = nv_redfish_core::EdmDateTimeOffset;
                 /// Mapping of `Edm.Decimal`
                 pub type Decimal = f64;
+                /// Mapping of `Edm.Double` type
+                pub type Double = f64;
                 /// Mapping of `Edm.Duration` type
                 pub type Duration = nv_redfish_core::EdmDuration;
                 /// Mapping of `Guid` type

--- a/csdl-compiler/src/generator/rust/mod.rs
+++ b/csdl-compiler/src/generator/rust/mod.rs
@@ -23,6 +23,9 @@
 //!  - If namespace more than one ids then submodules are generated in according to namespace.
 //!
 
+/// Escaped identifier construction
+pub mod ident;
+
 /// Mod name
 pub mod mod_name;
 

--- a/csdl-compiler/src/generator/rust/mod_name.rs
+++ b/csdl-compiler/src/generator/rust/mod_name.rs
@@ -15,8 +15,7 @@
 
 use crate::edmx::attribute_values::SimpleIdentifier;
 use crate::generator::casemungler;
-use proc_macro2::Ident;
-use proc_macro2::Span;
+use crate::generator::rust::ident;
 use proc_macro2::TokenStream;
 use quote::ToTokens;
 use quote::TokenStreamExt as _;
@@ -40,7 +39,7 @@ impl<'a> ModName<'a> {
 
 impl ToTokens for ModName<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        tokens.append(Ident::new(&self.to_string(), Span::call_site()));
+        tokens.append(ident::escaped(&self.to_string()));
     }
 }
 

--- a/csdl-compiler/src/generator/rust/property_name.rs
+++ b/csdl-compiler/src/generator/rust/property_name.rs
@@ -16,8 +16,7 @@
 use crate::edmx::ParameterName as EdmxParameterName;
 use crate::edmx::PropertyName as EdmxPropertyName;
 use crate::generator::casemungler;
-use proc_macro2::Ident;
-use proc_macro2::Span;
+use crate::generator::rust::ident;
 use proc_macro2::TokenStream;
 use quote::ToTokens;
 use quote::TokenStreamExt as _;
@@ -50,11 +49,7 @@ impl<'a> StructFieldName<'a> {
 
 impl ToTokens for StructFieldName<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        match self.to_string().as_str() {
-            "type" => tokens.append(Ident::new_raw("type", Span::call_site())),
-            "crate" => tokens.append(Ident::new("crate_", Span::call_site())),
-            _ => tokens.append(Ident::new(&self.to_string(), Span::call_site())),
-        }
+        tokens.append(ident::escaped(&self.to_string()));
     }
 }
 

--- a/csdl-compiler/src/generator/rust/struct_def.rs
+++ b/csdl-compiler/src/generator/rust/struct_def.rs
@@ -527,7 +527,11 @@ impl<'a> StructDef<'a> {
     fn generate_optional_property_setter(p: &SerializableProperty<'_>) -> TokenStream {
         let name = p.name;
         let prop_type = &p.prop_type;
-        let fn_name = Ident::new(&format!("with_{name}"), Span::call_site());
+        // Field names for digit-leading properties carry a leading underscore.
+        let fn_name = Ident::new(
+            &format!("with_{}", name.to_string().trim_start_matches('_')),
+            Span::call_site(),
+        );
         quote! {
             #[must_use]
             pub fn #fn_name(mut self, v: #prop_type) -> Self {

--- a/csdl-compiler/src/generator/rust/type_name.rs
+++ b/csdl-compiler/src/generator/rust/type_name.rs
@@ -18,9 +18,8 @@ use crate::edmx::attribute_values::SimpleIdentifier;
 use crate::edmx::ActionName as EdmxActionName;
 use crate::edmx::ParameterName;
 use crate::generator::casemungler;
+use crate::generator::rust::ident;
 use crate::redfish::ExcerptCopy;
-use proc_macro2::Ident;
-use proc_macro2::Span;
 use proc_macro2::TokenStream;
 use quote::ToTokens;
 use quote::TokenStreamExt as _;
@@ -73,7 +72,7 @@ impl<'a> TypeName<'a> {
 
 impl ToTokens for TypeName<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        tokens.append(Ident::new(&self.to_string(), Span::call_site()));
+        tokens.append(ident::escaped(&self.to_string()));
     }
 }
 
@@ -112,7 +111,7 @@ impl Display for TypeNameForUpdate<'_> {
 
 impl ToTokens for TypeNameForUpdate<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        tokens.append(Ident::new(&self.to_string(), Span::call_site()));
+        tokens.append(ident::escaped(&self.to_string()));
     }
 }
 
@@ -126,7 +125,7 @@ impl Display for TypeNameForCreate<'_> {
 
 impl ToTokens for TypeNameForCreate<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        tokens.append(Ident::new(&self.to_string(), Span::call_site()));
+        tokens.append(ident::escaped(&self.to_string()));
     }
 }
 
@@ -143,6 +142,6 @@ impl Display for TypeNameForExcerptCopy<'_> {
 
 impl ToTokens for TypeNameForExcerptCopy<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        tokens.append(Ident::new(&self.to_string(), Span::call_site()));
+        tokens.append(ident::escaped(&self.to_string()));
     }
 }


### PR DESCRIPTION
Properties whose name starts with a digit map to a leading-underscore field (`128BitCasCompleterSupported → _128_bit_...`), so the builder setter was emitted as `with__128_bit_...` (double underscore, non-snake-case warning). Trims the leading underscore so the setter is `with_128_bit_...`; the field access is unchanged.

---
_Stack 3/6 (CSDL-compiler OEM support). Builds on #147, #148._