### PR TITLE
feat(dispatcher): add externally-fed bounded queues

### DIFF
--- a/dispatcher/Cargo.toml
+++ b/dispatcher/Cargo.toml
@@ -37,6 +37,9 @@ all-features = true
 [features]
 default = []
 
+queue = []
+queue-fifo = ["queue"]
+queue-sfq = ["queue"]
 runtime-events = []
 
 serde = ["dep:serde", "serde/rc"]

--- a/dispatcher/Cargo.toml
+++ b/dispatcher/Cargo.toml
@@ -37,9 +37,6 @@ all-features = true
 [features]
 default = []
 
-queue = []
-queue-fifo = ["queue"]
-queue-sfq = ["queue"]
 runtime-events = []
 
 serde = ["dep:serde", "serde/rc"]

--- a/dispatcher/examples/composable_tree.rs
+++ b/dispatcher/examples/composable_tree.rs
@@ -148,7 +148,6 @@ impl Scheduler<Work> for PollLeaf {
 struct RoundRobin<T, M: WorkMeta> {
     children: Vec<Box<dyn Scheduler<T, Meta = M>>>,
     cursor: usize,
-    queue_event_sink: Option<QueueEventSink>,
     _payload: PhantomData<fn() -> T>,
 }
 
@@ -157,15 +156,11 @@ impl<T, M: WorkMeta> RoundRobin<T, M> {
         Self {
             children: Vec::new(),
             cursor: 0,
-            queue_event_sink: None,
             _payload: PhantomData,
         }
     }
 
-    fn add_child<S: Scheduler<T, Meta = M>>(&mut self, mut child: S) {
-        if let Some(sink) = self.queue_event_sink.clone() {
-            child.register_queue_event_sink(sink);
-        }
+    fn add_child<S: Scheduler<T, Meta = M>>(&mut self, child: S) {
         self.children.push(Box::new(child));
     }
 }
@@ -226,7 +221,6 @@ where
     }
 
     fn register_queue_event_sink(&mut self, sink: QueueEventSink) {
-        self.queue_event_sink = Some(sink.clone());
         for child in &mut self.children {
             child.register_queue_event_sink(sink.clone());
         }

--- a/dispatcher/examples/composable_tree.rs
+++ b/dispatcher/examples/composable_tree.rs
@@ -58,6 +58,7 @@ use core::time::Duration;
 use nv_redfish_dispatcher::ClockConfig;
 use nv_redfish_dispatcher::Completion;
 use nv_redfish_dispatcher::FutureWork;
+use nv_redfish_dispatcher::QueueEventSink;
 use nv_redfish_dispatcher::Readiness;
 use nv_redfish_dispatcher::Runtime;
 use nv_redfish_dispatcher::RuntimeConfig;
@@ -131,6 +132,10 @@ impl Scheduler<Work> for PollLeaf {
     fn on_complete(&mut self, _: Completion<()>) {
         // Leaves typically use this to update local stats / backoff.
     }
+
+    fn register_queue_event_sink(&mut self, _sink: QueueEventSink) {
+        // This leaf does not produce queue events.
+    }
 }
 
 // ──────────────────────────────────────────────────────────────────────
@@ -143,6 +148,7 @@ impl Scheduler<Work> for PollLeaf {
 struct RoundRobin<T, M: WorkMeta> {
     children: Vec<Box<dyn Scheduler<T, Meta = M>>>,
     cursor: usize,
+    queue_event_sink: Option<QueueEventSink>,
     _payload: PhantomData<fn() -> T>,
 }
 
@@ -151,11 +157,15 @@ impl<T, M: WorkMeta> RoundRobin<T, M> {
         Self {
             children: Vec::new(),
             cursor: 0,
+            queue_event_sink: None,
             _payload: PhantomData,
         }
     }
 
-    fn add_child<S: Scheduler<T, Meta = M>>(&mut self, child: S) {
+    fn add_child<S: Scheduler<T, Meta = M>>(&mut self, mut child: S) {
+        if let Some(sink) = self.queue_event_sink.clone() {
+            child.register_queue_event_sink(sink);
+        }
         self.children.push(Box::new(child));
     }
 }
@@ -212,6 +222,13 @@ where
             if let Some(child) = self.children.get_mut(idx as usize) {
                 child.on_complete(completion);
             }
+        }
+    }
+
+    fn register_queue_event_sink(&mut self, sink: QueueEventSink) {
+        self.queue_event_sink = Some(sink.clone());
+        for child in &mut self.children {
+            child.register_queue_event_sink(sink.clone());
         }
     }
 }

--- a/dispatcher/sim/src/lib.rs
+++ b/dispatcher/sim/src/lib.rs
@@ -39,8 +39,9 @@ use std::time::Instant;
 
 use nv_redfish_dispatcher::{
     CircuitBreaker, CircuitBreakerConfig, ClockConfig, Completion, CostUnits, FixedCost,
-    FutureWork, ManualClock, PeriodicLeaf, Readiness, RoundRobin, Runtime, RuntimeConfig,
-    RuntimeOutput, ScheduledWork, Scheduler, TokenBucket, TokenBucketConfig, WithCost,
+    FutureWork, ManualClock, PeriodicLeaf, QueueEventSink, Readiness, RoundRobin, Runtime,
+    RuntimeConfig, RuntimeOutput, ScheduledWork, Scheduler, TokenBucket, TokenBucketConfig,
+    WithCost,
 };
 
 /// Successful work reports (source, task).
@@ -221,6 +222,10 @@ where
     fn on_complete(&mut self, completion: Completion<S::Meta>) {
         self.counts.on_complete.fetch_add(1, Ordering::Relaxed);
         self.inner.on_complete(completion);
+    }
+
+    fn register_queue_event_sink(&mut self, sink: QueueEventSink) {
+        self.inner.register_queue_event_sink(sink);
     }
 }
 

--- a/dispatcher/src/event.rs
+++ b/dispatcher/src/event.rs
@@ -21,6 +21,97 @@
 
 #[cfg(not(feature = "runtime-events"))]
 use core::convert::Infallible;
+#[cfg(feature = "queue")]
+use std::sync::Arc;
+
+/// Stable runtime-assigned identity for an externally-fed queue.
+///
+/// IDs are unique within one runtime and become available when the queue
+/// scheduler is attached to that runtime.
+#[cfg(feature = "queue")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct QueueId(u64);
+
+#[cfg(feature = "queue")]
+impl QueueId {
+    pub(crate) const fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    /// Raw runtime-local queue identifier.
+    #[must_use]
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+}
+
+/// Signal sent by an externally-fed queue to its runtime.
+///
+/// [`QueueEvent::WakeUp`] is control-plane only and never appears in
+/// [`crate::RuntimeOutput`]. `Drained` becomes a
+/// `RuntimeEvent::QueueDrained` output when `runtime-events` is enabled.
+#[cfg(feature = "queue")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QueueEvent {
+    /// Queue readiness may have changed.
+    WakeUp,
+    /// A closed queue has no queued or in-flight work remaining.
+    Drained {
+        /// Stable identity assigned when the queue attached to runtime.
+        queue_id: QueueId,
+    },
+}
+
+#[cfg(feature = "queue")]
+type QueueEventHandler = dyn Fn(QueueEvent) + Send + Sync + 'static;
+#[cfg(feature = "queue")]
+type QueueIdAllocator = dyn Fn() -> QueueId + Send + Sync + 'static;
+
+/// Restricted capability used by queue schedulers to signal their runtime.
+///
+/// It accepts only [`QueueEvent`], preventing queue implementations from
+/// fabricating unrelated runtime events. The sink owns runtime wake-up;
+/// schedulers never receive a raw [`std::task::Waker`].
+#[cfg(feature = "queue")]
+#[derive(Clone)]
+pub struct QueueEventSink {
+    handler: Arc<QueueEventHandler>,
+    allocator: Arc<QueueIdAllocator>,
+    runtime_identity: Arc<()>,
+}
+
+#[cfg(feature = "queue")]
+impl QueueEventSink {
+    pub(crate) fn new(
+        handler: impl Fn(QueueEvent) + Send + Sync + 'static,
+        allocator: impl Fn() -> QueueId + Send + Sync + 'static,
+        runtime_identity: Arc<()>,
+    ) -> Self {
+        Self {
+            handler: Arc::new(handler),
+            allocator: Arc::new(allocator),
+            runtime_identity,
+        }
+    }
+
+    /// Allocate a stable identifier local to this runtime.
+    ///
+    /// Custom externally-fed queue schedulers use this when the sink is
+    /// first registered. Clones of a sink share one allocation domain.
+    #[must_use]
+    pub fn allocate_queue_id(&self) -> QueueId {
+        (self.allocator)()
+    }
+
+    /// Push a queue control or lifecycle event.
+    pub fn push(&self, event: QueueEvent) {
+        (self.handler)(event);
+    }
+
+    pub(crate) fn belongs_to_same_runtime(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.runtime_identity, &other.runtime_identity)
+    }
+}
 
 /// Concrete payload carried by [`crate::RuntimeOutput::Runtime`].
 #[cfg(feature = "runtime-events")]
@@ -55,6 +146,12 @@ mod with_events {
         WorkFailed,
         /// Reserved snapshot variant; payload fields land later.
         SchedulerStatsSnapshot,
+        /// A closed externally-fed queue has fully drained.
+        #[cfg(feature = "queue")]
+        QueueDrained {
+            /// Stable runtime-assigned queue identity.
+            queue_id: super::QueueId,
+        },
     }
 }
 

--- a/dispatcher/src/event.rs
+++ b/dispatcher/src/event.rs
@@ -21,18 +21,15 @@
 
 #[cfg(not(feature = "runtime-events"))]
 use core::convert::Infallible;
-#[cfg(feature = "queue")]
 use std::sync::Arc;
 
 /// Stable runtime-assigned identity for an externally-fed queue.
 ///
 /// IDs are unique within one runtime and become available when the queue
 /// scheduler is attached to that runtime.
-#[cfg(feature = "queue")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueueId(u64);
 
-#[cfg(feature = "queue")]
 impl QueueId {
     pub(crate) const fn new(value: u64) -> Self {
         Self(value)
@@ -50,7 +47,6 @@ impl QueueId {
 /// [`QueueEvent::WakeUp`] is control-plane only and never appears in
 /// [`crate::RuntimeOutput`]. `Drained` becomes a
 /// `RuntimeEvent::QueueDrained` output when `runtime-events` is enabled.
-#[cfg(feature = "queue")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum QueueEvent {
     /// Queue readiness may have changed.
@@ -62,9 +58,7 @@ pub enum QueueEvent {
     },
 }
 
-#[cfg(feature = "queue")]
 type QueueEventHandler = dyn Fn(QueueEvent) + Send + Sync + 'static;
-#[cfg(feature = "queue")]
 type QueueIdAllocator = dyn Fn() -> QueueId + Send + Sync + 'static;
 
 /// Restricted capability used by queue schedulers to signal their runtime.
@@ -72,7 +66,6 @@ type QueueIdAllocator = dyn Fn() -> QueueId + Send + Sync + 'static;
 /// It accepts only [`QueueEvent`], preventing queue implementations from
 /// fabricating unrelated runtime events. The sink owns runtime wake-up;
 /// schedulers never receive a raw [`std::task::Waker`].
-#[cfg(feature = "queue")]
 #[derive(Clone)]
 pub struct QueueEventSink {
     handler: Arc<QueueEventHandler>,
@@ -80,7 +73,6 @@ pub struct QueueEventSink {
     runtime_identity: Arc<()>,
 }
 
-#[cfg(feature = "queue")]
 impl QueueEventSink {
     pub(crate) fn new(
         handler: impl Fn(QueueEvent) + Send + Sync + 'static,
@@ -147,7 +139,6 @@ mod with_events {
         /// Reserved snapshot variant; payload fields land later.
         SchedulerStatsSnapshot,
         /// A closed externally-fed queue has fully drained.
-        #[cfg(feature = "queue")]
         QueueDrained {
             /// Stable runtime-assigned queue identity.
             queue_id: super::QueueId,

--- a/dispatcher/src/lib.rs
+++ b/dispatcher/src/lib.rs
@@ -92,6 +92,9 @@ pub mod work;
 pub use event::RuntimeEvent;
 #[doc(inline)]
 pub use event::RuntimeEventType;
+#[cfg(feature = "queue")]
+#[doc(inline)]
+pub use event::{QueueEvent, QueueEventSink, QueueId};
 #[doc(inline)]
 pub use runtime::ClockConfig;
 #[doc(inline)]
@@ -135,6 +138,19 @@ pub use work::WithPriority;
 #[doc(inline)]
 pub use work::WorkMeta;
 
+#[cfg(feature = "queue-fifo")]
+#[doc(inline)]
+pub use schedulers::Fifo;
+#[cfg(feature = "queue-sfq")]
+#[doc(inline)]
+pub use schedulers::StochasticFairQueue;
+#[cfg(feature = "queue")]
+#[doc(inline)]
+pub use schedulers::{
+    AdmissionContext, AdmissionDecision, AdmissionPolicy, BoundedQueue, BoundedQueueBuilder,
+    BoundedQueuePair, BoundedQueueProducer, BoundedQueueStats, EnqueueOutcome, QueueDiscipline,
+    QueueEntryId, QueueEntryRef, QueueLifecycle, TailDrop,
+};
 #[doc(inline)]
 pub use schedulers::{
     BoundedConcurrency, BreakerState, CircuitBreaker, CircuitBreakerConfig, FixedCost,

--- a/dispatcher/src/lib.rs
+++ b/dispatcher/src/lib.rs
@@ -92,7 +92,6 @@ pub mod work;
 pub use event::RuntimeEvent;
 #[doc(inline)]
 pub use event::RuntimeEventType;
-#[cfg(feature = "queue")]
 #[doc(inline)]
 pub use event::{QueueEvent, QueueEventSink, QueueId};
 #[doc(inline)]
@@ -138,13 +137,10 @@ pub use work::WithPriority;
 #[doc(inline)]
 pub use work::WorkMeta;
 
-#[cfg(feature = "queue-fifo")]
 #[doc(inline)]
 pub use schedulers::Fifo;
-#[cfg(feature = "queue-sfq")]
 #[doc(inline)]
 pub use schedulers::StochasticFairQueue;
-#[cfg(feature = "queue")]
 #[doc(inline)]
 pub use schedulers::{
     AdmissionContext, AdmissionDecision, AdmissionPolicy, BoundedQueue, BoundedQueueBuilder,

--- a/dispatcher/src/runtime.rs
+++ b/dispatcher/src/runtime.rs
@@ -115,7 +115,6 @@ where
         S: Scheduler<FutureWork<Ev, Err>, Meta = M>,
     {
         let signals = Arc::new(RuntimeSignals::default());
-        #[cfg(feature = "queue")]
         let root = {
             let mut root = root;
             root.register_queue_event_sink(signals.queue_event_sink());
@@ -516,7 +515,6 @@ where
             .lock()
             .expect("dispatcher runtime mutex is poisoned");
         let result = guard.root.as_any_mut().downcast_mut::<S>().map(f);
-        #[cfg(feature = "queue")]
         guard
             .root
             .register_queue_event_sink(self.signals.queue_event_sink());
@@ -585,9 +583,7 @@ struct StatsCells {
 
 struct RuntimeSignals {
     state: Mutex<RuntimeSignalState>,
-    #[cfg(feature = "queue")]
     next_queue_id: AtomicU64,
-    #[cfg(feature = "queue")]
     queue_identity: Arc<()>,
 }
 
@@ -602,9 +598,7 @@ impl Default for RuntimeSignals {
     fn default() -> Self {
         Self {
             state: Mutex::new(RuntimeSignalState::default()),
-            #[cfg(feature = "queue")]
             next_queue_id: AtomicU64::new(0),
-            #[cfg(feature = "queue")]
             queue_identity: Arc::new(()),
         }
     }
@@ -633,7 +627,6 @@ impl RuntimeSignals {
         }
     }
 
-    #[cfg(feature = "queue")]
     fn queue_event_sink(self: &Arc<Self>) -> crate::QueueEventSink {
         let event_signals = self.clone();
         let allocator_signals = self.clone();
@@ -644,7 +637,6 @@ impl RuntimeSignals {
         )
     }
 
-    #[cfg(feature = "queue")]
     fn allocate_queue_id(&self) -> crate::QueueId {
         let id = self
             .next_queue_id
@@ -655,7 +647,6 @@ impl RuntimeSignals {
         crate::QueueId::new(id)
     }
 
-    #[cfg(feature = "queue")]
     fn handle_queue_event(&self, event: crate::QueueEvent) {
         let mut state = self
             .state

--- a/dispatcher/src/runtime.rs
+++ b/dispatcher/src/runtime.rs
@@ -88,6 +88,7 @@ pub struct Runtime<Ev, Err, M: WorkMeta> {
     completion: Vec<Completion<M>>,
     output: VecDeque<RuntimeOutput<Ev, Err>>,
     shared: Arc<Mutex<Shared<Ev, Err, M>>>,
+    signals: Arc<RuntimeSignals>,
     stats: Arc<StatsCells>,
     _phantom: RuntimePhantom<Ev, Err, M>,
 }
@@ -113,6 +114,13 @@ where
     where
         S: Scheduler<FutureWork<Ev, Err>, Meta = M>,
     {
+        let signals = Arc::new(RuntimeSignals::default());
+        #[cfg(feature = "queue")]
+        let root = {
+            let mut root = root;
+            root.register_queue_event_sink(signals.queue_event_sink());
+            root
+        };
         Self {
             clock: match config.clock {
                 ClockConfig::Wallclock => RuntimeClock::Wallclock,
@@ -128,11 +136,11 @@ where
             config,
             shared: Mutex::new(Shared {
                 root: Box::new(root),
-                waker: None,
                 shutdown: false,
                 _phantom: PhantomData,
             })
             .into(),
+            signals,
             stats: Arc::new(StatsCells::default()),
             _phantom: PhantomData,
         }
@@ -143,6 +151,7 @@ where
     pub fn handle(&self) -> RuntimeHandle<Ev, Err, M> {
         RuntimeHandle {
             shared: self.shared.clone(),
+            signals: self.signals.clone(),
             stats: self.stats.clone(),
         }
     }
@@ -196,12 +205,13 @@ where
     ///
     /// Step order:
     ///
-    /// 1. Drain one queued output if any.
-    /// 2. If below [`RuntimeConfig::global_max_in_flight`], lock shared
+    /// 1. Register the current driver waker so any external control or
+    ///    queue signal racing with this poll can schedule another poll.
+    /// 2. Forward completions, collect runtime events, and drain one queued
+    ///    output if any.
+    /// 3. If below [`RuntimeConfig::global_max_in_flight`], lock shared
     ///    scheduler/control state briefly and dispatch available work until
     ///    the global cap is reached or the scheduler has no work.
-    /// 3. If shared state has no work while capacity remains, register the
-    ///    current waker so external control changes can wake this future.
     /// 4. Poll in-flight payloads without holding the shared lock; completed
     ///    payloads enqueue [`RuntimeOutput::Work`].
     /// 5. If no output was queued and no synchronous progress was made, park.
@@ -228,6 +238,7 @@ where
     type Output = RuntimeOutput<Ev, Err>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.runtime.signals.register_waker(cx.waker());
         let mut progress = true;
         while progress {
             if !self.runtime.completion.is_empty() {
@@ -240,6 +251,13 @@ where
                 for completion in completions {
                     shared.root.on_complete(completion);
                 }
+            }
+            #[cfg(feature = "runtime-events")]
+            {
+                let events = self.runtime.signals.take_events();
+                self.runtime
+                    .output
+                    .extend(events.into_iter().map(RuntimeOutput::Runtime));
             }
             if let Some(output) = self.runtime.output.pop_front() {
                 self.runtime
@@ -283,11 +301,6 @@ where
                             break;
                         }
                     }
-                }
-                // Setup waker if change in shared elements can cause
-                // progress for the future.
-                if in_flight.len() < global_max_in_flight.into() {
-                    shared.maybe_setup_waker(cx);
                 }
             }
             self.runtime
@@ -404,6 +417,7 @@ impl ManualClock {
 /// itself is not `Clone`.
 pub struct RuntimeHandle<Ev, Err, M: WorkMeta> {
     shared: Arc<Mutex<Shared<Ev, Err, M>>>,
+    signals: Arc<RuntimeSignals>,
     stats: Arc<StatsCells>,
 }
 
@@ -411,6 +425,7 @@ impl<Ev, Err, M: WorkMeta> Clone for RuntimeHandle<Ev, Err, M> {
     fn clone(&self) -> Self {
         Self {
             shared: self.shared.clone(),
+            signals: self.signals.clone(),
             stats: self.stats.clone(),
         }
     }
@@ -440,11 +455,8 @@ where
             .lock()
             .expect("dispatcher runtime mutex is poisoned");
         guard.shutdown = true;
-        let waker = guard.waker.take();
         drop(guard);
-        if let Some(waker) = waker {
-            waker.wake();
-        }
+        self.signals.wake();
     }
 
     /// Snapshot of runtime statistics. Lock-free; values are relaxed
@@ -504,11 +516,12 @@ where
             .lock()
             .expect("dispatcher runtime mutex is poisoned");
         let result = guard.root.as_any_mut().downcast_mut::<S>().map(f);
-        let waker = guard.waker.take();
+        #[cfg(feature = "queue")]
+        guard
+            .root
+            .register_queue_event_sink(self.signals.queue_event_sink());
         drop(guard);
-        if let Some(waker) = waker {
-            waker.wake();
-        }
+        self.signals.wake();
         result
     }
 }
@@ -570,8 +583,110 @@ struct StatsCells {
     output_queued: AtomicUsize,
 }
 
-struct Shared<Ev, Err, M> {
+struct RuntimeSignals {
+    state: Mutex<RuntimeSignalState>,
+    #[cfg(feature = "queue")]
+    next_queue_id: AtomicU64,
+    #[cfg(feature = "queue")]
+    queue_identity: Arc<()>,
+}
+
+#[derive(Default)]
+struct RuntimeSignalState {
     waker: Option<Waker>,
+    #[cfg(feature = "runtime-events")]
+    events: VecDeque<crate::RuntimeEvent>,
+}
+
+impl Default for RuntimeSignals {
+    fn default() -> Self {
+        Self {
+            state: Mutex::new(RuntimeSignalState::default()),
+            #[cfg(feature = "queue")]
+            next_queue_id: AtomicU64::new(0),
+            #[cfg(feature = "queue")]
+            queue_identity: Arc::new(()),
+        }
+    }
+}
+
+impl RuntimeSignals {
+    fn register_waker(&self, waker: &Waker) {
+        let mut state = self
+            .state
+            .lock()
+            .expect("dispatcher runtime signal mutex is poisoned");
+        if state.waker.as_ref().is_none_or(|old| !old.will_wake(waker)) {
+            state.waker = Some(waker.clone());
+        }
+    }
+
+    fn wake(&self) {
+        let waker = self
+            .state
+            .lock()
+            .expect("dispatcher runtime signal mutex is poisoned")
+            .waker
+            .take();
+        if let Some(waker) = waker {
+            waker.wake();
+        }
+    }
+
+    #[cfg(feature = "queue")]
+    fn queue_event_sink(self: &Arc<Self>) -> crate::QueueEventSink {
+        let event_signals = self.clone();
+        let allocator_signals = self.clone();
+        crate::QueueEventSink::new(
+            move |event| event_signals.handle_queue_event(event),
+            move || allocator_signals.allocate_queue_id(),
+            self.queue_identity.clone(),
+        )
+    }
+
+    #[cfg(feature = "queue")]
+    fn allocate_queue_id(&self) -> crate::QueueId {
+        let id = self
+            .next_queue_id
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+                current.checked_add(1)
+            })
+            .expect("a runtime supports at most u64::MAX attached queues");
+        crate::QueueId::new(id)
+    }
+
+    #[cfg(feature = "queue")]
+    fn handle_queue_event(&self, event: crate::QueueEvent) {
+        let mut state = self
+            .state
+            .lock()
+            .expect("dispatcher runtime signal mutex is poisoned");
+        #[cfg(feature = "runtime-events")]
+        if let crate::QueueEvent::Drained { queue_id } = event {
+            state
+                .events
+                .push_back(crate::RuntimeEvent::QueueDrained { queue_id });
+        }
+        #[cfg(not(feature = "runtime-events"))]
+        let _ = event;
+        let waker = state.waker.take();
+        drop(state);
+        if let Some(waker) = waker {
+            waker.wake();
+        }
+    }
+
+    #[cfg(feature = "runtime-events")]
+    fn take_events(&self) -> VecDeque<crate::RuntimeEvent> {
+        let mut state = self
+            .state
+            .lock()
+            .expect("dispatcher runtime signal mutex is poisoned");
+        mem::take(&mut state.events)
+    }
+}
+
+struct Shared<Ev, Err, M> {
     root: Box<dyn SchedulerObj<FutureWork<Ev, Err>, M>>,
     shutdown: bool,
     _phantom: PhantomData<(Ev, Err)>,
@@ -592,18 +707,6 @@ where
         }
         r.next_update_at
             .map_or(SharedNextResult::Nothing, SharedNextResult::SleepUntil)
-    }
-
-    fn maybe_setup_waker(&mut self, cx: &Context<'_>) {
-        let waker = cx.waker();
-
-        if self
-            .waker
-            .as_ref()
-            .is_none_or(|old_waker| !old_waker.will_wake(waker))
-        {
-            self.waker = Some(waker.clone());
-        }
     }
 }
 

--- a/dispatcher/src/scheduler.rs
+++ b/dispatcher/src/scheduler.rs
@@ -91,8 +91,9 @@ pub trait Scheduler<T>: Send + 'static {
     /// Register the runtime's restricted queue-event capability.
     ///
     /// Externally-fed queue leaves retain this sink and push queue signals
-    /// without receiving the runtime's raw waker. Branches must forward it
-    /// to their children and retain it for dynamically added children.
+    /// without receiving the runtime's raw waker. Branches forward it to
+    /// their current children. The runtime repeats this synchronization
+    /// after a dynamic root mutation.
     fn register_queue_event_sink(&mut self, sink: crate::QueueEventSink);
 }
 

--- a/dispatcher/src/scheduler.rs
+++ b/dispatcher/src/scheduler.rs
@@ -87,6 +87,14 @@ pub trait Scheduler<T>: Send + 'static {
     /// `&mut Completion<C::Meta>` (with the unwrapped meta) to the chosen
     /// child.
     fn on_complete(&mut self, completion: Completion<Self::Meta>);
+
+    /// Register the runtime's restricted queue-event capability.
+    ///
+    /// Externally-fed queue leaves retain this sink and push queue signals
+    /// without receiving the runtime's raw waker. Branches must forward it
+    /// to their children and retain it for dynamically added children.
+    #[cfg(feature = "queue")]
+    fn register_queue_event_sink(&mut self, _sink: crate::QueueEventSink) {}
 }
 
 impl<T, S> Scheduler<T> for Box<S>
@@ -106,6 +114,11 @@ where
 
     fn on_complete(&mut self, completion: Completion<S::Meta>) {
         (**self).on_complete(completion);
+    }
+
+    #[cfg(feature = "queue")]
+    fn register_queue_event_sink(&mut self, sink: crate::QueueEventSink) {
+        (**self).register_queue_event_sink(sink);
     }
 }
 
@@ -127,6 +140,8 @@ pub(crate) mod private {
         fn update_ready(&mut self, now: Instant) -> Readiness;
         fn take_next(&mut self) -> Option<ScheduledWork<T, M>>;
         fn on_complete(&mut self, completion: Completion<M>);
+        #[cfg(feature = "queue")]
+        fn register_queue_event_sink(&mut self, sink: crate::QueueEventSink);
         fn as_any(&self) -> &dyn Any;
         fn as_any_mut(&mut self) -> &mut dyn Any;
     }
@@ -145,6 +160,10 @@ pub(crate) mod private {
         }
         fn on_complete(&mut self, completion: Completion<M>) {
             <Self as super::Scheduler<T>>::on_complete(self, completion);
+        }
+        #[cfg(feature = "queue")]
+        fn register_queue_event_sink(&mut self, sink: crate::QueueEventSink) {
+            <Self as super::Scheduler<T>>::register_queue_event_sink(self, sink);
         }
         fn as_any(&self) -> &dyn Any {
             self

--- a/dispatcher/src/scheduler.rs
+++ b/dispatcher/src/scheduler.rs
@@ -93,8 +93,7 @@ pub trait Scheduler<T>: Send + 'static {
     /// Externally-fed queue leaves retain this sink and push queue signals
     /// without receiving the runtime's raw waker. Branches must forward it
     /// to their children and retain it for dynamically added children.
-    #[cfg(feature = "queue")]
-    fn register_queue_event_sink(&mut self, _sink: crate::QueueEventSink) {}
+    fn register_queue_event_sink(&mut self, sink: crate::QueueEventSink);
 }
 
 impl<T, S> Scheduler<T> for Box<S>
@@ -116,7 +115,6 @@ where
         (**self).on_complete(completion);
     }
 
-    #[cfg(feature = "queue")]
     fn register_queue_event_sink(&mut self, sink: crate::QueueEventSink) {
         (**self).register_queue_event_sink(sink);
     }
@@ -140,7 +138,6 @@ pub(crate) mod private {
         fn update_ready(&mut self, now: Instant) -> Readiness;
         fn take_next(&mut self) -> Option<ScheduledWork<T, M>>;
         fn on_complete(&mut self, completion: Completion<M>);
-        #[cfg(feature = "queue")]
         fn register_queue_event_sink(&mut self, sink: crate::QueueEventSink);
         fn as_any(&self) -> &dyn Any;
         fn as_any_mut(&mut self) -> &mut dyn Any;
@@ -161,7 +158,6 @@ pub(crate) mod private {
         fn on_complete(&mut self, completion: Completion<M>) {
             <Self as super::Scheduler<T>>::on_complete(self, completion);
         }
-        #[cfg(feature = "queue")]
         fn register_queue_event_sink(&mut self, sink: crate::QueueEventSink) {
             <Self as super::Scheduler<T>>::register_queue_event_sink(self, sink);
         }

--- a/dispatcher/src/schedulers/bounded_concurrency.rs
+++ b/dispatcher/src/schedulers/bounded_concurrency.rs
@@ -86,6 +86,11 @@ where
         self.in_flight = self.in_flight.saturating_sub(1);
         self.inner.on_complete(completion);
     }
+
+    #[cfg(feature = "queue")]
+    fn register_queue_event_sink(&mut self, sink: crate::QueueEventSink) {
+        self.inner.register_queue_event_sink(sink);
+    }
 }
 
 #[cfg(test)]

--- a/dispatcher/src/schedulers/bounded_concurrency.rs
+++ b/dispatcher/src/schedulers/bounded_concurrency.rs
@@ -87,7 +87,6 @@ where
         self.inner.on_complete(completion);
     }
 
-    #[cfg(feature = "queue")]
     fn register_queue_event_sink(&mut self, sink: crate::QueueEventSink) {
         self.inner.register_queue_event_sink(sink);
     }

--- a/dispatcher/src/schedulers/bounded_queue.rs
+++ b/dispatcher/src/schedulers/bounded_queue.rs
@@ -268,7 +268,7 @@ pub type BoundedQueuePair<T, M, P, D> =
 /// Builder for an externally-fed bounded queue.
 ///
 /// Admission defaults to [`TailDrop`]. A discipline is intentionally not
-/// selected by default: use `.fifo()` with `queue-fifo`, or
+/// selected by default: use `.fifo()`, or
 /// [`Self::discipline`] with an SFQ or custom implementation.
 pub struct BoundedQueueBuilder<P = TailDrop, D = ()> {
     capacity: NonZeroUsize,
@@ -689,7 +689,6 @@ fn take_entry<T, M: WorkMeta, P, D>(
 }
 
 #[cfg(test)]
-#[cfg(feature = "queue-fifo")]
 mod tests {
     #[cfg(feature = "runtime-events")]
     use core::sync::atomic::{AtomicBool, Ordering};

--- a/dispatcher/src/schedulers/bounded_queue.rs
+++ b/dispatcher/src/schedulers/bounded_queue.rs
@@ -1,0 +1,1261 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Core externally-fed bounded queue scheduler.
+//!
+//! The queue owns payload storage, hard-capacity enforcement, admission,
+//! lifecycle, events, and statistics. A [`QueueDiscipline`] owns only
+//! [`QueueEntryId`] values and decides dequeue order. Built-in disciplines
+//! are feature-gated separately.
+//!
+//! Closing stops admission but retains the scheduler in its parent while
+//! queued and in-flight work drains. Remove a queue from a dynamic parent
+//! only after [`QueueLifecycle::Drained`] (or the corresponding
+//! `RuntimeEvent::QueueDrained` with `runtime-events`); removal
+//! before then can intentionally detach pending work from scheduling.
+
+use core::convert::TryFrom as _;
+use core::sync::atomic::{AtomicUsize, Ordering};
+use std::collections::HashMap;
+use std::num::NonZeroUsize;
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::time::Instant;
+
+use crate::scheduler::{ScheduledWork, Scheduler};
+use crate::work::{Completion, Readiness, WorkMeta};
+use crate::{QueueEvent, QueueEventSink, QueueId};
+
+/// Stable identity assigned by a queue to one admitted entry.
+///
+/// This is infrastructure identity for exact eviction; application work
+/// identity belongs in [`ScheduledWork::meta`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct QueueEntryId(pub(crate) u64);
+
+/// Lifecycle of an externally-fed queue.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QueueLifecycle {
+    /// Producers may enqueue work.
+    Open,
+    /// Producers are closed, but queued or in-flight work remains.
+    Draining,
+    /// Producers are closed and no queued or in-flight work remains.
+    Drained,
+}
+
+/// Read-only view of one admitted queue entry.
+pub struct QueueEntryRef<'a, T, M: WorkMeta> {
+    id: QueueEntryId,
+    work: &'a ScheduledWork<T, M>,
+}
+
+impl<T, M: WorkMeta> Clone for QueueEntryRef<'_, T, M> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T, M: WorkMeta> Copy for QueueEntryRef<'_, T, M> {}
+
+impl<'a, T, M: WorkMeta> QueueEntryRef<'a, T, M> {
+    /// Queue-local entry identity used for exact eviction.
+    #[must_use]
+    pub const fn id(self) -> QueueEntryId {
+        self.id
+    }
+
+    /// Admitted work.
+    #[must_use]
+    pub const fn work(self) -> &'a ScheduledWork<T, M> {
+        self.work
+    }
+}
+
+struct StoredWork<T, M: WorkMeta> {
+    admitted_order: u64,
+    work: ScheduledWork<T, M>,
+}
+
+/// Read-only queue state supplied to an [`AdmissionPolicy`].
+pub struct AdmissionContext<'a, T, M: WorkMeta> {
+    capacity: usize,
+    entries: &'a HashMap<QueueEntryId, StoredWork<T, M>>,
+}
+
+impl<T, M: WorkMeta> AdmissionContext<'_, T, M> {
+    /// Current number of queued items.
+    #[must_use]
+    pub fn depth(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Hard queue capacity.
+    #[must_use]
+    pub const fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Existing queued work in unspecified order.
+    ///
+    /// This is a lazy iterator over canonical queue storage and performs
+    /// no allocation. Use [`Self::oldest`] when admission order matters.
+    #[must_use]
+    pub fn entries(&self) -> impl ExactSizeIterator<Item = QueueEntryRef<'_, T, M>> {
+        self.entries.iter().map(|(&id, stored)| QueueEntryRef {
+            id,
+            work: &stored.work,
+        })
+    }
+
+    /// Oldest currently queued entry by admission order.
+    #[must_use]
+    pub fn oldest(&self) -> Option<QueueEntryRef<'_, T, M>> {
+        self.entries
+            .iter()
+            .min_by_key(|(_, stored)| stored.admitted_order)
+            .map(|(&id, stored)| QueueEntryRef {
+                id,
+                work: &stored.work,
+            })
+    }
+}
+
+/// Admission decision returned by an [`AdmissionPolicy`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AdmissionDecision {
+    /// Admit the incoming item.
+    Admit,
+    /// Reject and return the incoming item.
+    Reject,
+    /// Remove the identified existing item, return it, and admit incoming.
+    EvictAndAdmit {
+        /// Stable identity selected from [`AdmissionContext::entries`].
+        id: QueueEntryId,
+    },
+}
+
+/// Replaceable queue admission policy.
+///
+/// Policies inspect immutable queue state and incoming work and express
+/// mutation only through [`AdmissionDecision`]. This keeps hard-capacity
+/// enforcement and payload ownership inside the queue.
+pub trait AdmissionPolicy<T, M: WorkMeta>: Send + 'static {
+    /// Decide what to do with `incoming`.
+    fn decide(
+        &mut self,
+        context: AdmissionContext<'_, T, M>,
+        incoming: &ScheduledWork<T, M>,
+    ) -> AdmissionDecision;
+}
+
+/// Built-in tail-drop admission: admit below capacity, reject at capacity.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct TailDrop;
+
+impl<T, M: WorkMeta> AdmissionPolicy<T, M> for TailDrop {
+    fn decide(
+        &mut self,
+        context: AdmissionContext<'_, T, M>,
+        _incoming: &ScheduledWork<T, M>,
+    ) -> AdmissionDecision {
+        if context.depth() < context.capacity() {
+            AdmissionDecision::Admit
+        } else {
+            AdmissionDecision::Reject
+        }
+    }
+}
+
+/// Pluggable storage order for accepted queue entries.
+///
+/// The bounded queue owns all payloads; a discipline stores only entry IDs.
+/// Implementations must return each accepted ID at most once and make
+/// [`Self::remove`] remove it from future selection. If a malformed custom
+/// discipline returns stale IDs or `None` while canonical entries remain,
+/// the queue falls back to its oldest entry so work cannot be stranded.
+pub trait QueueDiscipline<M>: Send + 'static {
+    /// Add a new entry. `meta` may be used for classification.
+    fn push(&mut self, id: QueueEntryId, meta: &M);
+
+    /// Select and remove the next entry ID.
+    fn take_next(&mut self) -> Option<QueueEntryId>;
+
+    /// Remove `id` before dispatch. Returns whether it was present.
+    fn remove(&mut self, id: QueueEntryId) -> bool;
+}
+
+/// Result of [`BoundedQueueProducer::try_push`].
+pub enum EnqueueOutcome<T, M: WorkMeta> {
+    /// Incoming work was admitted without an eviction.
+    Admitted,
+    /// Incoming work was rejected and is returned.
+    Rejected(ScheduledWork<T, M>),
+    /// Existing work was evicted and returned; incoming work was admitted.
+    Evicted {
+        /// The evicted work item.
+        work: ScheduledWork<T, M>,
+    },
+    /// The queue was closed; incoming work is returned.
+    Closed(ScheduledWork<T, M>),
+}
+
+/// Consistent snapshot of bounded queue statistics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BoundedQueueStats {
+    /// Runtime-assigned identity, or `None` before attachment.
+    pub queue_id: Option<QueueId>,
+    /// Current queued item count.
+    pub depth: usize,
+    /// Dispatched items whose completion has not returned.
+    pub in_flight: usize,
+    /// Hard queue capacity.
+    pub capacity: usize,
+    /// Policy or hard-capacity rejections; closed attempts are excluded.
+    pub rejections: u64,
+    /// Existing items evicted by admission policy.
+    pub evictions: u64,
+    /// Current queue lifecycle.
+    pub lifecycle: QueueLifecycle,
+}
+
+struct QueueState<T, M: WorkMeta, P, D> {
+    entries: HashMap<QueueEntryId, StoredWork<T, M>>,
+    policy: P,
+    discipline: D,
+    lifecycle: QueueLifecycle,
+    in_flight: usize,
+    rejections: u64,
+    evictions: u64,
+    next_id: u64,
+    next_order: u64,
+    event_sink: Option<QueueEventSink>,
+    queue_id: Option<QueueId>,
+    drained_event_sent: bool,
+}
+
+struct QueueShared<T, M: WorkMeta, P, D> {
+    capacity: usize,
+    state: Mutex<QueueState<T, M, P, D>>,
+    producer_count: AtomicUsize,
+}
+
+/// Scheduler leaf backed by an externally-fed bounded queue.
+pub struct BoundedQueue<T, M: WorkMeta, P, D> {
+    shared: Arc<QueueShared<T, M, P, D>>,
+}
+
+/// Cloneable producer handle for a [`BoundedQueue`].
+pub struct BoundedQueueProducer<T, M: WorkMeta, P, D> {
+    shared: Arc<QueueShared<T, M, P, D>>,
+}
+
+/// Scheduler leaf and first producer returned by [`BoundedQueueBuilder::build`].
+pub type BoundedQueuePair<T, M, P, D> =
+    (BoundedQueue<T, M, P, D>, BoundedQueueProducer<T, M, P, D>);
+
+/// Builder for an externally-fed bounded queue.
+///
+/// Admission defaults to [`TailDrop`]. A discipline is intentionally not
+/// selected by default: use `.fifo()` with `queue-fifo`, or
+/// [`Self::discipline`] with an SFQ or custom implementation.
+pub struct BoundedQueueBuilder<P = TailDrop, D = ()> {
+    capacity: NonZeroUsize,
+    policy: P,
+    discipline: D,
+}
+
+impl BoundedQueueBuilder {
+    /// Start a queue builder with tail-drop admission.
+    #[must_use]
+    pub const fn new(capacity: NonZeroUsize) -> Self {
+        Self {
+            capacity,
+            policy: TailDrop,
+            discipline: (),
+        }
+    }
+}
+
+impl<P, D> BoundedQueueBuilder<P, D> {
+    /// Replace the admission policy.
+    #[must_use]
+    pub fn admission_policy<P2>(self, policy: P2) -> BoundedQueueBuilder<P2, D> {
+        BoundedQueueBuilder {
+            capacity: self.capacity,
+            policy,
+            discipline: self.discipline,
+        }
+    }
+
+    /// Select a queue discipline.
+    #[must_use]
+    pub fn discipline<D2>(self, discipline: D2) -> BoundedQueueBuilder<P, D2> {
+        BoundedQueueBuilder {
+            capacity: self.capacity,
+            policy: self.policy,
+            discipline,
+        }
+    }
+
+    /// Build the scheduler leaf and its first producer.
+    #[must_use]
+    pub fn build<T, M>(self) -> BoundedQueuePair<T, M, P, D>
+    where
+        M: WorkMeta,
+        P: AdmissionPolicy<T, M>,
+        D: QueueDiscipline<M>,
+    {
+        let shared = Arc::new(QueueShared {
+            capacity: self.capacity.get(),
+            state: Mutex::new(QueueState {
+                entries: HashMap::with_capacity(self.capacity.get()),
+                policy: self.policy,
+                discipline: self.discipline,
+                lifecycle: QueueLifecycle::Open,
+                in_flight: 0,
+                rejections: 0,
+                evictions: 0,
+                next_id: 0,
+                next_order: 0,
+                event_sink: None,
+                queue_id: None,
+                drained_event_sent: false,
+            }),
+            producer_count: AtomicUsize::new(1),
+        });
+        (
+            BoundedQueue {
+                shared: shared.clone(),
+            },
+            BoundedQueueProducer { shared },
+        )
+    }
+}
+
+impl<T, M: WorkMeta, P, D> BoundedQueue<T, M, P, D> {
+    /// Runtime-assigned identity, or `None` before attachment.
+    #[must_use]
+    pub fn queue_id(&self) -> Option<QueueId> {
+        lock_state(&self.shared).queue_id
+    }
+
+    /// Snapshot queue statistics.
+    #[must_use]
+    pub fn stats(&self) -> BoundedQueueStats {
+        snapshot(&self.shared)
+    }
+}
+
+impl<T, M: WorkMeta, P, D> Clone for BoundedQueueProducer<T, M, P, D> {
+    fn clone(&self) -> Self {
+        self.shared.producer_count.fetch_add(1, Ordering::Relaxed);
+        Self {
+            shared: self.shared.clone(),
+        }
+    }
+}
+
+impl<T, M: WorkMeta, P, D> BoundedQueueProducer<T, M, P, D>
+where
+    P: AdmissionPolicy<T, M>,
+    D: QueueDiscipline<M>,
+{
+    /// Attempt to enqueue `work` without waiting for queue space.
+    ///
+    /// The policy and discipline run under the queue mutex and must return
+    /// promptly. Invalid admission decisions are rejected, and the hard
+    /// capacity is enforced independently of policy behavior.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the policy or discipline panics.
+    pub fn try_push(&self, work: ScheduledWork<T, M>) -> EnqueueOutcome<T, M> {
+        let (outcome, sink) = {
+            let mut state = lock_state(&self.shared);
+            let result = if state.lifecycle == QueueLifecycle::Open {
+                let decision = {
+                    let QueueState {
+                        entries, policy, ..
+                    } = &mut *state;
+                    policy.decide(
+                        AdmissionContext {
+                            capacity: self.shared.capacity,
+                            entries,
+                        },
+                        &work,
+                    )
+                };
+
+                let was_empty = state.entries.is_empty();
+                let outcome = state.apply_admission(decision, work, self.shared.capacity);
+                let wake = was_empty
+                    && !state.entries.is_empty()
+                    && matches!(
+                        &outcome,
+                        EnqueueOutcome::Admitted | EnqueueOutcome::Evicted { .. }
+                    );
+                let sink = wake.then(|| state.event_sink.clone()).flatten();
+                (outcome, sink)
+            } else {
+                (EnqueueOutcome::Closed(work), None)
+            };
+            drop(state);
+            result
+        };
+        if let Some(sink) = sink {
+            sink.push(QueueEvent::WakeUp);
+        }
+        outcome
+    }
+
+    /// Close the queue to every producer and return its resulting lifecycle.
+    ///
+    /// Already accepted work remains scheduled until fully drained.
+    ///
+    #[must_use]
+    pub fn close(&self) -> QueueLifecycle {
+        close_shared(&self.shared)
+    }
+
+    /// Runtime-assigned identity, or `None` before attachment.
+    #[must_use]
+    pub fn queue_id(&self) -> Option<QueueId> {
+        lock_state(&self.shared).queue_id
+    }
+
+    /// Snapshot queue statistics.
+    #[must_use]
+    pub fn stats(&self) -> BoundedQueueStats {
+        snapshot(&self.shared)
+    }
+}
+
+impl<T, M: WorkMeta, P, D> Drop for BoundedQueueProducer<T, M, P, D> {
+    fn drop(&mut self) {
+        if self.shared.producer_count.fetch_sub(1, Ordering::AcqRel) == 1 {
+            let _ = close_shared(&self.shared);
+        }
+    }
+}
+
+fn lock_state<T, M: WorkMeta, P, D>(
+    shared: &QueueShared<T, M, P, D>,
+) -> MutexGuard<'_, QueueState<T, M, P, D>> {
+    match shared.state.lock() {
+        Ok(state) => state,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+impl<T, M: WorkMeta, P, D> QueueState<T, M, P, D>
+where
+    D: QueueDiscipline<M>,
+{
+    fn apply_admission(
+        &mut self,
+        decision: AdmissionDecision,
+        work: ScheduledWork<T, M>,
+        capacity: usize,
+    ) -> EnqueueOutcome<T, M> {
+        match decision {
+            AdmissionDecision::Admit if self.entries.len() < capacity => {
+                insert_work(self, work);
+                EnqueueOutcome::Admitted
+            }
+            AdmissionDecision::EvictAndAdmit { id } => {
+                if let Some(evicted) = evict_entry(self, id) {
+                    self.evictions = self.evictions.saturating_add(1);
+                    insert_work(self, work);
+                    EnqueueOutcome::Evicted { work: evicted.work }
+                } else {
+                    self.rejections = self.rejections.saturating_add(1);
+                    EnqueueOutcome::Rejected(work)
+                }
+            }
+            AdmissionDecision::Admit | AdmissionDecision::Reject => {
+                self.rejections = self.rejections.saturating_add(1);
+                EnqueueOutcome::Rejected(work)
+            }
+        }
+    }
+}
+
+fn insert_work<T, M: WorkMeta, P, D>(state: &mut QueueState<T, M, P, D>, work: ScheduledWork<T, M>)
+where
+    D: QueueDiscipline<M>,
+{
+    let id = next_entry_id(state);
+    let admitted_order = next_admitted_order(state);
+    state.discipline.push(id, &work.meta);
+    state.entries.insert(
+        id,
+        StoredWork {
+            admitted_order,
+            work,
+        },
+    );
+}
+
+fn evict_entry<T, M: WorkMeta, P, D>(
+    state: &mut QueueState<T, M, P, D>,
+    id: QueueEntryId,
+) -> Option<StoredWork<T, M>>
+where
+    D: QueueDiscipline<M>,
+{
+    if !state.entries.contains_key(&id) || !state.discipline.remove(id) {
+        return None;
+    }
+    state.entries.remove(&id)
+}
+
+fn next_admitted_order<T, M: WorkMeta, P, D>(state: &mut QueueState<T, M, P, D>) -> u64 {
+    if state.next_order == u64::MAX {
+        rebase_admitted_order(state);
+    }
+    let admitted_order = state.next_order;
+    state.next_order += 1;
+    admitted_order
+}
+
+fn rebase_admitted_order<T, M: WorkMeta, P, D>(state: &mut QueueState<T, M, P, D>) {
+    let mut ordered: Vec<_> = state
+        .entries
+        .iter()
+        .map(|(&id, stored)| (id, stored.admitted_order))
+        .collect();
+    ordered.sort_unstable_by_key(|(_, admitted_order)| *admitted_order);
+    for (new_order, (id, _)) in ordered.into_iter().enumerate() {
+        let stored = state
+            .entries
+            .get_mut(&id)
+            .expect("collected queue entry remains present");
+        stored.admitted_order =
+            u64::try_from(new_order).expect("live queue entry count fits in u64");
+    }
+    state.next_order =
+        u64::try_from(state.entries.len()).expect("live queue entry count fits in u64");
+}
+
+fn next_entry_id<T, M: WorkMeta, P, D>(state: &mut QueueState<T, M, P, D>) -> QueueEntryId {
+    loop {
+        let id = QueueEntryId(state.next_id);
+        state.next_id = state.next_id.wrapping_add(1);
+        if !state.entries.contains_key(&id) {
+            return id;
+        }
+    }
+}
+
+fn close_shared<T, M: WorkMeta, P, D>(shared: &QueueShared<T, M, P, D>) -> QueueLifecycle {
+    let mut state = lock_state(shared);
+    if state.lifecycle == QueueLifecycle::Open {
+        state.lifecycle = if state.entries.is_empty() && state.in_flight == 0 {
+            QueueLifecycle::Drained
+        } else {
+            QueueLifecycle::Draining
+        };
+    }
+    let event = take_drained_event(&mut state);
+    let lifecycle = state.lifecycle;
+    drop(state);
+    emit(event);
+    lifecycle
+}
+
+fn snapshot<T, M: WorkMeta, P, D>(shared: &QueueShared<T, M, P, D>) -> BoundedQueueStats {
+    let state = lock_state(shared);
+    BoundedQueueStats {
+        queue_id: state.queue_id,
+        depth: state.entries.len(),
+        in_flight: state.in_flight,
+        capacity: shared.capacity,
+        rejections: state.rejections,
+        evictions: state.evictions,
+        lifecycle: state.lifecycle,
+    }
+}
+
+fn take_drained_event<T, M: WorkMeta, P, D>(
+    state: &mut QueueState<T, M, P, D>,
+) -> Option<(QueueEventSink, QueueEvent)> {
+    if state.lifecycle == QueueLifecycle::Drained && !state.drained_event_sent {
+        if let (Some(sink), Some(queue_id)) = (state.event_sink.clone(), state.queue_id) {
+            state.drained_event_sent = true;
+            return Some((sink, QueueEvent::Drained { queue_id }));
+        }
+    }
+    None
+}
+
+fn emit(event: Option<(QueueEventSink, QueueEvent)>) {
+    if let Some((sink, event)) = event {
+        sink.push(event);
+    }
+}
+
+impl<T, M, P, D> Scheduler<T> for BoundedQueue<T, M, P, D>
+where
+    T: Send + 'static,
+    M: WorkMeta,
+    P: AdmissionPolicy<T, M>,
+    D: QueueDiscipline<M>,
+{
+    type Meta = M;
+
+    fn update_ready(&mut self, _now: Instant) -> Readiness {
+        let state = lock_state(&self.shared);
+        if state.entries.is_empty() {
+            Readiness::not_ready(None)
+        } else {
+            Readiness::ready(None)
+        }
+    }
+
+    fn take_next(&mut self) -> Option<ScheduledWork<T, M>> {
+        let mut state = lock_state(&self.shared);
+        let attempts = state.entries.len().saturating_add(1);
+        for _ in 0..attempts {
+            let Some(id) = state.discipline.take_next() else {
+                break;
+            };
+            if let Some(work) = take_entry(&mut state, id) {
+                drop(state);
+                return Some(work);
+            }
+        }
+
+        let fallback = state
+            .entries
+            .iter()
+            .min_by_key(|(_, stored)| stored.admitted_order)
+            .map(|(&id, _)| id)?;
+        let _ = state.discipline.remove(fallback);
+        let work = take_entry(&mut state, fallback);
+        drop(state);
+        work
+    }
+
+    fn on_complete(&mut self, _completion: Completion<M>) {
+        let mut state = lock_state(&self.shared);
+        state.in_flight = state.in_flight.saturating_sub(1);
+        if state.lifecycle == QueueLifecycle::Draining
+            && state.entries.is_empty()
+            && state.in_flight == 0
+        {
+            state.lifecycle = QueueLifecycle::Drained;
+        }
+        let event = take_drained_event(&mut state);
+        drop(state);
+        emit(event);
+    }
+
+    fn register_queue_event_sink(&mut self, sink: QueueEventSink) {
+        let mut state = lock_state(&self.shared);
+        let new_runtime = state
+            .event_sink
+            .as_ref()
+            .is_none_or(|current| !current.belongs_to_same_runtime(&sink));
+        if new_runtime {
+            state.queue_id = Some(sink.allocate_queue_id());
+            state.drained_event_sent = false;
+        }
+        state.event_sink = Some(sink);
+        let event = take_drained_event(&mut state);
+        drop(state);
+        emit(event);
+    }
+}
+
+fn take_entry<T, M: WorkMeta, P, D>(
+    state: &mut QueueState<T, M, P, D>,
+    id: QueueEntryId,
+) -> Option<ScheduledWork<T, M>> {
+    let stored = state.entries.remove(&id)?;
+    state.in_flight = state.in_flight.saturating_add(1);
+    Some(stored.work)
+}
+
+#[cfg(test)]
+#[cfg(feature = "queue-fifo")]
+mod tests {
+    #[cfg(feature = "runtime-events")]
+    use core::sync::atomic::{AtomicBool, Ordering};
+    #[cfg(feature = "runtime-events")]
+    use core::task::Poll;
+    use core::time::Duration;
+    #[cfg(feature = "runtime-events")]
+    use futures_util::future::poll_fn;
+    #[cfg(feature = "runtime-events")]
+    use futures_util::task::AtomicWaker;
+    use std::num::{NonZeroU32, NonZeroUsize};
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+    #[cfg(feature = "runtime-events")]
+    use std::sync::Arc;
+    use std::thread;
+    use tokio::task::yield_now;
+    use tokio::time::timeout;
+
+    use super::{
+        AdmissionContext, AdmissionDecision, AdmissionPolicy, BoundedQueueBuilder, EnqueueOutcome,
+        QueueDiscipline, QueueEntryId, QueueLifecycle,
+    };
+    use crate::scheduler::{ScheduledWork, Scheduler as _};
+    use crate::schedulers::{BoundedConcurrency, RoundRobin};
+    use crate::work::{Completion, CompletionOutcome, RoutingPath};
+    use crate::{Runtime, RuntimeConfig, RuntimeOutput};
+
+    const fn capacity(value: usize) -> NonZeroUsize {
+        NonZeroUsize::new(value).expect("non-zero test capacity")
+    }
+
+    struct PrematureNone;
+
+    impl<M> QueueDiscipline<M> for PrematureNone {
+        fn push(&mut self, _id: QueueEntryId, _meta: &M) {}
+
+        fn take_next(&mut self) -> Option<QueueEntryId> {
+            None
+        }
+
+        fn remove(&mut self, _id: QueueEntryId) -> bool {
+            false
+        }
+    }
+
+    struct StaleId;
+
+    impl<M> QueueDiscipline<M> for StaleId {
+        fn push(&mut self, _id: QueueEntryId, _meta: &M) {}
+
+        fn take_next(&mut self) -> Option<QueueEntryId> {
+            Some(QueueEntryId(u64::MAX))
+        }
+
+        fn remove(&mut self, _id: QueueEntryId) -> bool {
+            false
+        }
+    }
+
+    struct PanicOnce {
+        id: Option<QueueEntryId>,
+        panicked: bool,
+    }
+
+    impl<M> QueueDiscipline<M> for PanicOnce {
+        fn push(&mut self, id: QueueEntryId, _meta: &M) {
+            self.id = Some(id);
+        }
+
+        #[allow(clippy::panic)]
+        fn take_next(&mut self) -> Option<QueueEntryId> {
+            if !self.panicked {
+                self.panicked = true;
+                panic!("test discipline panic");
+            }
+            self.id.take()
+        }
+
+        fn remove(&mut self, id: QueueEntryId) -> bool {
+            if self.id == Some(id) {
+                self.id = None;
+                true
+            } else {
+                false
+            }
+        }
+    }
+
+    #[test]
+    fn premature_none_from_custom_discipline_cannot_strand_entries() {
+        let (mut queue, producer) = BoundedQueueBuilder::new(capacity(2))
+            .discipline(PrematureNone)
+            .build();
+        let _ = producer.try_push(ScheduledWork::new((), 1_u8));
+        let _ = producer.try_push(ScheduledWork::new((), 2_u8));
+
+        assert_eq!(queue.take_next().map(|work| work.payload), Some(1));
+        assert_eq!(queue.take_next().map(|work| work.payload), Some(2));
+        assert_eq!(producer.stats().depth, 0);
+    }
+
+    #[test]
+    fn stale_ids_from_custom_discipline_cannot_strand_entries() {
+        let (mut queue, producer) = BoundedQueueBuilder::new(capacity(2))
+            .discipline(StaleId)
+            .build();
+        let _ = producer.try_push(ScheduledWork::new((), 1_u8));
+        let _ = producer.try_push(ScheduledWork::new((), 2_u8));
+
+        assert_eq!(queue.take_next().map(|work| work.payload), Some(1));
+        assert_eq!(queue.take_next().map(|work| work.payload), Some(2));
+        assert_eq!(producer.stats().depth, 0);
+    }
+
+    #[test]
+    fn poisoned_queue_state_is_recovered_without_stranding_entries() {
+        let (mut queue, producer) = BoundedQueueBuilder::new(capacity(1))
+            .discipline(PanicOnce {
+                id: None,
+                panicked: false,
+            })
+            .build();
+        let _ = producer.try_push(ScheduledWork::new((), 1_u8));
+
+        let panic = catch_unwind(AssertUnwindSafe(|| queue.take_next()));
+        assert!(panic.is_err());
+        assert_eq!(producer.stats().depth, 1);
+        assert_eq!(producer.queue_id(), None);
+        assert_eq!(queue.take_next().map(|work| work.payload), Some(1));
+        assert_eq!(producer.stats().depth, 0);
+    }
+
+    #[test]
+    fn tail_drop_is_bounded_and_fifo() {
+        let (mut queue, producer) = BoundedQueueBuilder::new(capacity(2)).fifo().build();
+        assert!(matches!(
+            producer.try_push(ScheduledWork::new((), 1_u8)),
+            EnqueueOutcome::Admitted
+        ));
+        assert!(matches!(
+            producer.try_push(ScheduledWork::new((), 2)),
+            EnqueueOutcome::Admitted
+        ));
+        assert!(matches!(
+            producer.try_push(ScheduledWork::new((), 3)),
+            EnqueueOutcome::Rejected(work) if work.payload == 3
+        ));
+        assert_eq!(producer.stats().depth, 2);
+        assert_eq!(producer.stats().rejections, 1);
+        assert_eq!(queue.take_next().map(|work| work.payload), Some(1));
+        assert_eq!(queue.take_next().map(|work| work.payload), Some(2));
+    }
+
+    struct EarlyDrop;
+
+    impl AdmissionPolicy<u8, u8> for EarlyDrop {
+        fn decide(
+            &mut self,
+            context: AdmissionContext<'_, u8, u8>,
+            incoming: &ScheduledWork<u8, u8>,
+        ) -> AdmissionDecision {
+            if incoming.meta == 0 && context.depth() >= 1 {
+                AdmissionDecision::Reject
+            } else {
+                AdmissionDecision::Admit
+            }
+        }
+    }
+
+    #[test]
+    fn custom_policy_can_drop_early_using_metadata() {
+        let (_queue, producer) = BoundedQueueBuilder::new(capacity(4))
+            .admission_policy(EarlyDrop)
+            .fifo()
+            .build();
+        let _ = producer.try_push(ScheduledWork::new(1, 10));
+        assert!(matches!(
+            producer.try_push(ScheduledWork::new(0, 11)),
+            EnqueueOutcome::Rejected(work) if work.payload == 11
+        ));
+        assert_eq!(producer.stats().depth, 1);
+    }
+
+    struct AlwaysAdmit;
+
+    impl AdmissionPolicy<usize, ()> for AlwaysAdmit {
+        fn decide(
+            &mut self,
+            _context: AdmissionContext<'_, usize, ()>,
+            _incoming: &ScheduledWork<usize, ()>,
+        ) -> AdmissionDecision {
+            AdmissionDecision::Admit
+        }
+    }
+
+    #[test]
+    fn hard_capacity_holds_for_concurrent_producers_and_bad_policy() {
+        let (_queue, producer) = BoundedQueueBuilder::new(capacity(8))
+            .admission_policy(AlwaysAdmit)
+            .fifo()
+            .build();
+        thread::scope(|scope| {
+            for producer_id in 0..4 {
+                let producer = producer.clone();
+                scope.spawn(move || {
+                    for item_id in 0..32 {
+                        let payload = producer_id * 32 + item_id;
+                        let _ = producer.try_push(ScheduledWork::new((), payload));
+                    }
+                });
+            }
+        });
+        assert_eq!(producer.stats().depth, 8);
+        assert_eq!(producer.stats().rejections, 120);
+    }
+
+    struct DropOldest;
+
+    impl AdmissionPolicy<u8, ()> for DropOldest {
+        fn decide(
+            &mut self,
+            context: AdmissionContext<'_, u8, ()>,
+            _incoming: &ScheduledWork<u8, ()>,
+        ) -> AdmissionDecision {
+            if context.depth() == context.capacity() {
+                AdmissionDecision::EvictAndAdmit {
+                    id: context
+                        .oldest()
+                        .expect("full queue has an oldest entry")
+                        .id(),
+                }
+            } else {
+                AdmissionDecision::Admit
+            }
+        }
+    }
+
+    #[test]
+    fn eviction_by_stable_id_returns_existing_work() {
+        let (mut queue, producer) = BoundedQueueBuilder::new(capacity(2))
+            .admission_policy(DropOldest)
+            .fifo()
+            .build();
+        let _ = producer.try_push(ScheduledWork::new((), 1));
+        let _ = producer.try_push(ScheduledWork::new((), 2));
+        assert!(matches!(
+            producer.try_push(ScheduledWork::new((), 3)),
+            EnqueueOutcome::Evicted { work } if work.payload == 1
+        ));
+        assert_eq!(queue.take_next().map(|work| work.payload), Some(2));
+        assert_eq!(queue.take_next().map(|work| work.payload), Some(3));
+    }
+
+    #[test]
+    fn admission_order_is_rebased_before_counter_rollover() {
+        let (_queue, producer) = BoundedQueueBuilder::new(capacity(4)).fifo().build();
+        let _ = producer.try_push(ScheduledWork::new((), 1_u8));
+        let _ = producer.try_push(ScheduledWork::new((), 2_u8));
+        {
+            let mut state = producer
+                .shared
+                .state
+                .lock()
+                .expect("test queue mutex is not poisoned");
+            for stored in state.entries.values_mut() {
+                stored.admitted_order = match stored.work.payload {
+                    1 => u64::MAX - 2,
+                    2 => u64::MAX - 1,
+                    _ => unreachable!("only two test entries exist"),
+                };
+            }
+            state.next_order = u64::MAX;
+        }
+
+        let _ = producer.try_push(ScheduledWork::new((), 3_u8));
+        let state = producer
+            .shared
+            .state
+            .lock()
+            .expect("test queue mutex is not poisoned");
+        let context = AdmissionContext {
+            capacity: producer.shared.capacity,
+            entries: &state.entries,
+        };
+        let oldest = context.oldest().map(|entry| entry.work().payload);
+        let mut orders: Vec<_> = state
+            .entries
+            .values()
+            .map(|stored| stored.admitted_order)
+            .collect();
+        drop(state);
+        assert_eq!(oldest, Some(1));
+        orders.sort_unstable();
+        assert_eq!(orders, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn close_tracks_queued_and_in_flight_draining() {
+        let (mut queue, producer) = BoundedQueueBuilder::new(capacity(2)).fifo().build();
+        let _ = producer.try_push(ScheduledWork::new((), 1_u8));
+        assert_eq!(producer.close(), QueueLifecycle::Draining);
+        assert_eq!(producer.close(), QueueLifecycle::Draining);
+
+        let work = queue.take_next().expect("queued work");
+        assert_eq!(producer.stats().depth, 0);
+        assert_eq!(producer.stats().in_flight, 1);
+        queue.on_complete(Completion {
+            outcome: CompletionOutcome::Succeeded,
+            latency: Duration::ZERO,
+            meta: work.meta,
+            routing: RoutingPath::empty(),
+        });
+        assert_eq!(producer.stats().lifecycle, QueueLifecycle::Drained);
+        assert_eq!(producer.stats().in_flight, 0);
+        assert!(matches!(
+            producer.try_push(ScheduledWork::new((), 2)),
+            EnqueueOutcome::Closed(work) if work.payload == 2
+        ));
+    }
+
+    #[test]
+    fn composes_with_round_robin_and_bounded_concurrency() {
+        let (queue, producer) = BoundedQueueBuilder::new(capacity(2)).fifo().build();
+        let mut round_robin: RoundRobin<u8, ()> = RoundRobin::new();
+        round_robin.add_child(queue);
+        let mut root = BoundedConcurrency::new(
+            NonZeroU32::new(1).expect("non-zero test concurrency"),
+            round_robin,
+        );
+        let _ = producer.try_push(ScheduledWork::new((), 7));
+        assert_eq!(root.take_next().map(|work| work.payload), Some(7));
+    }
+
+    #[tokio::test]
+    async fn wake_up_signal_wakes_a_waiting_runtime_without_an_output_event() {
+        type Work = crate::FutureWork<u8, ()>;
+
+        let (queue, producer) = BoundedQueueBuilder::new(capacity(1)).fifo().build();
+        let mut runtime = Runtime::new(
+            RuntimeConfig {
+                global_max_in_flight: capacity(1),
+                clock: crate::ClockConfig::Wallclock,
+            },
+            queue,
+        );
+
+        let push = async move {
+            yield_now().await;
+            let work: Work = Box::pin(async { Ok(vec![9]) });
+            let _ = producer.try_push(ScheduledWork::new((), work));
+        };
+        let next = timeout(Duration::from_secs(1), runtime.next());
+        let ((), output) = tokio::join!(push, next);
+        assert!(matches!(
+            output,
+            Ok(RuntimeOutput::Work {
+                result: Ok(events),
+                ..
+            }) if events == vec![9]
+        ));
+    }
+
+    #[tokio::test]
+    async fn dynamically_added_queue_receives_the_runtime_sink() {
+        type Work = crate::FutureWork<u8, ()>;
+
+        let root: RoundRobin<Work, ()> = RoundRobin::new();
+        let mut runtime = Runtime::new(
+            RuntimeConfig {
+                global_max_in_flight: capacity(1),
+                clock: crate::ClockConfig::Wallclock,
+            },
+            root,
+        );
+        let handle = runtime.handle();
+        let (queue, producer) = BoundedQueueBuilder::new(capacity(1)).fifo().build();
+        assert!(handle
+            .with_root_mut::<RoundRobin<Work, ()>, _>(|root| root.add_child(queue))
+            .is_some());
+
+        let push = async move {
+            yield_now().await;
+            let work: Work = Box::pin(async { Ok(vec![11]) });
+            let _ = producer.try_push(ScheduledWork::new((), work));
+        };
+        let next = timeout(Duration::from_secs(1), runtime.next());
+        let ((), output) = tokio::join!(push, next);
+        assert!(matches!(
+            output,
+            Ok(RuntimeOutput::Work {
+                result: Ok(events),
+                ..
+            }) if events == vec![11]
+        ));
+    }
+
+    #[test]
+    fn runtime_assigns_distinct_queue_ids() {
+        type Work = crate::FutureWork<u8, ()>;
+
+        let (first_queue, first_producer): (_, super::BoundedQueueProducer<Work, (), _, _>) =
+            BoundedQueueBuilder::new(capacity(1)).fifo().build();
+        let (second_queue, second_producer): (_, super::BoundedQueueProducer<Work, (), _, _>) =
+            BoundedQueueBuilder::new(capacity(1)).fifo().build();
+        assert_eq!(first_producer.queue_id(), None);
+        assert_eq!(second_producer.queue_id(), None);
+
+        let mut root: RoundRobin<Work, ()> = RoundRobin::new();
+        root.add_child(first_queue);
+        root.add_child(second_queue);
+        let _runtime: Runtime<u8, (), ()> = Runtime::new(
+            RuntimeConfig {
+                global_max_in_flight: capacity(1),
+                clock: crate::ClockConfig::Wallclock,
+            },
+            root,
+        );
+
+        let first_id = first_producer
+            .queue_id()
+            .expect("runtime assigns the first queue ID");
+        let second_id = second_producer
+            .queue_id()
+            .expect("runtime assigns the second queue ID");
+        assert_ne!(first_id, second_id);
+    }
+
+    #[cfg(feature = "runtime-events")]
+    #[tokio::test]
+    async fn runtime_emits_work_then_queue_drained_exactly_once() {
+        type Work = crate::FutureWork<u8, ()>;
+
+        let (queue, producer) = BoundedQueueBuilder::new(capacity(1)).fifo().build();
+        let mut runtime = Runtime::new(
+            RuntimeConfig {
+                global_max_in_flight: capacity(1),
+                clock: crate::ClockConfig::Wallclock,
+            },
+            queue,
+        );
+        let queue_id = producer.queue_id().expect("runtime assigns a queue ID");
+        let work: Work = Box::pin(async { Ok(vec![10]) });
+        let _ = producer.try_push(ScheduledWork::new((), work));
+        assert_eq!(producer.close(), QueueLifecycle::Draining);
+
+        assert!(matches!(
+            runtime.next().await,
+            RuntimeOutput::Work {
+                result: Ok(events),
+                ..
+            } if events == vec![10]
+        ));
+        assert!(matches!(
+            runtime.next().await,
+            RuntimeOutput::Runtime(crate::RuntimeEvent::QueueDrained {
+                queue_id: emitted
+            }) if emitted == queue_id
+        ));
+        assert_eq!(producer.stats().lifecycle, QueueLifecycle::Drained);
+        assert!(
+            timeout(Duration::from_millis(20), runtime.next())
+                .await
+                .is_err(),
+            "QueueDrained must be emitted exactly once"
+        );
+    }
+
+    #[cfg(feature = "runtime-events")]
+    #[tokio::test]
+    async fn dropping_final_producer_closes_in_flight_queue_and_emits_once() {
+        type Work = crate::FutureWork<u8, ()>;
+
+        let started = Arc::new(AtomicBool::new(false));
+        let released = Arc::new(AtomicBool::new(false));
+        let gate_waker = Arc::new(AtomicWaker::new());
+        let started_for_work = started.clone();
+        let released_for_work = released.clone();
+        let gate_waker_for_work = gate_waker.clone();
+        let work: Work = Box::pin(poll_fn(move |cx| {
+            started_for_work.store(true, Ordering::Release);
+            if released_for_work.load(Ordering::Acquire) {
+                return Poll::Ready(Ok(vec![12]));
+            }
+            gate_waker_for_work.register(cx.waker());
+            if released_for_work.load(Ordering::Acquire) {
+                Poll::Ready(Ok(vec![12]))
+            } else {
+                Poll::Pending
+            }
+        }));
+
+        let (queue, producer) = BoundedQueueBuilder::new(capacity(1)).fifo().build();
+        let mut runtime = Runtime::new(
+            RuntimeConfig {
+                global_max_in_flight: capacity(1),
+                clock: crate::ClockConfig::Wallclock,
+            },
+            queue,
+        );
+        let queue_id = producer.queue_id().expect("runtime assigns a queue ID");
+        let _ = producer.try_push(ScheduledWork::new((), work));
+
+        let drive = async {
+            assert!(matches!(
+                runtime.next().await,
+                RuntimeOutput::Work {
+                    result: Ok(events),
+                    ..
+                } if events == vec![12]
+            ));
+            assert!(matches!(
+                runtime.next().await,
+                RuntimeOutput::Runtime(crate::RuntimeEvent::QueueDrained {
+                    queue_id: emitted
+                }) if emitted == queue_id
+            ));
+            assert!(
+                timeout(Duration::from_millis(20), runtime.next())
+                    .await
+                    .is_err(),
+                "automatic close must emit QueueDrained exactly once"
+            );
+        };
+        let close_and_release = async move {
+            while !started.load(Ordering::Acquire) {
+                yield_now().await;
+            }
+            drop(producer);
+            released.store(true, Ordering::Release);
+            gate_waker.wake();
+        };
+        let ((), ()) = tokio::join!(drive, close_and_release);
+    }
+
+    #[cfg(feature = "runtime-events")]
+    #[tokio::test]
+    async fn closing_an_empty_queue_emits_drained_immediately() {
+        let (queue, producer): (
+            _,
+            super::BoundedQueueProducer<crate::FutureWork<u8, ()>, (), _, _>,
+        ) = BoundedQueueBuilder::new(capacity(1)).fifo().build();
+        assert_eq!(producer.close(), QueueLifecycle::Drained);
+        let mut runtime = Runtime::new(
+            RuntimeConfig {
+                global_max_in_flight: capacity(1),
+                clock: crate::ClockConfig::Wallclock,
+            },
+            queue,
+        );
+        let queue_id = producer.queue_id().expect("runtime assigns a queue ID");
+
+        assert!(matches!(
+            runtime.next().await,
+            RuntimeOutput::Runtime(crate::RuntimeEvent::QueueDrained {
+                queue_id: emitted
+            }) if emitted == queue_id
+        ));
+    }
+
+    #[test]
+    fn empty_closed_queue_is_immediately_drained() {
+        let (_queue, producer): (_, super::BoundedQueueProducer<u8, (), _, _>) =
+            BoundedQueueBuilder::new(capacity(1)).fifo().build();
+        assert_eq!(producer.close(), QueueLifecycle::Drained);
+        assert_eq!(producer.stats().lifecycle, QueueLifecycle::Drained);
+        assert_eq!(producer.stats().depth, 0);
+        assert_eq!(producer.stats().in_flight, 0);
+    }
+}

--- a/dispatcher/src/schedulers/circuit_breaker.rs
+++ b/dispatcher/src/schedulers/circuit_breaker.rs
@@ -223,7 +223,6 @@ where
         self.inner.on_complete(completion);
     }
 
-    #[cfg(feature = "queue")]
     fn register_queue_event_sink(&mut self, sink: crate::QueueEventSink) {
         self.inner.register_queue_event_sink(sink);
     }

--- a/dispatcher/src/schedulers/circuit_breaker.rs
+++ b/dispatcher/src/schedulers/circuit_breaker.rs
@@ -222,6 +222,11 @@ where
         }
         self.inner.on_complete(completion);
     }
+
+    #[cfg(feature = "queue")]
+    fn register_queue_event_sink(&mut self, sink: crate::QueueEventSink) {
+        self.inner.register_queue_event_sink(sink);
+    }
 }
 
 #[cfg(test)]

--- a/dispatcher/src/schedulers/fixed_cost.rs
+++ b/dispatcher/src/schedulers/fixed_cost.rs
@@ -91,7 +91,6 @@ where
         });
     }
 
-    #[cfg(feature = "queue")]
     fn register_queue_event_sink(&mut self, sink: crate::QueueEventSink) {
         self.inner.register_queue_event_sink(sink);
     }

--- a/dispatcher/src/schedulers/fixed_cost.rs
+++ b/dispatcher/src/schedulers/fixed_cost.rs
@@ -90,6 +90,11 @@ where
             routing: completion.routing,
         });
     }
+
+    #[cfg(feature = "queue")]
+    fn register_queue_event_sink(&mut self, sink: crate::QueueEventSink) {
+        self.inner.register_queue_event_sink(sink);
+    }
 }
 
 #[cfg(test)]

--- a/dispatcher/src/schedulers/mod.rs
+++ b/dispatcher/src/schedulers/mod.rs
@@ -20,21 +20,17 @@
 //! composed with each other or with user-written leaves and branches.
 
 mod bounded_concurrency;
-#[cfg(feature = "queue")]
 mod bounded_queue;
 mod circuit_breaker;
 mod fixed_cost;
 mod periodic_leaf;
-#[cfg(feature = "queue-fifo")]
 mod queue_fifo;
-#[cfg(feature = "queue-sfq")]
 mod queue_sfq;
 mod round_robin;
 mod strict_priority;
 mod token_bucket;
 
 pub use bounded_concurrency::BoundedConcurrency;
-#[cfg(feature = "queue")]
 pub use bounded_queue::{
     AdmissionContext, AdmissionDecision, AdmissionPolicy, BoundedQueue, BoundedQueueBuilder,
     BoundedQueuePair, BoundedQueueProducer, BoundedQueueStats, EnqueueOutcome, QueueDiscipline,
@@ -43,9 +39,7 @@ pub use bounded_queue::{
 pub use circuit_breaker::{BreakerState, CircuitBreaker, CircuitBreakerConfig};
 pub use fixed_cost::FixedCost;
 pub use periodic_leaf::PeriodicLeaf;
-#[cfg(feature = "queue-fifo")]
 pub use queue_fifo::Fifo;
-#[cfg(feature = "queue-sfq")]
 pub use queue_sfq::StochasticFairQueue;
 pub use round_robin::{RemovedChild, RoundRobin};
 pub use strict_priority::StrictPriority;
@@ -176,6 +170,8 @@ mod tests {
                 .expect("MockLeaf completions log poisoned")
                 .push(completion);
         }
+
+        fn register_queue_event_sink(&mut self, _sink: crate::QueueEventSink) {}
     }
 
     /// Drive one full dispatch / completion round-trip against `sched`.

--- a/dispatcher/src/schedulers/mod.rs
+++ b/dispatcher/src/schedulers/mod.rs
@@ -20,17 +20,33 @@
 //! composed with each other or with user-written leaves and branches.
 
 mod bounded_concurrency;
+#[cfg(feature = "queue")]
+mod bounded_queue;
 mod circuit_breaker;
 mod fixed_cost;
 mod periodic_leaf;
+#[cfg(feature = "queue-fifo")]
+mod queue_fifo;
+#[cfg(feature = "queue-sfq")]
+mod queue_sfq;
 mod round_robin;
 mod strict_priority;
 mod token_bucket;
 
 pub use bounded_concurrency::BoundedConcurrency;
+#[cfg(feature = "queue")]
+pub use bounded_queue::{
+    AdmissionContext, AdmissionDecision, AdmissionPolicy, BoundedQueue, BoundedQueueBuilder,
+    BoundedQueuePair, BoundedQueueProducer, BoundedQueueStats, EnqueueOutcome, QueueDiscipline,
+    QueueEntryId, QueueEntryRef, QueueLifecycle, TailDrop,
+};
 pub use circuit_breaker::{BreakerState, CircuitBreaker, CircuitBreakerConfig};
 pub use fixed_cost::FixedCost;
 pub use periodic_leaf::PeriodicLeaf;
+#[cfg(feature = "queue-fifo")]
+pub use queue_fifo::Fifo;
+#[cfg(feature = "queue-sfq")]
+pub use queue_sfq::StochasticFairQueue;
 pub use round_robin::{RemovedChild, RoundRobin};
 pub use strict_priority::StrictPriority;
 pub use token_bucket::{TokenBucket, TokenBucketConfig};

--- a/dispatcher/src/schedulers/periodic_leaf.rs
+++ b/dispatcher/src/schedulers/periodic_leaf.rs
@@ -143,6 +143,8 @@ where
     }
 
     fn on_complete(&mut self, _completion: Completion<()>) {}
+
+    fn register_queue_event_sink(&mut self, _sink: crate::QueueEventSink) {}
 }
 
 #[cfg(test)]

--- a/dispatcher/src/schedulers/periodic_leaf.rs
+++ b/dispatcher/src/schedulers/periodic_leaf.rs
@@ -130,6 +130,7 @@ where
         }
     }
 
+    #[inline]
     fn take_next(&mut self) -> Option<ScheduledWork<T, ()>> {
         if !self.due(self.last_now) {
             return None;

--- a/dispatcher/src/schedulers/queue_fifo.rs
+++ b/dispatcher/src/schedulers/queue_fifo.rs
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! FIFO queue discipline.
+
+use std::collections::VecDeque;
+
+use super::bounded_queue::{BoundedQueueBuilder, QueueDiscipline, QueueEntryId};
+
+/// First-in, first-out queue discipline.
+#[derive(Debug, Default)]
+pub struct Fifo {
+    entries: VecDeque<QueueEntryId>,
+}
+
+impl Fifo {
+    /// Empty FIFO discipline.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            entries: VecDeque::new(),
+        }
+    }
+}
+
+impl<M> QueueDiscipline<M> for Fifo {
+    fn push(&mut self, id: QueueEntryId, _meta: &M) {
+        self.entries.push_back(id);
+    }
+
+    fn take_next(&mut self) -> Option<QueueEntryId> {
+        self.entries.pop_front()
+    }
+
+    fn remove(&mut self, id: QueueEntryId) -> bool {
+        let Some(position) = self.entries.iter().position(|&entry| entry == id) else {
+            return false;
+        };
+        let _ = self.entries.remove(position);
+        true
+    }
+}
+
+impl<P, D> BoundedQueueBuilder<P, D> {
+    /// Select the built-in FIFO discipline.
+    #[must_use]
+    pub fn fifo(self) -> BoundedQueueBuilder<P, Fifo> {
+        self.discipline(Fifo::new())
+    }
+}

--- a/dispatcher/src/schedulers/queue_sfq.rs
+++ b/dispatcher/src/schedulers/queue_sfq.rs
@@ -1,0 +1,222 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Stochastic fair queue discipline.
+//!
+//! User metadata is classified into a flow key at enqueue. The key is
+//! hashed into one of a fixed number of FIFO buckets; dequeue rotates
+//! round-robin over non-empty buckets.
+
+use core::hash::{BuildHasher, Hash};
+use core::marker::PhantomData;
+use std::collections::hash_map::RandomState;
+use std::collections::{HashMap, VecDeque};
+use std::num::NonZeroUsize;
+
+use super::bounded_queue::{QueueDiscipline, QueueEntryId};
+
+/// Fixed-bucket stochastic fair queue.
+pub struct StochasticFairQueue<C, F, H = RandomState> {
+    classifier: C,
+    hash_builder: H,
+    buckets: Vec<VecDeque<QueueEntryId>>,
+    active: VecDeque<usize>,
+    membership: HashMap<QueueEntryId, usize>,
+    _flow: PhantomData<fn() -> F>,
+}
+
+impl<C, F> StochasticFairQueue<C, F, RandomState> {
+    /// Construct an SFQ with `bucket_count` and a metadata classifier.
+    ///
+    /// The classifier is called exactly once for each admitted item.
+    /// Per-instance [`RandomState`] hashing protects against adversarial
+    /// flow keys; use [`StochasticFairQueue::with_hash_builder`] when
+    /// deterministic bucket assignment is required.
+    #[must_use]
+    pub fn new(bucket_count: NonZeroUsize, classifier: C) -> Self {
+        Self::with_hash_builder(bucket_count, classifier, RandomState::new())
+    }
+}
+
+impl<C, F, H> StochasticFairQueue<C, F, H> {
+    /// Construct an SFQ with an explicit hash builder.
+    ///
+    /// This is useful for reproducible tests and deployments that require
+    /// stable flow-to-bucket assignment.
+    #[must_use]
+    pub fn with_hash_builder(bucket_count: NonZeroUsize, classifier: C, hash_builder: H) -> Self {
+        let buckets = (0..bucket_count.get()).map(|_| VecDeque::new()).collect();
+        Self {
+            classifier,
+            hash_builder,
+            buckets,
+            active: VecDeque::new(),
+            membership: HashMap::new(),
+            _flow: PhantomData,
+        }
+    }
+
+    fn bucket_for(&self, flow: &F) -> usize
+    where
+        F: Hash,
+        H: BuildHasher,
+    {
+        let hash = self.hash_builder.hash_one(flow);
+        #[allow(clippy::cast_possible_truncation)]
+        let hash = hash as usize;
+        hash % self.buckets.len()
+    }
+}
+
+impl<M, C, F, H> QueueDiscipline<M> for StochasticFairQueue<C, F, H>
+where
+    C: FnMut(&M) -> F + Send + 'static,
+    F: Hash + Send + 'static,
+    H: BuildHasher + Send + 'static,
+{
+    fn push(&mut self, id: QueueEntryId, meta: &M) {
+        let flow = (self.classifier)(meta);
+        let bucket = self.bucket_for(&flow);
+        let entries = self
+            .buckets
+            .get_mut(bucket)
+            .expect("hashed SFQ bucket is in range");
+        if entries.is_empty() {
+            self.active.push_back(bucket);
+        }
+        entries.push_back(id);
+        self.membership.insert(id, bucket);
+    }
+
+    fn take_next(&mut self) -> Option<QueueEntryId> {
+        let bucket = self.active.pop_front()?;
+        let entries = self.buckets.get_mut(bucket)?;
+        let id = entries.pop_front()?;
+        self.membership.remove(&id);
+        if !entries.is_empty() {
+            self.active.push_back(bucket);
+        }
+        Some(id)
+    }
+
+    fn remove(&mut self, id: QueueEntryId) -> bool {
+        let Some(bucket) = self.membership.remove(&id) else {
+            return false;
+        };
+        let entries = self
+            .buckets
+            .get_mut(bucket)
+            .expect("indexed SFQ bucket is in range");
+        let Some(position) = entries.iter().position(|&entry| entry == id) else {
+            return false;
+        };
+        let _ = entries.remove(position);
+        if entries.is_empty() {
+            if let Some(active_position) = self.active.iter().position(|&active| active == bucket) {
+                let _ = self.active.remove(active_position);
+            }
+        }
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::hash::BuildHasherDefault;
+    use core::sync::atomic::{AtomicUsize, Ordering};
+    use std::hash::DefaultHasher;
+    use std::num::NonZeroUsize;
+    use std::sync::Arc;
+
+    use super::StochasticFairQueue;
+    use crate::scheduler::{ScheduledWork, Scheduler as _};
+    use crate::schedulers::{BoundedQueueBuilder, QueueDiscipline as _, QueueEntryId};
+
+    fn buckets(value: usize) -> NonZeroUsize {
+        NonZeroUsize::new(value).expect("non-zero test bucket count")
+    }
+
+    #[test]
+    fn alternates_non_empty_buckets_and_preserves_bucket_fifo() {
+        let mut sfq = StochasticFairQueue::new(buckets(8), |flow: &u64| *flow);
+        let first_flow = 0;
+        let first_bucket = sfq.bucket_for(&first_flow);
+        let second_flow = (1..10_000)
+            .find(|flow| sfq.bucket_for(flow) != first_bucket)
+            .expect("multiple buckets produce a distinct flow");
+
+        sfq.push(QueueEntryId(1), &first_flow);
+        sfq.push(QueueEntryId(2), &first_flow);
+        sfq.push(QueueEntryId(3), &second_flow);
+        sfq.push(QueueEntryId(4), &second_flow);
+
+        assert_eq!(sfq.take_next(), Some(QueueEntryId(1)));
+        assert_eq!(sfq.take_next(), Some(QueueEntryId(3)));
+        assert_eq!(sfq.take_next(), Some(QueueEntryId(2)));
+        assert_eq!(sfq.take_next(), Some(QueueEntryId(4)));
+    }
+
+    #[test]
+    fn arbitrary_removal_keeps_rotation_consistent() {
+        let mut sfq = StochasticFairQueue::new(buckets(1), |flow: &u8| *flow);
+        sfq.push(QueueEntryId(1), &0);
+        sfq.push(QueueEntryId(2), &0);
+        sfq.push(QueueEntryId(3), &0);
+
+        assert!(sfq.remove(QueueEntryId(2)));
+        assert!(!sfq.remove(QueueEntryId(2)));
+        assert_eq!(sfq.take_next(), Some(QueueEntryId(1)));
+        assert_eq!(sfq.take_next(), Some(QueueEntryId(3)));
+        assert_eq!(sfq.take_next(), None);
+    }
+
+    #[test]
+    fn explicit_hash_builder_makes_bucket_assignment_reproducible() {
+        type StableHasher = BuildHasherDefault<DefaultHasher>;
+
+        let first = StochasticFairQueue::with_hash_builder(
+            buckets(16),
+            |flow: &u64| *flow,
+            StableHasher::default(),
+        );
+        let second = StochasticFairQueue::with_hash_builder(
+            buckets(16),
+            |flow: &u64| *flow,
+            StableHasher::default(),
+        );
+        for flow in 0..128 {
+            assert_eq!(first.bucket_for(&flow), second.bucket_for(&flow));
+        }
+    }
+
+    #[test]
+    fn builder_classifies_each_admitted_item_once() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_for_classifier = calls.clone();
+        let sfq = StochasticFairQueue::new(buckets(1), move |flow: &u8| {
+            calls_for_classifier.fetch_add(1, Ordering::Relaxed);
+            *flow
+        });
+        let (mut queue, producer) = BoundedQueueBuilder::new(buckets(4)).discipline(sfq).build();
+        for flow in 0..3 {
+            let _ = producer.try_push(ScheduledWork::new(flow, flow));
+        }
+        assert_eq!(calls.load(Ordering::Relaxed), 3);
+        assert_eq!(queue.take_next().map(|work| work.payload), Some(0));
+        assert_eq!(queue.take_next().map(|work| work.payload), Some(1));
+        assert_eq!(queue.take_next().map(|work| work.payload), Some(2));
+        assert_eq!(calls.load(Ordering::Relaxed), 3);
+    }
+}

--- a/dispatcher/src/schedulers/round_robin.rs
+++ b/dispatcher/src/schedulers/round_robin.rs
@@ -91,6 +91,8 @@ pub struct RoundRobin<T, M: WorkMeta> {
     /// the live children the queue is purged, so its length stays
     /// bounded by 2 × live regardless of churn.
     stale: usize,
+    #[cfg(feature = "queue")]
+    queue_event_sink: Option<crate::QueueEventSink>,
     _t: PhantomData<fn() -> T>,
 }
 
@@ -110,6 +112,8 @@ impl<T, M: WorkMeta> RoundRobin<T, M> {
             free: Vec::new(),
             queue: VecDeque::new(),
             stale: 0,
+            #[cfg(feature = "queue")]
+            queue_event_sink: None,
             _t: PhantomData,
         }
     }
@@ -128,6 +132,14 @@ impl<T, M: WorkMeta> RoundRobin<T, M> {
     where
         S: Scheduler<T, Meta = M>,
     {
+        #[cfg(feature = "queue")]
+        let child = {
+            let mut child = child;
+            if let Some(sink) = self.queue_event_sink.clone() {
+                child.register_queue_event_sink(sink);
+            }
+            child
+        };
         let live_pos = self.live_ids.len();
         let (id, generation) = if let Some(id) = self.free.pop() {
             let slot = self
@@ -221,6 +233,22 @@ impl<T, M: WorkMeta> RoundRobin<T, M> {
     fn queue_len(&self) -> usize {
         self.queue.len()
     }
+
+    #[cfg(feature = "queue")]
+    pub(super) fn set_queue_event_sink(&mut self, sink: &crate::QueueEventSink)
+    where
+        T: 'static,
+    {
+        self.queue_event_sink = Some(sink.clone());
+        for slot in &mut self.slots {
+            match &mut slot.entry {
+                Entry::Live(sched) | Entry::Draining(sched) => {
+                    sched.register_queue_event_sink(sink.clone());
+                }
+                Entry::Free => {}
+            }
+        }
+    }
 }
 
 impl<T, M> Scheduler<T> for RoundRobin<T, M>
@@ -310,6 +338,11 @@ where
             slot.entry = Entry::Free;
             self.free.push(id);
         }
+    }
+
+    #[cfg(feature = "queue")]
+    fn register_queue_event_sink(&mut self, sink: crate::QueueEventSink) {
+        self.set_queue_event_sink(&sink);
     }
 }
 

--- a/dispatcher/src/schedulers/round_robin.rs
+++ b/dispatcher/src/schedulers/round_robin.rs
@@ -91,7 +91,6 @@ pub struct RoundRobin<T, M: WorkMeta> {
     /// the live children the queue is purged, so its length stays
     /// bounded by 2 × live regardless of churn.
     stale: usize,
-    #[cfg(feature = "queue")]
     queue_event_sink: Option<crate::QueueEventSink>,
     _t: PhantomData<fn() -> T>,
 }
@@ -112,7 +111,6 @@ impl<T, M: WorkMeta> RoundRobin<T, M> {
             free: Vec::new(),
             queue: VecDeque::new(),
             stale: 0,
-            #[cfg(feature = "queue")]
             queue_event_sink: None,
             _t: PhantomData,
         }
@@ -132,7 +130,6 @@ impl<T, M: WorkMeta> RoundRobin<T, M> {
     where
         S: Scheduler<T, Meta = M>,
     {
-        #[cfg(feature = "queue")]
         let child = {
             let mut child = child;
             if let Some(sink) = self.queue_event_sink.clone() {
@@ -234,7 +231,6 @@ impl<T, M: WorkMeta> RoundRobin<T, M> {
         self.queue.len()
     }
 
-    #[cfg(feature = "queue")]
     pub(super) fn set_queue_event_sink(&mut self, sink: &crate::QueueEventSink)
     where
         T: 'static,
@@ -340,7 +336,6 @@ where
         }
     }
 
-    #[cfg(feature = "queue")]
     fn register_queue_event_sink(&mut self, sink: crate::QueueEventSink) {
         self.set_queue_event_sink(&sink);
     }

--- a/dispatcher/src/schedulers/round_robin.rs
+++ b/dispatcher/src/schedulers/round_robin.rs
@@ -91,7 +91,6 @@ pub struct RoundRobin<T, M: WorkMeta> {
     /// the live children the queue is purged, so its length stays
     /// bounded by 2 × live regardless of churn.
     stale: usize,
-    queue_event_sink: Option<crate::QueueEventSink>,
     _t: PhantomData<fn() -> T>,
 }
 
@@ -111,7 +110,6 @@ impl<T, M: WorkMeta> RoundRobin<T, M> {
             free: Vec::new(),
             queue: VecDeque::new(),
             stale: 0,
-            queue_event_sink: None,
             _t: PhantomData,
         }
     }
@@ -130,13 +128,6 @@ impl<T, M: WorkMeta> RoundRobin<T, M> {
     where
         S: Scheduler<T, Meta = M>,
     {
-        let child = {
-            let mut child = child;
-            if let Some(sink) = self.queue_event_sink.clone() {
-                child.register_queue_event_sink(sink);
-            }
-            child
-        };
         let live_pos = self.live_ids.len();
         let (id, generation) = if let Some(id) = self.free.pop() {
             let slot = self
@@ -230,21 +221,6 @@ impl<T, M: WorkMeta> RoundRobin<T, M> {
     fn queue_len(&self) -> usize {
         self.queue.len()
     }
-
-    pub(super) fn set_queue_event_sink(&mut self, sink: &crate::QueueEventSink)
-    where
-        T: 'static,
-    {
-        self.queue_event_sink = Some(sink.clone());
-        for slot in &mut self.slots {
-            match &mut slot.entry {
-                Entry::Live(sched) | Entry::Draining(sched) => {
-                    sched.register_queue_event_sink(sink.clone());
-                }
-                Entry::Free => {}
-            }
-        }
-    }
 }
 
 impl<T, M> Scheduler<T> for RoundRobin<T, M>
@@ -337,7 +313,14 @@ where
     }
 
     fn register_queue_event_sink(&mut self, sink: crate::QueueEventSink) {
-        self.set_queue_event_sink(&sink);
+        for slot in &mut self.slots {
+            match &mut slot.entry {
+                Entry::Live(scheduler) | Entry::Draining(scheduler) => {
+                    scheduler.register_queue_event_sink(sink.clone());
+                }
+                Entry::Free => {}
+            }
+        }
     }
 }
 

--- a/dispatcher/src/schedulers/strict_priority.rs
+++ b/dispatcher/src/schedulers/strict_priority.rs
@@ -34,7 +34,6 @@ use crate::work::{Completion, Readiness, WithPriority, WorkMeta};
 /// Strict priority over `u8` priority classes (higher wins).
 pub struct StrictPriority<T, C: Scheduler<T>> {
     classes: BTreeMap<u8, RoundRobin<T, C::Meta>>,
-    #[cfg(feature = "queue")]
     queue_event_sink: Option<crate::QueueEventSink>,
     _phantom: PhantomData<fn() -> C>,
 }
@@ -51,7 +50,6 @@ impl<T, C: Scheduler<T>> StrictPriority<T, C> {
     pub const fn new() -> Self {
         Self {
             classes: BTreeMap::new(),
-            #[cfg(feature = "queue")]
             queue_event_sink: None,
             _phantom: PhantomData,
         }
@@ -64,7 +62,6 @@ impl<T, C: Scheduler<T>> StrictPriority<T, C> {
         T: 'static,
     {
         let rr = self.classes.entry(priority).or_default();
-        #[cfg(feature = "queue")]
         if let Some(sink) = self.queue_event_sink.clone() {
             rr.set_queue_event_sink(&sink);
         }
@@ -137,7 +134,6 @@ where
         }
     }
 
-    #[cfg(feature = "queue")]
     fn register_queue_event_sink(&mut self, sink: crate::QueueEventSink) {
         self.queue_event_sink = Some(sink.clone());
         for rr in self.classes.values_mut() {

--- a/dispatcher/src/schedulers/strict_priority.rs
+++ b/dispatcher/src/schedulers/strict_priority.rs
@@ -34,7 +34,6 @@ use crate::work::{Completion, Readiness, WithPriority, WorkMeta};
 /// Strict priority over `u8` priority classes (higher wins).
 pub struct StrictPriority<T, C: Scheduler<T>> {
     classes: BTreeMap<u8, RoundRobin<T, C::Meta>>,
-    queue_event_sink: Option<crate::QueueEventSink>,
     _phantom: PhantomData<fn() -> C>,
 }
 
@@ -50,7 +49,6 @@ impl<T, C: Scheduler<T>> StrictPriority<T, C> {
     pub const fn new() -> Self {
         Self {
             classes: BTreeMap::new(),
-            queue_event_sink: None,
             _phantom: PhantomData,
         }
     }
@@ -62,9 +60,6 @@ impl<T, C: Scheduler<T>> StrictPriority<T, C> {
         T: 'static,
     {
         let rr = self.classes.entry(priority).or_default();
-        if let Some(sink) = self.queue_event_sink.clone() {
-            rr.set_queue_event_sink(&sink);
-        }
         let id = rr.add_child(child);
         (priority, id)
     }
@@ -135,9 +130,8 @@ where
     }
 
     fn register_queue_event_sink(&mut self, sink: crate::QueueEventSink) {
-        self.queue_event_sink = Some(sink.clone());
         for rr in self.classes.values_mut() {
-            rr.set_queue_event_sink(&sink);
+            rr.register_queue_event_sink(sink.clone());
         }
     }
 }

--- a/dispatcher/src/schedulers/strict_priority.rs
+++ b/dispatcher/src/schedulers/strict_priority.rs
@@ -34,6 +34,8 @@ use crate::work::{Completion, Readiness, WithPriority, WorkMeta};
 /// Strict priority over `u8` priority classes (higher wins).
 pub struct StrictPriority<T, C: Scheduler<T>> {
     classes: BTreeMap<u8, RoundRobin<T, C::Meta>>,
+    #[cfg(feature = "queue")]
+    queue_event_sink: Option<crate::QueueEventSink>,
     _phantom: PhantomData<fn() -> C>,
 }
 
@@ -49,14 +51,23 @@ impl<T, C: Scheduler<T>> StrictPriority<T, C> {
     pub const fn new() -> Self {
         Self {
             classes: BTreeMap::new(),
+            #[cfg(feature = "queue")]
+            queue_event_sink: None,
             _phantom: PhantomData,
         }
     }
 
     /// Add `child` at the given `priority` class. Returns `(priority,
     /// child_id_within_class)`.
-    pub fn add_child(&mut self, child: C, priority: u8) -> (u8, u32) {
+    pub fn add_child(&mut self, child: C, priority: u8) -> (u8, u32)
+    where
+        T: 'static,
+    {
         let rr = self.classes.entry(priority).or_default();
+        #[cfg(feature = "queue")]
+        if let Some(sink) = self.queue_event_sink.clone() {
+            rr.set_queue_event_sink(&sink);
+        }
         let id = rr.add_child(child);
         (priority, id)
     }
@@ -123,6 +134,14 @@ where
         };
         if let Some(rr) = self.classes.get_mut(&priority) {
             rr.on_complete(inner_completion);
+        }
+    }
+
+    #[cfg(feature = "queue")]
+    fn register_queue_event_sink(&mut self, sink: crate::QueueEventSink) {
+        self.queue_event_sink = Some(sink.clone());
+        for rr in self.classes.values_mut() {
+            rr.set_queue_event_sink(&sink);
         }
     }
 }

--- a/dispatcher/src/schedulers/token_bucket.rs
+++ b/dispatcher/src/schedulers/token_bucket.rs
@@ -276,6 +276,11 @@ where
     fn on_complete(&mut self, completion: Completion<C::Meta>) {
         self.inner.on_complete(completion);
     }
+
+    #[cfg(feature = "queue")]
+    fn register_queue_event_sink(&mut self, sink: crate::QueueEventSink) {
+        self.inner.register_queue_event_sink(sink);
+    }
 }
 
 fn cost_to_i64(cost: CostUnits) -> i64 {

--- a/dispatcher/src/schedulers/token_bucket.rs
+++ b/dispatcher/src/schedulers/token_bucket.rs
@@ -277,7 +277,6 @@ where
         self.inner.on_complete(completion);
     }
 
-    #[cfg(feature = "queue")]
     fn register_queue_event_sink(&mut self, sink: crate::QueueEventSink) {
         self.inner.register_queue_event_sink(sink);
     }


### PR DESCRIPTION
## Summary

Add an externally-fed bounded queue scheduler for work submitted by concurrent producers.

The queue has a hard capacity, nonblocking enqueue, pluggable admission and queue disciplines, runtime wake-up, and explicit draining lifecycle.

## Changes

- Add `queue`, `queue-fifo`, and `queue-sfq` features.
- Add `BoundedQueueBuilder` and cloneable producer handles.
- Add pluggable `AdmissionPolicy` and `QueueDiscipline` interfaces.
- Include tail-drop admission and FIFO discipline.
- Add stochastic fair queuing with user-provided flow classification.
- Support explicit hash builders for deterministic SFQ behavior.
- Return rejected, evicted, or closed work to the producer.
- Track queue depth, in-flight work, rejections, evictions, and lifecycle.
- Automatically close the queue when the final producer is dropped.
- Emit exactly one `QueueDrained` runtime event.
- Generate queue IDs within the runtime.
- Wake a parked runtime when an empty queue receives work.
- Forward queue event sinks through scheduler trees and dynamically added children.
- Defend against malformed custom disciplines returning stale IDs or premature `None`.

Closes #169
