### PR TITLE
fix(dispatcher): exclude repo-only package targets

### DIFF
--- a/dispatcher/Cargo.toml
+++ b/dispatcher/Cargo.toml
@@ -20,6 +20,12 @@ version.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true
+# These repository-only tests and benchmarks depend on the unpublished
+# simulation helper crate.
+exclude = [
+    "benches/**",
+    "tests/**",
+]
 edition.workspace = true
 keywords.workspace = true
 categories.workspace = true


### PR DESCRIPTION
## Why

`nv-redfish-dispatcher` packaged tests and benches referenced the unpublished `nv-redfish-dispatcher-sim` helper.