### PR TITLE
refactor(csdl-compiler): extract serializable property generation

### DIFF
--- a/csdl-compiler/src/generator/rust/mod.rs
+++ b/csdl-compiler/src/generator/rust/mod.rs
@@ -59,6 +59,9 @@ pub mod type_def;
 /// Enum definitions
 pub mod enum_def;
 
+/// Generation helpers for properties in create and update request structures.
+pub mod serializable_properties;
+
 use crate::compiler::Compiled;
 use crate::compiler::ForcedUpdate;
 use crate::compiler::IsCreatable;
@@ -85,6 +88,8 @@ pub use mod_def::ModDef;
 pub use mod_name::ModName;
 #[doc(inline)]
 pub use property_name::StructFieldName;
+#[doc(inline)]
+pub use serializable_properties::SerializableProperties;
 #[doc(inline)]
 pub use struct_def::StructDef;
 #[doc(inline)]

--- a/csdl-compiler/src/generator/rust/serializable_properties.rs
+++ b/csdl-compiler/src/generator/rust/serializable_properties.rs
@@ -1,0 +1,273 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::compiler::Properties;
+use crate::generator::rust::Config;
+use crate::generator::rust::FullTypeName;
+use crate::generator::rust::StructFieldName;
+use crate::odata::annotations::Permissions;
+use crate::OneOrCollection;
+use proc_macro2::Ident;
+use proc_macro2::Literal;
+use proc_macro2::Span;
+use proc_macro2::TokenStream;
+use quote::quote;
+
+/// A compiled property that can be emitted in a create or update request structure.
+struct SerializableProperty<'a> {
+    /// The Redfish property name used by serde on the wire.
+    rename: Literal,
+    /// The generated Rust field name.
+    name: StructFieldName<'a>,
+    /// The generated Rust type, excluding any request-specific optional wrapper.
+    prop_type: TokenStream,
+    /// Whether the property is a required argument when constructing a create request.
+    required_on_create: bool,
+    /// Whether the property may be written but not read.
+    write_only: bool,
+}
+
+/// Properties selected for serialization in generated create and update request structures.
+pub struct SerializableProperties<'a>(Vec<SerializableProperty<'a>>);
+
+trait IntoTokenStream {
+    fn into_token_stream(self) -> TokenStream;
+}
+
+impl<I: Iterator<Item = TokenStream>> IntoTokenStream for I {
+    fn into_token_stream(self) -> TokenStream {
+        let mut stream = TokenStream::new();
+        stream.extend(self);
+        stream
+    }
+}
+
+impl<'a> SerializableProperties<'a> {
+    /// Selects properties that are required on create or writable
+    /// according to their Redfish and `OData` annotations, and
+    /// computes their generated Rust names and types.
+    #[must_use]
+    pub fn new(properties: &Properties<'a>, config: &Config) -> Self {
+        Self(
+            properties
+                .properties
+                .iter()
+                .filter_map(|p| {
+                    let (typeinfo, v) = &p.ptype.inner();
+                    if !(p.redfish.is_required_on_create.into_inner()
+                        || (p.odata.permissions_is_write()
+                            && typeinfo.permissions.is_none_or(|p| p != Permissions::Read)))
+                    {
+                        return None;
+                    }
+
+                    let full_type = FullTypeName::new(*v, config).for_update(Some(typeinfo.class));
+                    let prop_type = match p.ptype {
+                        OneOrCollection::One(_) => quote! { #full_type },
+                        OneOrCollection::Collection(_) => {
+                            if p.rigid_array_support.into_inner() {
+                                quote! { Vec<Option<#full_type>> }
+                            } else {
+                                quote! { Vec<#full_type> }
+                            }
+                        }
+                    };
+                    Some(SerializableProperty {
+                        rename: Literal::string(p.name.inner().inner()),
+                        name: StructFieldName::new_property(p.name),
+                        prop_type,
+                        required_on_create: p.redfish.is_required_on_create.into_inner(),
+                        write_only: p.odata.permissions_is_write_only(),
+                    })
+                })
+                .collect(),
+        )
+    }
+
+    /// Generates the field declarations for an update request structure.
+    ///
+    /// Every field is optional and omitted from the serialized request when it is not set.
+    #[must_use]
+    pub fn struct_content_for_update(&self) -> TokenStream {
+        self.0
+            .iter()
+            .map(|p| {
+                let rename = &p.rename;
+                let name = p.name;
+                let prop_type = &p.prop_type;
+                quote! {
+                    #[serde(rename=#rename)]
+                    #[serde(skip_serializing_if = "Option::is_none")]
+                    pub #name: Option<#prop_type>,
+                }
+            })
+            .into_token_stream()
+    }
+
+    /// Generates the field declarations for a create request structure.
+    ///
+    /// Properties required on create are emitted directly; all other fields are optional and
+    /// omitted from the serialized request when they are not set.
+    #[must_use]
+    pub fn struct_content_for_create(&self) -> TokenStream {
+        self.0
+            .iter()
+            .map(|p| {
+                let rename = &p.rename;
+                let name = p.name;
+                let prop_type = &p.prop_type;
+                if p.required_on_create {
+                    quote! {
+                        #[serde(rename=#rename)]
+                        pub #name: #prop_type,
+                    }
+                } else {
+                    quote! {
+                        #[serde(rename=#rename)]
+                        #[serde(skip_serializing_if = "Option::is_none")]
+                        pub #name: Option<#prop_type>,
+                    }
+                }
+            })
+            .into_token_stream()
+    }
+
+    /// Generates builder setters for create-request properties that are not required on create.
+    #[must_use]
+    pub fn optional_property_setter_for_create(&self) -> TokenStream {
+        self.0
+            .iter()
+            .filter_map(|p| {
+                if p.required_on_create {
+                    None
+                } else {
+                    Some(Self::generate_optional_property_setter(p))
+                }
+            })
+            .into_token_stream()
+    }
+
+    /// Generates builder setters for every update-request property.
+    #[must_use]
+    pub fn optional_property_setter_for_update(&self) -> TokenStream {
+        self.0
+            .iter()
+            .map(Self::generate_optional_property_setter)
+            .into_token_stream()
+    }
+
+    /// Returns whether any selected property is write-only and therefore potentially sensitive.
+    #[must_use]
+    pub fn can_contain_sensitive_info(&self) -> bool {
+        self.0.iter().any(|p| p.write_only)
+    }
+
+    /// Generates `DebugStruct::field` calls for a create request.
+    ///
+    /// Write-only values are replaced with a redaction marker. For optional write-only fields,
+    /// the generated output preserves whether the field was set without exposing its value.
+    #[must_use]
+    pub fn debug_print_fields_for_create(&self) -> TokenStream {
+        self.0
+            .iter()
+            .map(|p| {
+                let name = p.name;
+                let debug_name = Literal::string(&name.to_string());
+                if p.write_only {
+                    if p.required_on_create {
+                        quote! { .field(#debug_name, &"<redacted>") }
+                    } else {
+                        quote! { .field(#debug_name, &self.#name.as_ref().map(|_| "<redacted>")) }
+                    }
+                } else {
+                    quote! { .field(#debug_name, &self.#name) }
+                }
+            })
+            .into_token_stream()
+    }
+
+    /// Generates `DebugStruct::field` calls for an update request.
+    ///
+    /// Write-only values are replaced with a redaction marker while preserving whether each
+    /// optional field was set.
+    #[must_use]
+    pub fn debug_print_fields_for_update(&self) -> TokenStream {
+        self.0
+            .iter()
+            .map(|p| {
+                let name = p.name;
+                let debug_name = Literal::string(&name.to_string());
+                if p.write_only {
+                    quote! { .field(#debug_name, &self.#name.as_ref().map(|_| "<redacted>")) }
+                } else {
+                    quote! { .field(#debug_name, &self.#name) }
+                }
+            })
+            .into_token_stream()
+    }
+
+    /// Generates the required-property arguments for a create request's `builder` function.
+    #[must_use]
+    pub fn builder_fn_arg_list_for_create(&self) -> TokenStream {
+        self.0
+            .iter()
+            .filter_map(|p| {
+                let name = p.name;
+                let prop_type = &p.prop_type;
+                if p.required_on_create {
+                    Some(quote! {#name: #prop_type,})
+                } else {
+                    None
+                }
+            })
+            .into_token_stream()
+    }
+
+    /// Generates the field initializers for a create request's `builder` function.
+    ///
+    /// Required properties are initialized from arguments and optional properties are initialized
+    /// to `None`.
+    #[must_use]
+    pub fn builder_fn_content_for_create(&self) -> TokenStream {
+        self.0
+            .iter()
+            .map(|p| {
+                let name = p.name;
+                if p.required_on_create {
+                    quote! { #name, }
+                } else {
+                    quote! { #name: None, }
+                }
+            })
+            .into_token_stream()
+    }
+
+    fn generate_optional_property_setter(p: &SerializableProperty<'a>) -> TokenStream {
+        let name = p.name;
+        let prop_type = &p.prop_type;
+        // Field names for digit-leading properties carry a leading underscore.
+        let fn_name = Ident::new(
+            &format!("with_{}", name.to_string().trim_start_matches('_')),
+            Span::call_site(),
+        );
+        quote! {
+            #[must_use]
+            pub fn #fn_name(mut self, v: #prop_type) -> Self {
+                self.#name = Some(v);
+                self
+            }
+        }
+    }
+}

--- a/csdl-compiler/src/generator/rust/struct_def.rs
+++ b/csdl-compiler/src/generator/rust/struct_def.rs
@@ -30,6 +30,7 @@ use crate::generator::rust::ActionName;
 use crate::generator::rust::Config;
 use crate::generator::rust::Error;
 use crate::generator::rust::FullTypeName;
+use crate::generator::rust::SerializableProperties;
 use crate::generator::rust::StructFieldName;
 use crate::generator::rust::TypeName;
 use crate::odata::annotations::Permissions;
@@ -87,14 +88,6 @@ enum ImplType {
 enum SerializableStructKind {
     Create,
     Update,
-}
-
-struct SerializableProperty<'a> {
-    rename: Literal,
-    name: StructFieldName<'a>,
-    prop_type: TokenStream,
-    required_on_create: bool,
-    write_only: bool,
 }
 
 // Action request fields are generated as two coordinated token streams. Keeping
@@ -365,7 +358,7 @@ impl<'a> StructDef<'a> {
             },
         );
 
-        let properties = self.serializable_properties(config);
+        let properties = SerializableProperties::new(&self.properties, config);
 
         let has_additional_properties =
             self.odata.additional_properties.is_some_and(|v| *v.inner());
@@ -382,18 +375,7 @@ impl<'a> StructDef<'a> {
             TokenStream::new()
         };
 
-        let properties_content = properties.iter().map(|p| {
-            let rename = &p.rename;
-            let name = p.name;
-            let prop_type = &p.prop_type;
-            quote! {
-                #[serde(rename=#rename)]
-                #[serde(skip_serializing_if = "Option::is_none")]
-                pub #name: Option<#prop_type>,
-            }
-        });
-        let mut content = TokenStream::new();
-        content.extend(properties_content);
+        let content = properties.struct_content_for_update();
         let comment = format!(" Update struct corresponding to `{}`", self.name);
         let name = self.name.for_update(None);
         let (debug_derive, debug_impl) = Self::debug_serializable(
@@ -410,11 +392,7 @@ impl<'a> StructDef<'a> {
             pub struct #name { #base #content #additional_properties }
         });
 
-        let properties_impl = properties
-            .iter()
-            .map(Self::generate_optional_property_setter);
-        let mut content = TokenStream::new();
-        content.extend(properties_impl);
+        let content = properties.optional_property_setter_for_update();
 
         // Generate builder for struct.
         tokens.extend(quote! {
@@ -435,28 +413,9 @@ impl<'a> StructDef<'a> {
     }
 
     fn generate_create(&self, tokens: &mut TokenStream, config: &Config) {
-        let properties = self.serializable_properties(config);
+        let properties = SerializableProperties::new(&self.properties, config);
 
-        let properties_content = properties.iter().map(|p| {
-            let rename = &p.rename;
-            let name = p.name;
-            let prop_type = &p.prop_type;
-            if p.required_on_create {
-                quote! {
-                    #[serde(rename=#rename)]
-                    pub #name: #prop_type,
-                }
-            } else {
-                quote! {
-                    #[serde(rename=#rename)]
-                    #[serde(skip_serializing_if = "Option::is_none")]
-                    pub #name: Option<#prop_type>,
-                }
-            }
-        });
-
-        let mut content = TokenStream::new();
-        content.extend(properties_content);
+        let content = properties.struct_content_for_create();
         let comment = format!(" Create struct corresponding to `{}`", self.name);
         let name = self.name.for_create();
         let (debug_derive, debug_impl) = Self::debug_serializable(
@@ -473,38 +432,17 @@ impl<'a> StructDef<'a> {
             pub struct #name { #content }
         }]);
 
+        let prop_fn_content = properties.optional_property_setter_for_create();
         // Implement builder for create struct:
-        let (builder_fn_arglist, builder_fn_impl) = properties.iter().fold(
-            (TokenStream::new(), TokenStream::new()),
-            |(mut arglist, mut implcontent), p| {
-                let name = p.name;
-                let prop_type = &p.prop_type;
-                if p.required_on_create {
-                    arglist.extend(quote! {#name: #prop_type,});
-                    implcontent.extend(quote! { #name, });
-                } else {
-                    implcontent.extend(quote! { #name: None, });
-                }
-                (arglist, implcontent)
-            },
-        );
-
-        let prop_fn_impl = properties.iter().filter_map(|p| {
-            if p.required_on_create {
-                None
-            } else {
-                Some(Self::generate_optional_property_setter(p))
-            }
-        });
-        let mut prop_fn_content = TokenStream::new();
-        prop_fn_content.extend(prop_fn_impl);
+        let builder_fn_arglist = properties.builder_fn_arg_list_for_create();
+        let builder_fn_content = properties.builder_fn_content_for_create();
 
         tokens.extend([quote! {
             impl #name {
                 #[must_use]
                 pub fn builder(#builder_fn_arglist) -> Self {
                     Self {
-                        #builder_fn_impl
+                        #builder_fn_content
                     }
                 }
                 #[must_use]
@@ -517,67 +455,27 @@ impl<'a> StructDef<'a> {
         }]);
     }
 
-    fn serializable_properties(&self, config: &Config) -> Vec<SerializableProperty<'a>> {
-        self.properties
-            .properties
-            .iter()
-            .filter_map(|p| {
-                let (typeinfo, v) = &p.ptype.inner();
-                if !(p.redfish.is_required_on_create.into_inner()
-                    || (p.odata.permissions_is_write()
-                        && typeinfo.permissions.is_none_or(|p| p != Permissions::Read)))
-                {
-                    return None;
-                }
-
-                let full_type = FullTypeName::new(*v, config).for_update(Some(typeinfo.class));
-                let prop_type = match p.ptype {
-                    OneOrCollection::One(_) => quote! { #full_type },
-                    OneOrCollection::Collection(_) => {
-                        if p.rigid_array_support.into_inner() {
-                            quote! { Vec<Option<#full_type>> }
-                        } else {
-                            quote! { Vec<#full_type> }
-                        }
-                    }
-                };
-                Some(SerializableProperty {
-                    rename: Literal::string(p.name.inner().inner()),
-                    name: StructFieldName::new_property(p.name),
-                    prop_type,
-                    required_on_create: p.redfish.is_required_on_create.into_inner(),
-                    write_only: p.odata.permissions_is_write_only(),
-                })
-            })
-            .collect()
-    }
-
     fn debug_serializable<N: ToTokens>(
         name: N,
-        properties: &[SerializableProperty<'a>],
+        properties: &SerializableProperties<'a>,
         kind: SerializableStructKind,
         has_base: bool,
         has_additional_properties: bool,
     ) -> (TokenStream, TokenStream) {
-        if properties.iter().any(|p| p.write_only) || has_additional_properties {
+        // Additional properties contain arbitrary request values and have no schema metadata that
+        // can identify sensitive entries, so always use a redacting Debug implementation for them.
+        if properties.can_contain_sensitive_info() || has_additional_properties {
             let mut fields = TokenStream::new();
-            for p in properties {
-                let name = p.name;
-                let debug_name = Literal::string(&name.to_string());
-                if p.write_only {
-                    let optional =
-                        matches!(kind, SerializableStructKind::Update) || !p.required_on_create;
-                    if optional {
-                        // Preserve whether an optional value was supplied while replacing the
-                        // sensitive value itself with a redaction marker.
-                        fields.extend(quote! {
-                            .field(#debug_name, &self.#name.as_ref().map(|_| "<redacted>"))
-                        });
-                    } else {
-                        fields.extend(quote! { .field(#debug_name, &"<redacted>") });
-                    }
-                } else {
-                    fields.extend(quote! { .field(#debug_name, &self.#name) });
+            match kind {
+                SerializableStructKind::Update => {
+                    properties
+                        .debug_print_fields_for_update()
+                        .to_tokens(&mut fields);
+                }
+                SerializableStructKind::Create => {
+                    properties
+                        .debug_print_fields_for_create()
+                        .to_tokens(&mut fields);
                 }
             }
             let base = has_base.then(|| quote! { .field("base", &self.base) });
@@ -601,23 +499,6 @@ impl<'a> StructDef<'a> {
             )
         } else {
             (quote! { #[derive(Debug)] }, quote! {})
-        }
-    }
-
-    fn generate_optional_property_setter(p: &SerializableProperty<'_>) -> TokenStream {
-        let name = p.name;
-        let prop_type = &p.prop_type;
-        // Field names for digit-leading properties carry a leading underscore.
-        let fn_name = Ident::new(
-            &format!("with_{}", name.to_string().trim_start_matches('_')),
-            Span::call_site(),
-        );
-        quote! {
-            #[must_use]
-            pub fn #fn_name(mut self, v: #prop_type) -> Self {
-                self.#name = Some(v);
-                self
-            }
         }
     }
 


### PR DESCRIPTION
Move create and update property token generation into a dedicated helper. Centralize builder fields, setters, and sensitive Debug redaction while preserving generated request behavior.