### PR TITLE
chore: fix deprecation warning in SseStream

### DIFF
--- a/bmc-http/src/reqwest.rs
+++ b/bmc-http/src/reqwest.rs
@@ -1082,7 +1082,7 @@ impl HttpClient for Client {
             });
         }
 
-        let stream = sse_stream::SseStream::from_byte_stream(response.bytes_stream()).filter_map(
+        let stream = sse_stream::SseStream::from_bytes_stream(response.bytes_stream()).filter_map(
             |event| async move {
                 match event {
                     Err(err) => Some(Err(BmcError::SseStreamError(err))),


### PR DESCRIPTION
SseStream error:
```
    #[deprecated(
        since = "0.2.4",
        note = "It's a typo, use `from_bytes_stream` instead. This method will be removed in 0.3.0"
    )]
```