### PR TITLE
fix: Adding a event size cap and stream timeout to prevent compromised BMC…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ categories = ["hardware-support"]
 clap = { version = "4.5" }
 clap_derive = { version = "4.5" }
 sse-stream = { version = "0.2.1" }
+bytes = { version = "1" }
 futures-util = { version = "0.3" }
 futures-core = { version = "0.3" }
 futures-io = { version = "0.3" }

--- a/bmc-http/Cargo.toml
+++ b/bmc-http/Cargo.toml
@@ -14,10 +14,11 @@ documentation = "https://docs.rs/nv-redfish-bmc-http"
 default = ["reqwest"]
 
 # HTTP client implementations with reqwest
-reqwest = ["dep:reqwest", "dep:serde_path_to_error", "dep:futures-util", "dep:sse-stream", "dep:tokio-util", "dep:tokio"]
+reqwest = ["dep:reqwest", "dep:serde_path_to_error", "dep:futures-util", "dep:sse-stream", "dep:tokio-util", "dep:tokio", "dep:bytes"]
 update-service-deprecated = ["nv-redfish-core/update-service-deprecated"]
 
 [dependencies]
+bytes = { workspace = true, optional = true }
 futures-core = { workspace = true }
 futures-util = { workspace = true, optional = true }
 nv-redfish-core = { workspace = true }

--- a/bmc-http/Cargo.toml
+++ b/bmc-http/Cargo.toml
@@ -44,7 +44,7 @@ nv-redfish-csdl-compiler = { workspace = true }
 nv-redfish-schema = { workspace = true }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt"] }
+tokio = { workspace = true, features = ["macros", "rt", "net", "io-util"] }
 tokio-test = { workspace = true }
 wiremock = { workspace = true }
 

--- a/bmc-http/src/reqwest.rs
+++ b/bmc-http/src/reqwest.rs
@@ -558,7 +558,7 @@ impl ClientParams {
 
     /// Sets the maximum buffered size of a single, not-yet-terminated SSE event.
     ///
-    /// See [`ClientParams::sse_max_event_bytes`].
+    /// See [`SseOptions::max_event_bytes`].
     #[must_use]
     pub const fn sse_max_event_bytes(mut self, bytes: usize) -> Self {
         self.sse.max_event_bytes = bytes;
@@ -581,9 +581,8 @@ impl ClientParams {
 /// reqwest HTTP client library. It supports all standard HTTP features including
 /// TLS, authentication, and connection pooling.
 #[derive(Clone)]
-#[allow(clippy::struct_field_names)]
 pub struct Client {
-    client: ReqwestClient,
+    inner: ReqwestClient,
     retry: Option<RetryPolicy>,
     sse: SseOptions,
 }
@@ -655,7 +654,7 @@ impl Client {
         }
 
         Ok(Self {
-            client: builder.build()?,
+            inner: builder.build()?,
             retry: params.retry,
             sse: params.sse,
         })
@@ -671,14 +670,11 @@ impl Client {
     /// The supplied client must reject cross-origin redirects. Reqwest's default redirect policy
     /// can forward Redfish `X-Auth-Token` and arbitrary custom headers to another origin.
     #[must_use]
-    pub const fn with_client(client: ReqwestClient) -> Self {
+    pub fn with_client(client: ReqwestClient) -> Self {
         Self {
-            client,
+            inner: client,
             retry: None,
-            sse: SseOptions {
-                max_event_bytes: 1024 * 1024, // 1 MiB
-                idle_timeout: None,
-            },
+            sse: SseOptions::default(),
         }
     }
 }
@@ -690,7 +686,7 @@ impl Client {
     /// bodies cannot be cloned and are sent exactly once.
     async fn send(&self, request: reqwest::Request) -> Result<reqwest::Response, BmcError> {
         let Some(policy) = &self.retry else {
-            return Ok(self.client.execute(request).await?);
+            return Ok(self.inner.execute(request).await?);
         };
 
         let mut attempt: u32 = 0;
@@ -700,7 +696,7 @@ impl Client {
             // try_clone() returns None for streaming bodies, which therefore
             // get a single attempt.
             let next = if is_last { None } else { current.try_clone() };
-            let response = self.client.execute(current).await?;
+            let response = self.inner.execute(current).await?;
             match next {
                 // The clone is identical to the request just sent, so the
                 // classifier sees what went over the wire.
@@ -1078,7 +1074,7 @@ impl HttpClient for Client {
         T: DeserializeOwned,
     {
         let mut request =
-            auth_headers(self.client.get(url), credentials).headers(custom_headers.clone());
+            auth_headers(self.inner.get(url), credentials).headers(custom_headers.clone());
 
         if let Some(etag) = etag {
             request = request.header(header::IF_NONE_MATCH, etag.to_string());
@@ -1099,7 +1095,7 @@ impl HttpClient for Client {
         B: Serialize + Send + Sync,
         T: DeserializeOwned + Send + Sync,
     {
-        let request = auth_headers(self.client.post(url), credentials)
+        let request = auth_headers(self.inner.post(url), credentials)
             .headers(custom_headers.clone())
             .json(body);
 
@@ -1118,7 +1114,7 @@ impl HttpClient for Client {
         T: DeserializeOwned + Send + Sync,
     {
         let request = self
-            .client
+            .inner
             .post(url)
             .headers(custom_headers.clone())
             .json(body);
@@ -1140,7 +1136,7 @@ impl HttpClient for Client {
         T: DeserializeOwned + Send + Sync,
     {
         let mut request =
-            auth_headers(self.client.patch(url), credentials).headers(custom_headers.clone());
+            auth_headers(self.inner.patch(url), credentials).headers(custom_headers.clone());
 
         request = request.header(header::IF_MATCH, etag.to_string());
 
@@ -1158,7 +1154,7 @@ impl HttpClient for Client {
         T: DeserializeOwned + Send + Sync,
     {
         let request =
-            auth_headers(self.client.delete(url), credentials).headers(custom_headers.clone());
+            auth_headers(self.inner.delete(url), credentials).headers(custom_headers.clone());
 
         let response = self.send(request.build()?).await?;
         self.handle_modification_response(response).await
@@ -1205,7 +1201,7 @@ impl HttpClient for Client {
             form = form.part(name, part);
         }
 
-        let request = auth_headers(self.client.post(url), credentials)
+        let request = auth_headers(self.inner.post(url), credentials)
             .headers(custom_headers.clone())
             .multipart(form)
             .timeout(upload_timeout);
@@ -1238,7 +1234,7 @@ impl HttpClient for Client {
 
         let body = reqwest::Body::wrap_stream(ReaderStream::new(reader.compat()));
 
-        let mut request = auth_headers(self.client.post(url), credentials)
+        let mut request = auth_headers(self.inner.post(url), credentials)
             .headers(custom_headers.clone())
             .header(header::CONTENT_TYPE, "application/octet-stream")
             .body(body)
@@ -1262,7 +1258,7 @@ impl HttpClient for Client {
         credentials: &BmcCredentials,
         custom_headers: &HeaderMap,
     ) -> Result<BoxTryStream<T, Self::Error>, Self::Error> {
-        let request = auth_headers(self.client.get(url), credentials)
+        let request = auth_headers(self.inner.get(url), credentials)
             .headers(custom_headers.clone())
             .header(header::ACCEPT, "text/event-stream")
             .timeout(Duration::MAX);

--- a/bmc-http/src/reqwest.rs
+++ b/bmc-http/src/reqwest.rs
@@ -17,8 +17,7 @@
 
 use std::error::Error as StdErr;
 use std::fmt;
-use std::sync::atomic::AtomicUsize;
-use std::sync::atomic::Ordering;
+use std::future::ready;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -33,7 +32,9 @@ use crate::MultipartUpdateRequest;
 use crate::RejectedUriReferenceError;
 use crate::RequestError;
 
+use bytes::Bytes;
 use futures_util::stream::unfold;
+use futures_util::Stream;
 use futures_util::StreamExt as _;
 use http::header;
 use http::HeaderMap;
@@ -176,9 +177,15 @@ impl StdErr for BmcError {
     }
 }
 
-/// Default maximum number of bytes buffered for a single, not-yet-terminated
-/// SSE event before [`Client::sse`] aborts the stream (1 MiB).
-pub const DEFAULT_SSE_MAX_EVENT_BYTES: usize = 1024 * 1024;
+impl BmcError {
+    /// Returns `true` if this error should terminate an SSE stream.
+    ///
+    /// A JSON decode error is scoped to a single event and is therefore
+    /// non-fatal; every other error ends the stream.
+    const fn is_stream_fatal(&self) -> bool {
+        !matches!(self, Self::JsonError(_))
+    }
+}
 
 /// Error produced by the byte-counting adapter that feeds the SSE decoder.
 ///
@@ -224,6 +231,72 @@ fn map_sse_error(err: sse_stream::Error) -> BmcError {
     }
 }
 
+/// Line-terminator state used by [`cap_event_bytes`] to detect SSE record
+/// boundaries (blank lines) directly in the raw byte stream.
+#[derive(Clone, Copy)]
+enum DelimiterState {
+    /// Inside a line.
+    Data,
+    /// Saw `\r`; a following `\n` belongs to the same terminator.
+    Cr,
+    /// Saw one complete line terminator.
+    Eol,
+}
+
+/// Bound the bytes buffered for a single, not-yet-terminated SSE event.
+///
+/// Counts bytes on the raw transport stream and resets the count at each SSE
+/// record boundary (a blank line), aborting with [`SseByteError::EventTooLarge`]
+/// once an unterminated event exceeds `limit`. Working on raw bytes (rather than
+/// decoded events) means comment/heartbeat records that end in a blank line also
+/// reset the budget, and a well-behaved long-lived stream is never penalized.
+fn cap_event_bytes(
+    bytes: impl Stream<Item = Result<Bytes, reqwest::Error>>,
+    limit: usize,
+) -> impl Stream<Item = Result<Bytes, SseByteError>> {
+    use DelimiterState::{Cr, Data, Eol};
+    bytes.scan((0_usize, Data), move |(count, state), chunk| {
+        let item = chunk.map_err(SseByteError::Upstream).and_then(|bytes| {
+            for &b in bytes.as_ref() {
+                *count += 1;
+                *state = match (*state, b) {
+                    (Data, b'\r') => Cr,
+                    (Data | Cr, b'\n') => Eol,
+                    (Cr | Eol, b'\r') => {
+                        *count = 0; // blank line: event delimited
+                        Cr
+                    }
+                    (Eol, b'\n') => {
+                        *count = 0; // blank line: event delimited
+                        Eol
+                    }
+                    _ => Data,
+                };
+            }
+            if *count > limit {
+                Err(SseByteError::EventTooLarge { limit })
+            } else {
+                Ok(bytes)
+            }
+        });
+        ready(Some(item))
+    })
+}
+
+/// Decode one SSE record into a typed item, or `None` for records without data
+/// (e.g. comments) so they are filtered out of the stream.
+fn event_to_item<T: DeserializeOwned>(
+    event: Result<sse_stream::Sse, sse_stream::Error>,
+) -> Option<Result<T, BmcError>> {
+    match event {
+        Err(err) => Some(Err(map_sse_error(err))),
+        Ok(sse) => sse.data.map(|data| {
+            serde_path_to_error::deserialize(&mut serde_json::Deserializer::from_str(&data))
+                .map_err(BmcError::JsonError)
+        }),
+    }
+}
+
 /// Classifier deciding whether a response should be retried.
 ///
 /// Receives the request and the response, returns `true` if the request
@@ -259,7 +332,6 @@ type RetryClassifier =
 /// let params = ClientParams::new().retry(policy);
 /// ```
 #[derive(Clone)]
-#[allow(clippy::struct_field_names)]
 pub struct RetryPolicy {
     /// Number of extra attempts after the first one.
     max_retries: u32,
@@ -363,9 +435,6 @@ pub struct ClientParams {
     /// Maximum idle time between SSE events before [`Client::sse`] aborts with
     /// [`BmcError::SseIdleTimeout`]. `None` disables the check.
     pub sse_idle_timeout: Option<Duration>,
-    /// Optional overall deadline applied to the SSE request. `None` leaves the
-    /// long-lived SSE request without a total-request timeout.
-    pub sse_total_timeout: Option<Duration>,
 }
 
 impl Default for ClientParams {
@@ -382,9 +451,8 @@ impl Default for ClientParams {
             default_headers: None,
             use_rust_tls: true,
             retry: None,
-            sse_max_event_bytes: DEFAULT_SSE_MAX_EVENT_BYTES,
+            sse_max_event_bytes: 1024 * 1024,
             sse_idle_timeout: None,
-            sse_total_timeout: None,
         }
     }
 }
@@ -490,22 +558,6 @@ impl ClientParams {
         self.sse_idle_timeout = Some(timeout);
         self
     }
-
-    /// Disables the SSE idle timeout.
-    #[must_use]
-    pub const fn no_sse_idle_timeout(mut self) -> Self {
-        self.sse_idle_timeout = None;
-        self
-    }
-
-    /// Sets an overall deadline for the SSE request.
-    ///
-    /// See [`ClientParams::sse_total_timeout`].
-    #[must_use]
-    pub const fn sse_total_timeout(mut self, timeout: Duration) -> Self {
-        self.sse_total_timeout = Some(timeout);
-        self
-    }
 }
 
 /// HTTP client implementation using the reqwest library.
@@ -520,7 +572,6 @@ pub struct Client {
     retry: Option<RetryPolicy>,
     sse_max_event_bytes: usize,
     sse_idle_timeout: Option<Duration>,
-    sse_total_timeout: Option<Duration>,
 }
 
 impl Client {
@@ -594,7 +645,6 @@ impl Client {
             retry: params.retry,
             sse_max_event_bytes: params.sse_max_event_bytes,
             sse_idle_timeout: params.sse_idle_timeout,
-            sse_total_timeout: params.sse_total_timeout,
         })
     }
 
@@ -612,9 +662,8 @@ impl Client {
         Self {
             client,
             retry: None,
-            sse_max_event_bytes: DEFAULT_SSE_MAX_EVENT_BYTES,
+            sse_max_event_bytes: 1024 * 1024,
             sse_idle_timeout: None,
-            sse_total_timeout: None,
         }
     }
 }
@@ -1188,9 +1237,9 @@ impl HttpClient for Client {
         self.handle_modification_response(response).await
     }
 
-    // The idle-timeout branch matches on `Option<Duration>` where both arms
-    // await distinct future types, which cannot be expressed as an `Option`
-    // combinator without boxing; `option_if_let_else`'s suggestion does not apply.
+    // The idle branch matches on `Option<Duration>` where both arms await
+    // distinct future types, which cannot be expressed as an `Option` combinator
+    // without boxing; `option_if_let_else`'s suggestion does not apply.
     #[allow(clippy::option_if_let_else)]
     async fn sse<T: Send + Sized + for<'de> serde::Deserialize<'de>>(
         &self,
@@ -1198,14 +1247,12 @@ impl HttpClient for Client {
         credentials: &BmcCredentials,
         custom_headers: &HeaderMap,
     ) -> Result<BoxTryStream<T, Self::Error>, Self::Error> {
-        // An SSE stream is long-lived; apply an overall deadline only when
-        // one is explicitly configured, otherwise leave it unbounded.
-        let mut request = auth_headers(self.client.get(url), credentials)
+        // An SSE stream is long-lived, so there is no overall request deadline;
+        // liveness is bounded by the idle timeout and memory by the byte cap.
+        let request = auth_headers(self.client.get(url), credentials)
             .headers(custom_headers.clone())
-            .header(header::ACCEPT, "text/event-stream");
-        if let Some(total_timeout) = self.sse_total_timeout {
-            request = request.timeout(total_timeout);
-        }
+            .header(header::ACCEPT, "text/event-stream")
+            .timeout(Duration::MAX);
 
         let response = self.send(request.build()?).await?;
 
@@ -1217,58 +1264,16 @@ impl HttpClient for Client {
             });
         }
 
-        // Hard memory bound: cap the bytes buffered for a single, not-yet-
-        // terminated event. `counter` tracks bytes pulled from the transport
-        // since the last completed event and is reset each time the decoder
-        // emits one (below), so a well-behaved long-lived stream is never
-        // penalized while an endless unterminated event is aborted.
-        //
-        // Arc is required because BoxTryStream is Send, so all captured state
-        // must be Send. The stream is polled sequentially (no concurrent access);
-        // Relaxed ordering is correct throughout.
-        let limit = self.sse_max_event_bytes;
-        let counter = Arc::new(AtomicUsize::new(0));
-
-        let capped_bytes = {
-            let counter = Arc::clone(&counter);
-            response.bytes_stream().map(move |chunk| match chunk {
-                Ok(bytes) => {
-                    let total = counter.fetch_add(bytes.len(), Ordering::Relaxed) + bytes.len();
-                    if total > limit {
-                        Err(SseByteError::EventTooLarge { limit })
-                    } else {
-                        Ok(bytes)
-                    }
-                }
-                Err(e) => Err(SseByteError::Upstream(e)),
-            })
-        };
-
-        let events = {
-            let counter = Arc::clone(&counter);
-            sse_stream::SseStream::from_bytes_stream(capped_bytes).filter_map(move |event| {
-                let counter = Arc::clone(&counter);
-                async move {
-                    match event {
-                        Err(err) => Some(Err(map_sse_error(err))),
-                        Ok(sse) => {
-                            // A completed event flushed the decoder's buffers;
-                            // reset the per-event byte budget.
-                            counter.store(0, Ordering::Relaxed);
-                            sse.data.map(|data| {
-                                serde_path_to_error::deserialize(
-                                    &mut serde_json::Deserializer::from_str(&data),
-                                )
-                                .map_err(BmcError::JsonError)
-                            })
-                        }
-                    }
-                }
-            })
-        };
+        let capped = cap_event_bytes(response.bytes_stream(), self.sse_max_event_bytes);
+        let events = sse_stream::SseStream::from_bytes_stream(capped)
+            .filter_map(|event| async move { event_to_item::<T>(event) });
 
         // Liveness bound: optionally abort if no event arrives within the idle
-        // window. Keyed on completed events, not raw byte activity.
+        // window. It is keyed on decoded events, so comment heartbeats (which
+        // `sse_stream` discards) do NOT reset it; a server relying solely on
+        // comment heartbeats should not enable the idle timeout. A JSON decode
+        // error is per-event and non-fatal; every other error is terminal and
+        // stops the stream promptly.
         let idle = self.sse_idle_timeout;
         let guarded = unfold(
             (Box::pin(events), false),
@@ -1284,8 +1289,11 @@ impl HttpClient for Client {
                     None => events.next().await,
                 };
                 match next {
-                    Some(item @ Err(_)) => Some((item, (events, true))),
-                    Some(item) => Some((item, (events, false))),
+                    Some(Err(e)) => {
+                        let terminal = e.is_stream_fatal();
+                        Some((Err(e), (events, terminal)))
+                    }
+                    Some(ok) => Some((ok, (events, false))),
                     None => None,
                 }
             },

--- a/bmc-http/src/reqwest.rs
+++ b/bmc-http/src/reqwest.rs
@@ -428,13 +428,29 @@ pub struct ClientParams {
     pub use_rust_tls: bool,
     /// Retry policy for received responses, `None` disables retries
     pub retry: Option<RetryPolicy>,
+    /// SSE-specific limits applied by [`Client::sse`].
+    pub sse: SseOptions,
+}
+
+/// Limits applied to Server-Sent Event streams opened by [`Client::sse`].
+#[derive(Clone, Copy, Debug)]
+pub struct SseOptions {
     /// Maximum bytes buffered for a single, not-yet-terminated SSE event before
     /// [`Client::sse`] aborts with [`BmcError::SseEventTooLarge`]. Guards against
     /// a server that never sends the SSE event terminator.
-    pub sse_max_event_bytes: usize,
+    pub max_event_bytes: usize,
     /// Maximum idle time between SSE events before [`Client::sse`] aborts with
     /// [`BmcError::SseIdleTimeout`]. `None` disables the check.
-    pub sse_idle_timeout: Option<Duration>,
+    pub idle_timeout: Option<Duration>,
+}
+
+impl Default for SseOptions {
+    fn default() -> Self {
+        Self {
+            max_event_bytes: 1024 * 1024,
+            idle_timeout: None,
+        }
+    }
 }
 
 impl Default for ClientParams {
@@ -451,8 +467,7 @@ impl Default for ClientParams {
             default_headers: None,
             use_rust_tls: true,
             retry: None,
-            sse_max_event_bytes: 1024 * 1024,
-            sse_idle_timeout: None,
+            sse: SseOptions::default(),
         }
     }
 }
@@ -546,16 +561,16 @@ impl ClientParams {
     /// See [`ClientParams::sse_max_event_bytes`].
     #[must_use]
     pub const fn sse_max_event_bytes(mut self, bytes: usize) -> Self {
-        self.sse_max_event_bytes = bytes;
+        self.sse.max_event_bytes = bytes;
         self
     }
 
     /// Sets the maximum idle time between SSE events.
     ///
-    /// See [`ClientParams::sse_idle_timeout`].
+    /// See [`SseOptions::idle_timeout`].
     #[must_use]
     pub const fn sse_idle_timeout(mut self, timeout: Duration) -> Self {
-        self.sse_idle_timeout = Some(timeout);
+        self.sse.idle_timeout = Some(timeout);
         self
     }
 }
@@ -570,8 +585,7 @@ impl ClientParams {
 pub struct Client {
     client: ReqwestClient,
     retry: Option<RetryPolicy>,
-    sse_max_event_bytes: usize,
-    sse_idle_timeout: Option<Duration>,
+    sse: SseOptions,
 }
 
 impl Client {
@@ -643,8 +657,7 @@ impl Client {
         Ok(Self {
             client: builder.build()?,
             retry: params.retry,
-            sse_max_event_bytes: params.sse_max_event_bytes,
-            sse_idle_timeout: params.sse_idle_timeout,
+            sse: params.sse,
         })
     }
 
@@ -662,8 +675,10 @@ impl Client {
         Self {
             client,
             retry: None,
-            sse_max_event_bytes: 1024 * 1024,
-            sse_idle_timeout: None,
+            sse: SseOptions {
+                max_event_bytes: 1024 * 1024, // 1 MiB
+                idle_timeout: None,
+            },
         }
     }
 }
@@ -1247,8 +1262,6 @@ impl HttpClient for Client {
         credentials: &BmcCredentials,
         custom_headers: &HeaderMap,
     ) -> Result<BoxTryStream<T, Self::Error>, Self::Error> {
-        // An SSE stream is long-lived, so there is no overall request deadline;
-        // liveness is bounded by the idle timeout and memory by the byte cap.
         let request = auth_headers(self.client.get(url), credentials)
             .headers(custom_headers.clone())
             .header(header::ACCEPT, "text/event-stream")
@@ -1264,17 +1277,15 @@ impl HttpClient for Client {
             });
         }
 
-        let capped = cap_event_bytes(response.bytes_stream(), self.sse_max_event_bytes);
+        let capped = cap_event_bytes(response.bytes_stream(), self.sse.max_event_bytes);
         let events = sse_stream::SseStream::from_bytes_stream(capped)
             .filter_map(|event| async move { event_to_item::<T>(event) });
 
         // Liveness bound: optionally abort if no event arrives within the idle
         // window. It is keyed on decoded events, so comment heartbeats (which
         // `sse_stream` discards) do NOT reset it; a server relying solely on
-        // comment heartbeats should not enable the idle timeout. A JSON decode
-        // error is per-event and non-fatal; every other error is terminal and
-        // stops the stream promptly.
-        let idle = self.sse_idle_timeout;
+        // comment heartbeats should not enable the idle timeout.
+        let idle = self.sse.idle_timeout;
         let guarded = unfold(
             (Box::pin(events), false),
             move |(mut events, done)| async move {

--- a/bmc-http/src/reqwest.rs
+++ b/bmc-http/src/reqwest.rs
@@ -17,6 +17,8 @@
 
 use std::error::Error as StdErr;
 use std::fmt;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -31,6 +33,7 @@ use crate::MultipartUpdateRequest;
 use crate::RejectedUriReferenceError;
 use crate::RequestError;
 
+use futures_util::stream::unfold;
 use futures_util::StreamExt as _;
 use http::header;
 use http::HeaderMap;
@@ -53,6 +56,7 @@ use reqwest::Error as ReqwestError;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use tokio::time::sleep;
+use tokio::time::timeout;
 use tokio_util::compat::FuturesAsyncReadCompatExt as _;
 use tokio_util::io::ReaderStream;
 use url::Url;
@@ -85,6 +89,16 @@ pub enum BmcError {
     EncodeError(serde_json::Error),
     /// Request rejected before transport.
     InvalidRequest(String),
+    /// A single SSE event exceeded the configured maximum buffered size.
+    SseEventTooLarge {
+        /// Configured byte limit that was exceeded.
+        limit: usize,
+    },
+    /// No SSE event was received within the configured idle timeout.
+    SseIdleTimeout {
+        /// Idle duration that elapsed with no event.
+        idle: Duration,
+    },
 }
 
 impl From<reqwest::Error> for BmcError {
@@ -139,6 +153,13 @@ impl fmt::Display for BmcError {
             Self::DecodeError(e) => write!(f, "JSON Decode error: {e}"),
             Self::EncodeError(e) => write!(f, "JSON Encode error: {e}"),
             Self::InvalidRequest(e) => write!(f, "Invalid request: {e}"),
+            Self::SseEventTooLarge { limit } => write!(
+                f,
+                "SSE event exceeded maximum buffered size of {limit} bytes"
+            ),
+            Self::SseIdleTimeout { idle } => {
+                write!(f, "SSE stream idle for longer than {idle:?}")
+            }
         }
     }
 }
@@ -152,6 +173,54 @@ impl StdErr for BmcError {
             Self::DecodeError(e) | Self::EncodeError(e) => Some(e),
             _ => None,
         }
+    }
+}
+
+/// Default maximum number of bytes buffered for a single, not-yet-terminated
+/// SSE event before [`Client::sse`] aborts the stream (1 MiB).
+pub const DEFAULT_SSE_MAX_EVENT_BYTES: usize = 1024 * 1024;
+
+/// Error produced by the byte-counting adapter that feeds the SSE decoder.
+///
+/// It is passed through the decoder's error channel so a transport failure and
+/// the "event too large" guard can be distinguished once the decoder surfaces
+/// them (see [`map_sse_error`]).
+#[derive(Debug)]
+enum SseByteError {
+    /// Underlying transport error from the response body stream.
+    Upstream(reqwest::Error),
+    /// The per-event byte budget was exceeded before the event terminated.
+    EventTooLarge {
+        /// Configured byte limit that was exceeded.
+        limit: usize,
+    },
+}
+
+impl fmt::Display for SseByteError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Upstream(e) => write!(f, "{e}"),
+            Self::EventTooLarge { limit } => {
+                write!(f, "SSE event exceeded {limit} bytes without terminating")
+            }
+        }
+    }
+}
+
+impl StdErr for SseByteError {}
+
+/// Translate an [`sse_stream::Error`] back into a [`BmcError`], recovering the
+/// [`SseByteError`] that the byte-counting adapter passed through the decoder.
+fn map_sse_error(err: sse_stream::Error) -> BmcError {
+    match err {
+        sse_stream::Error::Body(boxed) => match boxed.downcast::<SseByteError>() {
+            Ok(inner) => match *inner {
+                SseByteError::Upstream(e) => BmcError::ReqwestError(e),
+                SseByteError::EventTooLarge { limit } => BmcError::SseEventTooLarge { limit },
+            },
+            Err(other) => BmcError::SseStreamError(sse_stream::Error::Body(other)),
+        },
+        other => BmcError::SseStreamError(other),
     }
 }
 
@@ -190,6 +259,7 @@ type RetryClassifier =
 /// let params = ClientParams::new().retry(policy);
 /// ```
 #[derive(Clone)]
+#[allow(clippy::struct_field_names)]
 pub struct RetryPolicy {
     /// Number of extra attempts after the first one.
     max_retries: u32,
@@ -286,6 +356,16 @@ pub struct ClientParams {
     pub use_rust_tls: bool,
     /// Retry policy for received responses, `None` disables retries
     pub retry: Option<RetryPolicy>,
+    /// Maximum bytes buffered for a single, not-yet-terminated SSE event before
+    /// [`Client::sse`] aborts with [`BmcError::SseEventTooLarge`]. Guards against
+    /// a server that never sends the SSE event terminator.
+    pub sse_max_event_bytes: usize,
+    /// Maximum idle time between SSE events before [`Client::sse`] aborts with
+    /// [`BmcError::SseIdleTimeout`]. `None` disables the check.
+    pub sse_idle_timeout: Option<Duration>,
+    /// Optional overall deadline applied to the SSE request. `None` leaves the
+    /// long-lived SSE request without a total-request timeout.
+    pub sse_total_timeout: Option<Duration>,
 }
 
 impl Default for ClientParams {
@@ -302,6 +382,9 @@ impl Default for ClientParams {
             default_headers: None,
             use_rust_tls: true,
             retry: None,
+            sse_max_event_bytes: DEFAULT_SSE_MAX_EVENT_BYTES,
+            sse_idle_timeout: None,
+            sse_total_timeout: None,
         }
     }
 }
@@ -389,6 +472,40 @@ impl ClientParams {
         self.retry = Some(retry);
         self
     }
+
+    /// Sets the maximum buffered size of a single, not-yet-terminated SSE event.
+    ///
+    /// See [`ClientParams::sse_max_event_bytes`].
+    #[must_use]
+    pub const fn sse_max_event_bytes(mut self, bytes: usize) -> Self {
+        self.sse_max_event_bytes = bytes;
+        self
+    }
+
+    /// Sets the maximum idle time between SSE events.
+    ///
+    /// See [`ClientParams::sse_idle_timeout`].
+    #[must_use]
+    pub const fn sse_idle_timeout(mut self, timeout: Duration) -> Self {
+        self.sse_idle_timeout = Some(timeout);
+        self
+    }
+
+    /// Disables the SSE idle timeout.
+    #[must_use]
+    pub const fn no_sse_idle_timeout(mut self) -> Self {
+        self.sse_idle_timeout = None;
+        self
+    }
+
+    /// Sets an overall deadline for the SSE request.
+    ///
+    /// See [`ClientParams::sse_total_timeout`].
+    #[must_use]
+    pub const fn sse_total_timeout(mut self, timeout: Duration) -> Self {
+        self.sse_total_timeout = Some(timeout);
+        self
+    }
 }
 
 /// HTTP client implementation using the reqwest library.
@@ -397,9 +514,13 @@ impl ClientParams {
 /// reqwest HTTP client library. It supports all standard HTTP features including
 /// TLS, authentication, and connection pooling.
 #[derive(Clone)]
+#[allow(clippy::struct_field_names)]
 pub struct Client {
     client: ReqwestClient,
     retry: Option<RetryPolicy>,
+    sse_max_event_bytes: usize,
+    sse_idle_timeout: Option<Duration>,
+    sse_total_timeout: Option<Duration>,
 }
 
 impl Client {
@@ -471,6 +592,9 @@ impl Client {
         Ok(Self {
             client: builder.build()?,
             retry: params.retry,
+            sse_max_event_bytes: params.sse_max_event_bytes,
+            sse_idle_timeout: params.sse_idle_timeout,
+            sse_total_timeout: params.sse_total_timeout,
         })
     }
 
@@ -488,6 +612,9 @@ impl Client {
         Self {
             client,
             retry: None,
+            sse_max_event_bytes: DEFAULT_SSE_MAX_EVENT_BYTES,
+            sse_idle_timeout: None,
+            sse_total_timeout: None,
         }
     }
 }
@@ -1061,16 +1188,24 @@ impl HttpClient for Client {
         self.handle_modification_response(response).await
     }
 
+    // The idle-timeout branch matches on `Option<Duration>` where both arms
+    // await distinct future types, which cannot be expressed as an `Option`
+    // combinator without boxing; `option_if_let_else`'s suggestion does not apply.
+    #[allow(clippy::option_if_let_else)]
     async fn sse<T: Send + Sized + for<'de> serde::Deserialize<'de>>(
         &self,
         url: Url,
         credentials: &BmcCredentials,
         custom_headers: &HeaderMap,
     ) -> Result<BoxTryStream<T, Self::Error>, Self::Error> {
-        let request = auth_headers(self.client.get(url), credentials)
+        // An SSE stream is long-lived; apply an overall deadline only when
+        // one is explicitly configured, otherwise leave it unbounded.
+        let mut request = auth_headers(self.client.get(url), credentials)
             .headers(custom_headers.clone())
-            .header(header::ACCEPT, "text/event-stream")
-            .timeout(Duration::MAX);
+            .header(header::ACCEPT, "text/event-stream");
+        if let Some(total_timeout) = self.sse_total_timeout {
+            request = request.timeout(total_timeout);
+        }
 
         let response = self.send(request.build()?).await?;
 
@@ -1082,21 +1217,81 @@ impl HttpClient for Client {
             });
         }
 
-        let stream = sse_stream::SseStream::from_bytes_stream(response.bytes_stream()).filter_map(
-            |event| async move {
-                match event {
-                    Err(err) => Some(Err(BmcError::SseStreamError(err))),
-                    Ok(sse) => sse.data.map(|data| {
-                        serde_path_to_error::deserialize(&mut serde_json::Deserializer::from_str(
-                            &data,
-                        ))
-                        .map_err(BmcError::JsonError)
-                    }),
+        // Hard memory bound: cap the bytes buffered for a single, not-yet-
+        // terminated event. `counter` tracks bytes pulled from the transport
+        // since the last completed event and is reset each time the decoder
+        // emits one (below), so a well-behaved long-lived stream is never
+        // penalized while an endless unterminated event is aborted.
+        //
+        // Arc is required because BoxTryStream is Send, so all captured state
+        // must be Send. The stream is polled sequentially (no concurrent access);
+        // Relaxed ordering is correct throughout.
+        let limit = self.sse_max_event_bytes;
+        let counter = Arc::new(AtomicUsize::new(0));
+
+        let capped_bytes = {
+            let counter = Arc::clone(&counter);
+            response.bytes_stream().map(move |chunk| match chunk {
+                Ok(bytes) => {
+                    let total = counter.fetch_add(bytes.len(), Ordering::Relaxed) + bytes.len();
+                    if total > limit {
+                        Err(SseByteError::EventTooLarge { limit })
+                    } else {
+                        Ok(bytes)
+                    }
+                }
+                Err(e) => Err(SseByteError::Upstream(e)),
+            })
+        };
+
+        let events = {
+            let counter = Arc::clone(&counter);
+            sse_stream::SseStream::from_bytes_stream(capped_bytes).filter_map(move |event| {
+                let counter = Arc::clone(&counter);
+                async move {
+                    match event {
+                        Err(err) => Some(Err(map_sse_error(err))),
+                        Ok(sse) => {
+                            // A completed event flushed the decoder's buffers;
+                            // reset the per-event byte budget.
+                            counter.store(0, Ordering::Relaxed);
+                            sse.data.map(|data| {
+                                serde_path_to_error::deserialize(
+                                    &mut serde_json::Deserializer::from_str(&data),
+                                )
+                                .map_err(BmcError::JsonError)
+                            })
+                        }
+                    }
+                }
+            })
+        };
+
+        // Liveness bound: optionally abort if no event arrives within the idle
+        // window. Keyed on completed events, not raw byte activity.
+        let idle = self.sse_idle_timeout;
+        let guarded = unfold(
+            (Box::pin(events), false),
+            move |(mut events, done)| async move {
+                if done {
+                    return None;
+                }
+                let next = match idle {
+                    Some(d) => match timeout(d, events.next()).await {
+                        Ok(item) => item,
+                        Err(_) => Some(Err(BmcError::SseIdleTimeout { idle: d })),
+                    },
+                    None => events.next().await,
+                };
+                match next {
+                    Some(item @ Err(_)) => Some((item, (events, true))),
+                    Some(item) => Some((item, (events, false))),
+                    None => None,
                 }
             },
         );
 
-        Ok(Box::pin(stream))
+        Ok(Box::pin(guarded))
     }
 }
 

--- a/bmc-http/tests/event_stream_tests.rs
+++ b/bmc-http/tests/event_stream_tests.rs
@@ -192,7 +192,8 @@ mod tests {
         let result = stream.next().await.expect("expected an error item");
         assert!(
             matches!(result, Err(BmcError::SseEventTooLarge { limit: 16 })),
-            "expected SseEventTooLarge, got: {result:?}",
+            "expected SseEventTooLarge, got: {:?}",
+            result
         );
     }
 
@@ -255,7 +256,8 @@ mod tests {
         let result = stream.next().await.expect("expected an error item");
         assert!(
             matches!(result, Err(BmcError::SseIdleTimeout { .. })),
-            "expected SseIdleTimeout, got: {result:?}",
+            "expected SseIdleTimeout, got: {:?}",
+            result
         );
     }
 

--- a/bmc-http/tests/event_stream_tests.rs
+++ b/bmc-http/tests/event_stream_tests.rs
@@ -153,6 +153,113 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn sse_aborts_when_event_exceeds_byte_limit() {
+        use nv_redfish_bmc_http::reqwest::{Client, ClientParams};
+        use nv_redfish_bmc_http::{CacheSettings, HttpBmc};
+        use url::Url;
+
+        let mock_server = MockServer::start().await;
+
+        // 6-byte prefix ("data: ") + 20 bytes of data + newline = 27 bytes total,
+        // well over the 16-byte limit. No event terminator (\n\n) so the decoder
+        // never emits a complete event — the counter fires first.
+        let sse_body = format!("data: {}\n", "x".repeat(20));
+
+        Mock::given(method("GET"))
+            .and(path(SSE_URI))
+            .and(header("accept", "text/event-stream"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse_body),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let client = Client::with_params(ClientParams::new().sse_max_event_bytes(16)).unwrap();
+        let bmc = HttpBmc::new(
+            client,
+            Url::parse(&mock_server.uri()).unwrap(),
+            create_test_credentials(),
+            CacheSettings::default(),
+        );
+
+        let mut stream = bmc
+            .stream::<JsonValue>(SSE_URI)
+            .await
+            .expect("stream must open");
+
+        let result = stream.next().await.expect("expected an error item");
+        assert!(
+            matches!(result, Err(BmcError::SseEventTooLarge { limit: 16 })),
+            "expected SseEventTooLarge, got: {result:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn sse_aborts_on_idle_timeout() {
+        use nv_redfish_bmc_http::reqwest::{Client, ClientParams};
+        use nv_redfish_bmc_http::{CacheSettings, HttpBmc};
+        use std::time::Duration;
+        use tokio::io::AsyncWriteExt as _;
+        use tokio::net::TcpListener;
+        use url::Url;
+
+        // Bind to an OS-assigned port so we never collide with other tests.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        // Spawn a minimal HTTP server that sends one SSE event then stalls,
+        // keeping the connection open so the client has nothing to time out on.
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            socket
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\n\
+                      Content-Type: text/event-stream\r\n\
+                      Connection: keep-alive\r\n\
+                      \r\n\
+                      data: {}\n\n",
+                )
+                .await
+                .unwrap();
+            socket.flush().await.unwrap();
+            // Hold the connection open so the idle timeout is what fires, not EOF.
+            tokio::time::sleep(Duration::from_secs(30)).await;
+        });
+
+        let client =
+            Client::with_params(ClientParams::new().sse_idle_timeout(Duration::from_millis(100)))
+                .unwrap();
+        let bmc = HttpBmc::new(
+            client,
+            Url::parse(&format!("http://{addr}")).unwrap(),
+            create_test_credentials(),
+            CacheSettings::default(),
+        );
+
+        let mut stream = bmc
+            .stream::<JsonValue>(SSE_URI)
+            .await
+            .expect("stream must open");
+
+        // First poll delivers the one event the server sent.
+        let first = stream
+            .next()
+            .await
+            .expect("first event expected")
+            .expect("first event must be Ok");
+        assert_eq!(first, serde_json::json!({}));
+
+        // Second poll blocks until the idle timeout fires.
+        let result = stream.next().await.expect("expected an error item");
+        assert!(
+            matches!(result, Err(BmcError::SseIdleTimeout { .. })),
+            "expected SseIdleTimeout, got: {result:?}",
+        );
+    }
+
+    #[tokio::test]
     async fn test_event_stream_rejects_cross_origin_uri() {
         let mock_server = MockServer::start().await;
         let bmc = create_test_bmc(&mock_server);


### PR DESCRIPTION
#138 
Adds a configurable per-event byte cap that aborts the SSE stream if a single event exceeds the limit without terminating, preventing a compromised BMC from exhausting memory by sending an endless unterminated event.
Adds a configurable idle timeout that aborts the stream if no event arrives within the window, catching connections that have stalled

This was tested manually using a mock BMC that opens a text/event-stream response and then streams an SSE event that never terminates, against a client that consumes the stream through EventService/Bmc::stream in a memory-capped container.

Two tests added as well
sse_aborts_when_event_exceeds_byte_limit()
sse_aborts_on_idle_timeout()
