### PR TITLE
perf(dispatcher): register dynamic subtrees incrementally

### DIFF
--- a/dispatcher/benches/scheduler.rs
+++ b/dispatcher/benches/scheduler.rs
@@ -17,21 +17,25 @@
 
 #[cfg(unix)]
 mod unix {
+    use core::mem;
     use core::sync::atomic::AtomicBool;
     use core::time::Duration;
     use std::hint::black_box;
+    use std::num::NonZeroUsize;
     use std::sync::Arc;
     use std::time::Instant;
 
     use gungraun::library_benchmark;
     use nv_redfish_dispatcher::{
-        Completion, CompletionOutcome, RemovedChild, RoundRobin, ScheduledWork, Scheduler,
+        ClockConfig, Completion, CompletionOutcome, RemovedChild, RoundRobin, Runtime,
+        RuntimeConfig, ScheduledWork, Scheduler,
     };
 
-    use nv_redfish_dispatcher_sim::{ample_bucket, source, source_due_at, Meta, Work};
+    use nv_redfish_dispatcher_sim::{ample_bucket, source, source_due_at, Err, Ev, Meta, Work};
 
     pub type Tree = RoundRobin<Work, Meta>;
     type Removed = Option<RemovedChild<Work, Meta>>;
+    type BenchRuntime = Runtime<Ev, Err, Meta>;
 
     /// Fleet of `n` sources; when `sparse`, only the last one in
     /// rotation order has work due, so a dispatch scans the other n-1.
@@ -81,6 +85,23 @@ mod unix {
             black_box(root.remove_child(id));
         }
         (root, now)
+    }
+
+    /// Runtime with `n` existing sources and one pre-built child. Runtime
+    /// construction and the initial sink registration are fixture setup;
+    /// the benchmark measures only registering and attaching the new child.
+    fn runtime_with_spare(n: u32) -> (BenchRuntime, Box<dyn Scheduler<Work, Meta = Meta>>) {
+        let (root, now) = fleet(n, false);
+        let no_fail = Arc::new(AtomicBool::new(false));
+        let child = Box::new(source(now, n, ample_bucket(), no_fail));
+        let runtime = Runtime::new(
+            RuntimeConfig {
+                global_max_in_flight: NonZeroUsize::MIN,
+                clock: ClockConfig::Wallclock,
+            },
+            root,
+        );
+        (runtime, child)
     }
 
     fn dispatch((mut root, now): (Tree, Instant)) -> Tree {
@@ -140,15 +161,42 @@ mod unix {
     pub fn stale_purge_dispatch(input: (Tree, Instant)) -> Tree {
         dispatch(input)
     }
+
+    // Registering one new subtree must be independent of the number of
+    // schedulers already attached to the runtime.
+    #[library_benchmark]
+    #[bench::existing_1(runtime_with_spare(1))]
+    #[bench::existing_100(runtime_with_spare(100))]
+    #[bench::existing_1000(runtime_with_spare(1000))]
+    pub fn dynamic_add_child(
+        (runtime, child): (BenchRuntime, Box<dyn Scheduler<Work, Meta = Meta>>),
+    ) {
+        let handle = runtime.handle();
+        let added = handle.with_root_mut::<Tree, _>(|mut root| root.add_child(child));
+        black_box(added);
+
+        // Dropping the fixture would walk the whole tree inside the
+        // measurement and obscure the complexity of the mutation itself.
+        mem::forget(runtime);
+    }
 }
 
 #[cfg(unix)]
-use unix::{churn_detached, churn_draining, dense_dispatch, sparse_dispatch, stale_purge_dispatch};
+use unix::{
+    churn_detached, churn_draining, dense_dispatch, dynamic_add_child, sparse_dispatch,
+    stale_purge_dispatch,
+};
 
 #[cfg(unix)]
 gungraun::library_benchmark_group!(
     name = scheduler;
-    benchmarks = dense_dispatch, sparse_dispatch, churn_detached, churn_draining, stale_purge_dispatch
+    benchmarks =
+        dense_dispatch,
+        sparse_dispatch,
+        churn_detached,
+        churn_draining,
+        stale_purge_dispatch,
+        dynamic_add_child
 );
 
 #[cfg(unix)]

--- a/dispatcher/examples/composable_tree.rs
+++ b/dispatcher/examples/composable_tree.rs
@@ -61,6 +61,7 @@ use nv_redfish_dispatcher::FutureWork;
 use nv_redfish_dispatcher::QueueEventSink;
 use nv_redfish_dispatcher::Readiness;
 use nv_redfish_dispatcher::Runtime;
+use nv_redfish_dispatcher::RuntimeChildContainer;
 use nv_redfish_dispatcher::RuntimeConfig;
 use nv_redfish_dispatcher::RuntimeOutput;
 use nv_redfish_dispatcher::ScheduledWork;
@@ -227,6 +228,23 @@ where
     }
 }
 
+impl<T, M> RuntimeChildContainer<T> for RoundRobin<T, M>
+where
+    T: Send + 'static,
+    M: WorkMeta,
+{
+    type ChildMeta = M;
+    type ChildId = ();
+    type ChildArgs = ();
+
+    fn attach_child<S>(&mut self, child: S, (): Self::ChildArgs)
+    where
+        S: Scheduler<T, Meta = M>,
+    {
+        self.add_child(child);
+    }
+}
+
 // ──────────────────────────────────────────────────────────────────────
 // Driver
 // ──────────────────────────────────────────────────────────────────────
@@ -255,14 +273,14 @@ async fn main() {
 
     // 3a. Add another leaf to the root, dynamically.
     handle
-        .with_root_mut(|root: &mut RoundRobin<Work, ()>| {
+        .with_root_mut::<RoundRobin<Work, ()>, _>(|mut root| {
             root.add_child(PollLeaf::new("sensor-C", Duration::from_secs(3)));
         })
         .expect("downcast failed");
 
     // 3b. Add an entirely new sub-branch with its own children.
     handle
-        .with_root_mut(|root: &mut RoundRobin<Work, ()>| {
+        .with_root_mut::<RoundRobin<Work, ()>, _>(|mut root| {
             let mut subnet: RoundRobin<Work, ()> = RoundRobin::new();
             subnet.add_child(PollLeaf::new("subnet-1-a", Duration::from_secs(5)));
             subnet.add_child(PollLeaf::new("subnet-1-b", Duration::from_secs(5)));

--- a/dispatcher/src/lib.rs
+++ b/dispatcher/src/lib.rs
@@ -109,6 +109,10 @@ pub use runtime::RuntimeHandle;
 #[doc(inline)]
 pub use runtime::RuntimeOutput;
 #[doc(inline)]
+pub use runtime::RuntimeRootMut;
+#[doc(inline)]
+pub use scheduler::RuntimeChildContainer;
+#[doc(inline)]
 pub use scheduler::ScheduledWork;
 #[doc(inline)]
 pub use scheduler::Scheduler;

--- a/dispatcher/src/runtime.rs
+++ b/dispatcher/src/runtime.rs
@@ -32,6 +32,7 @@
 
 use crate::scheduler::private::SchedulerObj;
 use crate::scheduler::Scheduler;
+use crate::schedulers::{RemovedChild, RoundRobin, StrictPriority};
 use crate::stats::OutputQueueStats;
 use crate::stats::RuntimeStats;
 use crate::work::WorkMeta;
@@ -420,6 +421,110 @@ pub struct RuntimeHandle<Ev, Err, M: WorkMeta> {
     stats: Arc<StatsCells>,
 }
 
+struct RuntimeMutationContext<T> {
+    queue_event_sink: crate::QueueEventSink,
+    _payload: PhantomData<fn() -> T>,
+}
+
+impl<T> RuntimeMutationContext<T>
+where
+    T: 'static,
+{
+    fn register<S>(&self, mut scheduler: S) -> S
+    where
+        S: Scheduler<T>,
+    {
+        scheduler.register_queue_event_sink(self.queue_event_sink.clone());
+        scheduler
+    }
+}
+
+/// Exclusive, runtime-aware access to a scheduler root.
+///
+/// This wrapper deliberately does not expose `&mut R` or implement
+/// [`DerefMut`](core::ops::DerefMut). Its mutation methods preserve runtime
+/// invariants such as registering every newly attached scheduler subtree
+/// with the queue-event sink.
+pub struct RuntimeRootMut<'a, R, T> {
+    root: &'a mut R,
+    mutation: RuntimeMutationContext<T>,
+}
+
+impl<R, T> RuntimeRootMut<'_, R, T>
+where
+    T: Send + 'static,
+    R: crate::RuntimeChildContainer<T>,
+{
+    /// Register and attach one child scheduler with branch-specific arguments.
+    ///
+    /// Registration visits only `child`; its cost is independent of the
+    /// number of children already present in the root.
+    pub fn add_child_with<S>(&mut self, child: S, args: R::ChildArgs) -> R::ChildId
+    where
+        S: Scheduler<T, Meta = R::ChildMeta>,
+    {
+        self.root.attach_child(self.mutation.register(child), args)
+    }
+}
+
+impl<R, T> RuntimeRootMut<'_, R, T>
+where
+    T: Send + 'static,
+    R: crate::RuntimeChildContainer<T, ChildArgs = ()>,
+{
+    /// Register and attach one child scheduler without branch-specific arguments.
+    ///
+    /// Registration visits only `child`; its cost is independent of the
+    /// number of children already present in the root.
+    pub fn add_child<S>(&mut self, child: S) -> R::ChildId
+    where
+        S: Scheduler<T, Meta = R::ChildMeta>,
+    {
+        self.add_child_with(child, ())
+    }
+}
+
+impl<T, M> RuntimeRootMut<'_, RoundRobin<T, M>, T>
+where
+    T: Send + 'static,
+    M: WorkMeta,
+{
+    /// Remove a child by id.
+    pub fn remove_child(&mut self, id: u32) -> Option<RemovedChild<T, M>> {
+        self.root.remove_child(id)
+    }
+
+    /// Number of live children.
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.root.len()
+    }
+
+    /// Whether the root currently has no live children.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.root.is_empty()
+    }
+}
+
+impl<T, C> RuntimeRootMut<'_, StrictPriority<T, C>, T>
+where
+    T: Send + 'static,
+    C: Scheduler<T>,
+    C::Meta: WorkMeta,
+{
+    /// Register and attach one child scheduler at `priority`.
+    pub fn add_priority_child(&mut self, child: C, priority: u8) -> (u8, u32) {
+        self.add_child_with(child, priority)
+    }
+
+    /// Number of populated priority classes.
+    #[must_use]
+    pub fn class_count(&self) -> usize {
+        self.root.class_count()
+    }
+}
+
 impl<Ev, Err, M: WorkMeta> Clone for RuntimeHandle<Ev, Err, M> {
     fn clone(&self) -> Self {
         Self {
@@ -501,23 +606,34 @@ where
     /// Holds the root lock for the duration of `f`; keep it short and do
     /// not re-enter the runtime from inside (it will deadlock).
     ///
+    /// The closure receives a [`RuntimeRootMut`] rather than `&mut S`, so
+    /// newly attached scheduler subtrees are registered automatically.
+    ///
     /// # Panics
     ///
     /// Can panic if runtime mutex is poisoned. Which only can happen
     /// if any f passed to this function paniced.
     #[allow(clippy::unwrap_in_result)]
-    pub fn with_root_mut<S, R>(&self, f: impl FnOnce(&mut S) -> R) -> Option<R>
+    pub fn with_root_mut<S, R>(
+        &self,
+        f: impl FnOnce(RuntimeRootMut<'_, S, FutureWork<Ev, Err>>) -> R,
+    ) -> Option<R>
     where
         S: 'static,
     {
+        let mutation = RuntimeMutationContext {
+            queue_event_sink: self.signals.queue_event_sink(),
+            _payload: PhantomData,
+        };
         let mut guard = self
             .shared
             .lock()
             .expect("dispatcher runtime mutex is poisoned");
-        let result = guard.root.as_any_mut().downcast_mut::<S>().map(f);
-        guard
+        let result = guard
             .root
-            .register_queue_event_sink(self.signals.queue_event_sink());
+            .as_any_mut()
+            .downcast_mut::<S>()
+            .map(|root| f(RuntimeRootMut { root, mutation }));
         drop(guard);
         self.signals.wake();
         result
@@ -852,7 +968,7 @@ mod tests {
         assert_eq!(handle.with_root::<u32, _>(|_| ()), None, "wrong type");
 
         let id = handle
-            .with_root_mut::<TestRoot, _>(|root| {
+            .with_root_mut::<TestRoot, _>(|mut root| {
                 root.add_child(PeriodicLeaf::new(
                     Instant::now(),
                     Duration::from_secs(9999),
@@ -863,7 +979,7 @@ mod tests {
         assert_eq!(handle.with_root::<TestRoot, _>(TestRoot::len), Some(2));
 
         handle
-            .with_root_mut::<TestRoot, _>(|root| {
+            .with_root_mut::<TestRoot, _>(|mut root| {
                 root.remove_child(id).expect("child exists");
             })
             .expect("root downcasts");

--- a/dispatcher/src/scheduler.rs
+++ b/dispatcher/src/scheduler.rs
@@ -97,6 +97,25 @@ pub trait Scheduler<T>: Send + 'static {
     fn register_queue_event_sink(&mut self, sink: crate::QueueEventSink);
 }
 
+/// Scheduler root that accepts dynamically attached child subtrees.
+///
+/// [`crate::RuntimeRootMut::add_child_with`] registers the child with its
+/// runtime before calling [`RuntimeChildContainer::attach_child`].
+/// Implementations therefore only perform their branch-specific insertion.
+pub trait RuntimeChildContainer<T>: Scheduler<T> {
+    /// Metadata expected from an attached child.
+    type ChildMeta: WorkMeta;
+    /// Stable identifier returned by the branch.
+    type ChildId;
+    /// Branch-specific arguments needed to attach a child.
+    type ChildArgs;
+
+    /// Physically attach an already runtime-registered child.
+    fn attach_child<S>(&mut self, child: S, args: Self::ChildArgs) -> Self::ChildId
+    where
+        S: Scheduler<T, Meta = Self::ChildMeta>;
+}
+
 impl<T, S> Scheduler<T> for Box<S>
 where
     T: 'static,
@@ -139,7 +158,6 @@ pub(crate) mod private {
         fn update_ready(&mut self, now: Instant) -> Readiness;
         fn take_next(&mut self) -> Option<ScheduledWork<T, M>>;
         fn on_complete(&mut self, completion: Completion<M>);
-        fn register_queue_event_sink(&mut self, sink: crate::QueueEventSink);
         fn as_any(&self) -> &dyn Any;
         fn as_any_mut(&mut self) -> &mut dyn Any;
     }
@@ -158,9 +176,6 @@ pub(crate) mod private {
         }
         fn on_complete(&mut self, completion: Completion<M>) {
             <Self as super::Scheduler<T>>::on_complete(self, completion);
-        }
-        fn register_queue_event_sink(&mut self, sink: crate::QueueEventSink) {
-            <Self as super::Scheduler<T>>::register_queue_event_sink(self, sink);
         }
         fn as_any(&self) -> &dyn Any {
             self

--- a/dispatcher/src/schedulers/bounded_queue.rs
+++ b/dispatcher/src/schedulers/bounded_queue.rs
@@ -712,8 +712,10 @@ mod tests {
         QueueDiscipline, QueueEntryId, QueueLifecycle,
     };
     use crate::scheduler::{ScheduledWork, Scheduler as _};
-    use crate::schedulers::{BoundedConcurrency, RoundRobin};
-    use crate::work::{Completion, CompletionOutcome, RoutingPath};
+    use crate::schedulers::{
+        BoundedConcurrency, BoundedQueue, Fifo, RoundRobin, StrictPriority, TailDrop,
+    };
+    use crate::work::{Completion, CompletionOutcome, RoutingPath, WithPriority};
     use crate::{Runtime, RuntimeConfig, RuntimeOutput};
 
     const fn capacity(value: usize) -> NonZeroUsize {
@@ -1066,7 +1068,7 @@ mod tests {
         let handle = runtime.handle();
         let (queue, producer) = BoundedQueueBuilder::new(capacity(1)).fifo().build();
         assert!(handle
-            .with_root_mut::<RoundRobin<Work, ()>, _>(|root| root.add_child(queue))
+            .with_root_mut::<RoundRobin<Work, ()>, _>(|mut root| { root.add_child(queue) })
             .is_some());
 
         let push = async move {
@@ -1082,6 +1084,42 @@ mod tests {
                 result: Ok(events),
                 ..
             }) if events == vec![11]
+        ));
+    }
+
+    #[tokio::test]
+    async fn dynamically_added_priority_queue_receives_the_runtime_sink() {
+        type Work = crate::FutureWork<u8, ()>;
+        type Queue = BoundedQueue<Work, (), TailDrop, Fifo>;
+        type Root = StrictPriority<Work, Queue>;
+
+        let mut runtime: Runtime<u8, (), WithPriority<()>> = Runtime::new(
+            RuntimeConfig {
+                global_max_in_flight: capacity(1),
+                clock: crate::ClockConfig::Wallclock,
+            },
+            Root::new(),
+        );
+        let handle = runtime.handle();
+        let (queue, producer) = BoundedQueueBuilder::new(capacity(1)).fifo().build();
+        let child_id = handle
+            .with_root_mut::<Root, _>(|mut root| root.add_child_with(queue, 7))
+            .expect("root downcasts");
+        assert_eq!(child_id.0, 7);
+
+        let push = async move {
+            yield_now().await;
+            let work: Work = Box::pin(async { Ok(vec![13]) });
+            let _ = producer.try_push(ScheduledWork::new((), work));
+        };
+        let next = timeout(Duration::from_secs(1), runtime.next());
+        let ((), output) = tokio::join!(push, next);
+        assert!(matches!(
+            output,
+            Ok(RuntimeOutput::Work {
+                result: Ok(events),
+                ..
+            }) if events == vec![13]
         ));
     }
 

--- a/dispatcher/src/schedulers/round_robin.rs
+++ b/dispatcher/src/schedulers/round_robin.rs
@@ -44,7 +44,7 @@ use core::mem;
 use std::collections::VecDeque;
 use std::time::Instant;
 
-use crate::scheduler::{ScheduledWork, Scheduler};
+use crate::scheduler::{RuntimeChildContainer, ScheduledWork, Scheduler};
 use crate::work::{Completion, Readiness, WorkMeta};
 
 enum Entry<T, M: WorkMeta> {
@@ -321,6 +321,23 @@ where
                 Entry::Free => {}
             }
         }
+    }
+}
+
+impl<T, M> RuntimeChildContainer<T> for RoundRobin<T, M>
+where
+    T: Send + 'static,
+    M: WorkMeta,
+{
+    type ChildMeta = M;
+    type ChildId = u32;
+    type ChildArgs = ();
+
+    fn attach_child<S>(&mut self, child: S, (): Self::ChildArgs) -> Self::ChildId
+    where
+        S: Scheduler<T, Meta = M>,
+    {
+        self.add_child(child)
     }
 }
 

--- a/dispatcher/src/schedulers/strict_priority.rs
+++ b/dispatcher/src/schedulers/strict_priority.rs
@@ -28,7 +28,7 @@ use std::collections::BTreeMap;
 use std::time::Instant;
 
 use super::round_robin::RoundRobin;
-use crate::scheduler::{ScheduledWork, Scheduler};
+use crate::scheduler::{RuntimeChildContainer, ScheduledWork, Scheduler};
 use crate::work::{Completion, Readiness, WithPriority, WorkMeta};
 
 /// Strict priority over `u8` priority classes (higher wins).
@@ -133,6 +133,25 @@ where
         for rr in self.classes.values_mut() {
             rr.register_queue_event_sink(sink.clone());
         }
+    }
+}
+
+impl<T, C> RuntimeChildContainer<T> for StrictPriority<T, C>
+where
+    T: Send + 'static,
+    C: Scheduler<T>,
+    C::Meta: WorkMeta,
+{
+    type ChildMeta = C::Meta;
+    type ChildId = (u8, u32);
+    type ChildArgs = u8;
+
+    fn attach_child<S>(&mut self, child: S, priority: Self::ChildArgs) -> Self::ChildId
+    where
+        S: Scheduler<T, Meta = Self::ChildMeta>,
+    {
+        let class = self.classes.entry(priority).or_default();
+        (priority, class.add_child(child))
     }
 }
 


### PR DESCRIPTION
Previously, every `RuntimeHandle::with_root_mut` call re-registered the event sink across the entire scheduler tree. Adding one child therefore cost `O(N)`.

This PR introduces `RuntimeRootMut`, which owns the mutation context and automatically registers only the newly added subtree before attaching it.

Custom roots implement `RuntimeChildContainer`; callers simply use:

```rust
handle.with_root_mut(|mut root| {
    root.add_child(child);
});
```

The raw mutable root is intentionally hidden, so registration cannot be skipped accidentally.

A new `dynamic_add_child` benchmark confirms constant cost regardless of the existing tree size:

| Existing children | Instructions |
|------------------:|-------------:|
|                 1 |         1146 |
|               100 |         1146 |
|              1000 |         1146 |
