### PR TITLE
fix(quirks): enable missing-ChassisType/Name workaround for Supermicro

### DIFF
--- a/redfish/src/bmc_quirks.rs
+++ b/redfish/src/bmc_quirks.rs
@@ -37,6 +37,7 @@ enum Platform {
     NvidiaDpu,
     Anonymous1_9_0,
     NvSwitch,
+    Supermicro,
 }
 
 impl BmcQuirks {
@@ -63,6 +64,7 @@ impl BmcQuirks {
             Some("NVIDIA") if product_str == Some("P3809") => Some(Platform::NvSwitch),
             Some("NVIDIA") => Some(Platform::Nvidia),
             Some("Nvidia") if product_str == Some("Nvidia-BMCMezz") => Some(Platform::NvidiaDpu),
+            Some("Supermicro") => Some(Platform::Supermicro),
             None if redfish_version_str == Some("1.9.0") => Some(Platform::Anonymous1_9_0),
             _ => None,
         };
@@ -130,15 +132,21 @@ impl BmcQuirks {
     /// property is Required in according to specification but some
     /// systems doesn't provide it.
     #[cfg(feature = "chassis")]
-    pub(crate) fn bug_missing_chassis_type_field(&self) -> bool {
-        self.platform == Some(Platform::AmiViking)
+    pub(crate) const fn bug_missing_chassis_type_field(&self) -> bool {
+        matches!(
+            self.platform,
+            Some(Platform::AmiViking | Platform::Supermicro)
+        )
     }
 
     /// Missing Name property in Chassis resource. This property is
     /// required in any resource.
     #[cfg(feature = "chassis")]
-    pub(crate) fn bug_missing_chassis_name_field(&self) -> bool {
-        self.platform == Some(Platform::AmiViking)
+    pub(crate) const fn bug_missing_chassis_name_field(&self) -> bool {
+        matches!(
+            self.platform,
+            Some(Platform::AmiViking | Platform::Supermicro)
+        )
     }
 
     /// NVIDIA DPU sometimes returns empty string UUID in

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -96,6 +96,31 @@ pub fn ami_viking_service_root(root_id: &ODataId, fields: Value) -> Value {
     json_merge([&base, &fields])
 }
 
+/// Build a ServiceRoot payload for Supermicro (`Vendor=Supermicro`) merged with
+/// the provided `fields`. Supermicro host BMCs are the platform behind the
+/// missing-`ChassisType` chassis workaround.
+pub fn supermicro_service_root(root_id: &ODataId, fields: Value) -> Value {
+    let base = json!({
+        ODATA_ID: root_id,
+        ODATA_TYPE: "#ServiceRoot.v1_13_0.ServiceRoot",
+        "Id": "RootService",
+        "Name": "RootService",
+        "ProtocolFeaturesSupported": {
+            "ExpandQuery": {
+                "NoLinks": true
+            }
+        },
+        "Vendor": "Supermicro",
+        "RedfishVersion": "1.17.0",
+        "Links": {
+            "Sessions": {
+                ODATA_ID: format!("{root_id}/SessionService/Sessions"),
+            }
+        },
+    });
+    json_merge([&base, &fields])
+}
+
 /// Build an AMI ServiceRoot payload (`Vendor=AMI`) with the given
 /// `RedfishVersion` and optional AMI OEM `RtpVersion`, merged with `fields`.
 ///

--- a/tests/tests/test-chassis.rs
+++ b/tests/tests/test-chassis.rs
@@ -31,6 +31,7 @@ use nv_redfish_tests::expect_redfish_reset_action;
 use nv_redfish_tests::json_merge;
 use nv_redfish_tests::redfish_action_payload;
 use nv_redfish_tests::redfish_empty_actions_payload;
+use nv_redfish_tests::supermicro_service_root;
 use nv_redfish_tests::Bmc;
 use nv_redfish_tests::Expect;
 use nv_redfish_tests::ODATA_ID;
@@ -352,6 +353,79 @@ async fn ami_viking_missing_chassis_name_workaround() -> Result<(), Box<dyn StdE
 }
 
 #[test]
+async fn supermicro_missing_chassis_type_workaround() -> Result<(), Box<dyn StdError>> {
+    let bmc = Arc::new(Bmc::default());
+    let ids = ids();
+    let root = expect_supermicro_service_root(
+        bmc.clone(),
+        &ids,
+        json!({
+            "Chassis": { ODATA_ID: &ids.chassis_collection_id }
+        }),
+    )
+    .await?;
+    // Supermicro keeps `$expand`, so the collection is fetched with the member
+    // inline. A SmartNIC chassis omits the Redfish-required `ChassisType`; the
+    // workaround injects a default so the member still deserializes.
+    bmc.expect(Expect::expand(
+        &ids.chassis_collection_id,
+        json!({
+            ODATA_ID: &ids.chassis_collection_id,
+            ODATA_TYPE: CHASSIS_COLLECTION_DATA_TYPE,
+            "Id": "Chassis",
+            "Name": "Chassis Collection",
+            "Members": [{
+                ODATA_ID: &ids.chassis_id,
+                ODATA_TYPE: CHASSIS_DATA_TYPE,
+                "Id": "1",
+                "Name": "Chassis"
+            }]
+        }),
+    ));
+
+    let collection = root.chassis().await?.unwrap();
+    let members = collection.members().await?;
+    assert_eq!(members.len(), 1);
+
+    Ok(())
+}
+
+#[test]
+async fn supermicro_missing_chassis_name_workaround() -> Result<(), Box<dyn StdError>> {
+    let bmc = Arc::new(Bmc::default());
+    let ids = ids();
+    let root = expect_supermicro_service_root(
+        bmc.clone(),
+        &ids,
+        json!({
+            "Chassis": { ODATA_ID: &ids.chassis_collection_id }
+        }),
+    )
+    .await?;
+    bmc.expect(Expect::expand(
+        &ids.chassis_collection_id,
+        json!({
+            ODATA_ID: &ids.chassis_collection_id,
+            ODATA_TYPE: CHASSIS_COLLECTION_DATA_TYPE,
+            "Id": "Chassis",
+            "Name": "Chassis Collection",
+            "Members": [{
+                ODATA_ID: &ids.chassis_id,
+                ODATA_TYPE: CHASSIS_DATA_TYPE,
+                "Id": "1",
+                "ChassisType": "RackMount"
+            }]
+        }),
+    ));
+
+    let collection = root.chassis().await?.unwrap();
+    let members = collection.members().await?;
+    assert_eq!(members.len(), 1);
+
+    Ok(())
+}
+
+#[test]
 async fn ami_gb300_disables_expand_for_chassis_collection() -> Result<(), Box<dyn StdError>> {
     // Platform under test: Grace-based NVIDIA GB300 host BMC (AMI, RtpVersion 13.09.1).
     // Quirk under test: its `$expand` drops Required fields (Id/Name/ChassisType)
@@ -607,6 +681,18 @@ async fn expect_viking_service_root(
     bmc.expect(Expect::get(
         &ids.root_id,
         ami_viking_service_root(&ids.root_id, fields),
+    ));
+    ServiceRoot::new(bmc).await.map_err(Into::into)
+}
+
+async fn expect_supermicro_service_root(
+    bmc: Arc<Bmc>,
+    ids: &Ids,
+    fields: Value,
+) -> Result<ServiceRoot<Bmc>, Box<dyn StdError>> {
+    bmc.expect(Expect::get(
+        &ids.root_id,
+        supermicro_service_root(&ids.root_id, fields),
     ));
     ServiceRoot::new(bmc).await.map_err(Into::into)
 }


### PR DESCRIPTION
## Summary
Supermicro host BMCs expose chassis (e.g. a `SmartNIC` chassis) that omit the Redfish-**Required** `ChassisType` (and `Name`) fields, which fails chassis deserialization in consumers. This classifies `Vendor=Supermicro` as a platform and enables the existing `bug_missing_chassis_type_field` / `bug_missing_chassis_name_field` workarounds for it — the patch injects a default only when the field is absent (`entry().or_insert()`), so it's a no-op for compliant Supermicro chassis.

Reported downstream in NVIDIA/infra-controller#3715.

## Changes
- `bmc_quirks.rs`: add `Platform::Supermicro` (detected via service-root `Vendor == "Supermicro"`) and enable the two chassis workarounds for it.
- Tests: `supermicro_missing_chassis_type_workaround` and `supermicro_missing_chassis_name_workaround`, plus a `supermicro_service_root` helper.

## Notes for review
- I enabled the `Name` workaround alongside `ChassisType`: the reported `SmartNIC` chassis omitted every field, and `Name` is likewise Required, so ChassisType alone would just move the error to `missing field Name`. Mirrors the AmiViking precedent. Happy to drop it to ChassisType-only if preferred.
- Detection is `Vendor == "Supermicro"` (all Supermicro BMCs). Can narrow to a specific product/version if that's preferred — but the patch is harmless for compliant chassis.

## Testing
- `cargo test -p nv-redfish-tests` — all green (17/17 chassis tests).
- `cargo clippy -p nv-redfish --features chassis --all-targets` — clean. 